### PR TITLE
fix(ui): let SettingsFieldRow labels truncate on long content

### DIFF
--- a/packages/ui/src/components/sections/openchamber/PasskeySettings.tsx
+++ b/packages/ui/src/components/sections/openchamber/PasskeySettings.tsx
@@ -219,7 +219,7 @@ export const PasskeySettings: React.FC = () => {
             {passkeys.map((passkey) => (
               <SettingsFieldRow
                 key={passkey.id}
-                label={<span className="truncate">{passkey.label}</span>}
+                label={<span className="truncate" title={passkey.label}>{passkey.label}</span>}
                 alignEnd={false}
                 controlClassName="justify-between sm:flex-1"
               >

--- a/packages/ui/src/components/sections/shared/SettingsSection.tsx
+++ b/packages/ui/src/components/sections/shared/SettingsSection.tsx
@@ -310,8 +310,8 @@ export const SettingsFieldRow: React.FC<SettingsFieldRowProps> = ({
       )}
     >
       <div className="min-w-0 @xl:w-56 @xl:shrink-0">
-        <div className="flex items-center gap-1.5">
-          <div className={SETTINGS_FIELD_LABEL_CLASS}>{label}</div>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <div className={cn('min-w-0 truncate', SETTINGS_FIELD_LABEL_CLASS)}>{label}</div>
           {info != null ? <SettingsInfoHint>{info}</SettingsInfoHint> : null}
         </div>
         {description != null ? (

--- a/packages/ui/src/components/sections/shared/fieldrow.repro.test.tsx
+++ b/packages/ui/src/components/sections/shared/fieldrow.repro.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Window } from 'happy-dom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { SettingsFieldRow } from '@/components/sections/shared/SettingsSection';
+
+// Browser-generated passkeys (e.g. Edge on Windows) use the full user-agent
+// string as the device label, so it is very long.
+const longLabel =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0';
+
+let windowInstance: Window;
+let host: HTMLDivElement;
+let root: Root;
+
+afterEach(() => {
+  root?.unmount();
+});
+
+describe('PasskeySettings long device-name label (issue #3181)', () => {
+  test('label truncation requires min-w-0 on every flex ancestor', async () => {
+    windowInstance = new Window({ width: 1000, height: 800 });
+    Object.assign(globalThis, {
+      window: windowInstance,
+      document: windowInstance.document,
+      HTMLElement: windowInstance.HTMLElement,
+      Element: windowInstance.Element,
+      Node: windowInstance.Node,
+      IS_REACT_ACT_ENVIRONMENT: true,
+    });
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        // Mirrors the PasskeySettings row (label = passkey.label with `truncate`).
+        <SettingsFieldRow
+          label={<span className="truncate">{longLabel}</span>}
+          alignEnd={false}
+          controlClassName="justify-between sm:flex-1"
+        >
+          <span className="typography-meta text-muted-foreground truncate">Added Aug 27, 2026</span>
+          <button>Delete</button>
+        </SettingsFieldRow>,
+      );
+    });
+
+    // For `truncate` (overflow:hidden + text-overflow:ellipsis + white-space:nowrap)
+    // to constrain a flex child, every flex ancestor between the row and the
+    // truncated element must carry min-w-0. Without it, the flex item's default
+    // min-width:auto stops it shrinking, and the long text overflows the 224px
+    // label column, overlaying the date and delete button in the control column.
+    const row = host.firstElementChild as HTMLElement;
+    const labelColumn = row?.firstElementChild as HTMLElement;
+    const innerFlex = labelColumn?.firstElementChild as HTMLElement;
+    const labelDiv = innerFlex?.firstElementChild as HTMLElement;
+    const labelSpan = labelDiv?.firstElementChild as HTMLElement;
+
+    const flexAncestors = [labelColumn, innerFlex, labelDiv].filter(Boolean);
+    const missingMinW0 = flexAncestors.filter(
+      (el) => !String(el.className).split(/\s+/).includes('min-w-0'),
+    );
+
+    expect(labelSpan?.className.split(/\s+/)).toContain('truncate');
+    // Repro: two intermediate flex containers lack min-w-0, so the ellipsis is
+    // inert and the long label overflows its column.
+    expect(missingMinW0.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3181.

Long browser-generated passkey labels (for example, Windows/Edge user-agent strings) were overflowing the label column and covering the "Added …" date and Delete button.

This change constrains the label correctly and truncates it with an ellipsis.

The full value remains available via the title tooltip.

## Changes

- Add `min-w-0` to the inner flex container in `SettingsFieldRow` so the label can shrink below its content width.
- Add `min-w-0 truncate` to the label container so it truncates with an ellipsis when the column is constrained.
- Add the full label as the `title` attribute on the truncated span so the user-agent string is available on hover for device identification.
- Add a regression test for the flex sizing requirements.

## Screenshots

### Before
Reproduced locally. Screenshot from the original issue report.
<img width="1611" height="872" alt="image" src="https://github.com/user-attachments/assets/c308e8a1-feb6-4f47-8bdc-9fb176a854b5" />


### After — Desktop (`@xl`)
<img width="1214" height="827" alt="screenshot" src="https://github.com/user-attachments/assets/fed861ef-002c-4551-9f6d-abfb9209f176" />


### After — Narrow screens
<img width="761" height="844" alt="screenshot-small" src="https://github.com/user-attachments/assets/da5dc809-e10b-48f9-be47-c4877c656693" />


## Testing

- `bun run type-check` ✓
- `bun run lint` ✓
- `cd packages/ui && bun test src/components/sections/shared/fieldrow.repro.test.tsx` ✓
- Manually verified at narrow and `@xl` widths in light and dark themes.

## Notes

The regression test was cherry-picked from the upstream
`reproduce/issue-3181` branch and retains its original authorship.

The CI `bun run test` job reports three pre-existing failures on
`upstream/main` (shortcuts.test.ts, markdownCore.test.ts, and
SessionAuthGate.behavior.test.tsx) that are unrelated to this change —
none of the failing tests touch the files modified here.