### PR TITLE
test(ui): repair current main test baseline

### DIFF
--- a/packages/ui/src/components/auth/SessionAuthGate.behavior.test.tsx
+++ b/packages/ui/src/components/auth/SessionAuthGate.behavior.test.tsx
@@ -303,6 +303,19 @@ mock.module('@/lib/passkeys', () => ({
   registerCurrentDevicePasskey: mock(() => Promise.resolve(null)),
 }));
 
+const authSessionStore = {
+  state: 'ok' as const,
+  markAuthenticated: mock(() => undefined),
+};
+
+mock.module('@/lib/runtime-auth-expiry', () => ({
+  installAuthSessionFocusWatch: mock(() => undefined),
+  useAuthSessionStore: Object.assign(
+    (selector: (store: typeof authSessionStore) => unknown) => selector(authSessionStore),
+    { getState: () => authSessionStore },
+  ),
+}));
+
 const { SessionAuthGate } = await import('./SessionAuthGate');
 
 const flushEffects = async () => {

--- a/packages/ui/src/components/chat/markdown/markdownCore.test.ts
+++ b/packages/ui/src/components/chat/markdown/markdownCore.test.ts
@@ -19,6 +19,15 @@ const sanitizeHooks: {
   afterSanitizeAttributes?: (node: unknown) => void;
 } = {};
 
+// Mirrors DOMPurify's default URI policy: approved schemes plus relative URLs.
+const DOMPURIFY_ALLOWED_URI_RE =
+  // Keep this byte-aligned with DOMPurify's default IS_ALLOWED_URI expression.
+  // eslint-disable-next-line no-useless-escape
+  /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+const URI_ATTRIBUTE_WHITESPACE_RE =
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g;
+
 Object.assign(globalThis, {
   window: {},
   HTMLAnchorElement: TestAnchorElement,
@@ -36,7 +45,10 @@ mock.module('dompurify', () => ({
       sanitizeHooks.uponSanitizeAttribute?.(anchor, data);
       sanitizeHooks.afterSanitizeAttributes?.(anchor);
 
-      return data.forceKeepAttr || /^(?:https?|mailto|tel):/i.test(href) ? attribute : '';
+      const normalizedHref = href.replace(URI_ATTRIBUTE_WHITESPACE_RE, '');
+      return data.forceKeepAttr || DOMPURIFY_ALLOWED_URI_RE.test(normalizedHref)
+        ? attribute
+        : '';
     }),
   },
 }));

--- a/packages/ui/src/lib/shortcuts.test.ts
+++ b/packages/ui/src/lib/shortcuts.test.ts
@@ -8,8 +8,8 @@ import {
 } from './shortcuts';
 
 describe('getEffectiveShortcutPrefix', () => {
-  test('falls back to the action default (bare mod) when unset', () => {
-    expect(getEffectiveShortcutPrefix('switch_context_surface', {})).toBe('mod');
+  test('falls back to the action default (bare mod+alt) when unset', () => {
+    expect(getEffectiveShortcutPrefix('switch_context_surface', {})).toBe('mod+alt');
   });
 
   test('honors modifier + key overrides', () => {


### PR DESCRIPTION
## Intent

Restore the current-main UI test baseline by updating three stale test doubles and expectations. This unblocks CI for PRs that already include current main, including #2029 and #3082.

## Non-goals

No production behavior, runtime dependencies, or user-facing UI changes.

## Affected surfaces

UI tests for authentication fallback, Markdown URL sanitization, and configurable shortcut defaults. Production web, desktop, mobile, and VS Code behavior is unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | Defines contribution evidence | Uses every required section and exact validation results |
| UI test isolation runner | Bun module mocks are process-wide | Verified with the repository's one-process-per-file runner |
| DOMPurify 3.3.3 policy | The Markdown test mocks URI filtering | Keeps the URI and whitespace regexes byte-aligned with DOMPurify defaults |

## Validation

| Check | Result |
|---|---|
| `cd packages/ui && bun run test` | 336/336 test files passed |
| `cd packages/ui && bun run type-check` | Passed |
| `cd packages/ui && bun run lint` | Passed |
| Focused auth, Markdown, and shortcut tests | 74 passed, 0 failed |
| `git diff --check` | Passed |

## Visual evidence

No visible change. The diff only updates test mocks and a stale test expectation.

## Risks and failure behavior

The sanitizer mock could drift after a DOMPurify upgrade. Its copied expressions and comments make that dependency explicit. The authentication mock intentionally isolates expiry-store behavior from gate fallback tests. Rollback only restores the three current CI failures.