### PR TITLE
fix(git): check out a local tracking branch when a remote branch is picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Files: opening a file over 5,000 lines is no longer blocked — the line-count guard now allows up to 20,000 lines, letting large files reach the virtualized full-file preview instead of being rejected at the open step (thanks @gaojunran).
 - Usage: GitHub Copilot now shows a single AI Credits window, matching Copilot's token-based quota, in place of the old Chat Requests and Completions windows (thanks to @jakoss).
 - Settings: fixed the Cloudflare Tunnel download link shown when cloudflared is not installed (thanks to @AyoubAchour).
+- Git: picking a remote branch such as `origin/main` in the branch selector now switches you to that branch instead of leaving the repository on a detached `HEAD` with no branch name.
 - Desktop: "Restart to Update" no longer looks dead when the update cannot be installed — the update window now shows the reason, including when the running copy was not installed from an official signed release, and the button stays available to retry.
 
 ## [1.21.0] - 2026-08-26

--- a/packages/ui/src/components/views/GitView.tsx
+++ b/packages/ui/src/components/views/GitView.tsx
@@ -1347,8 +1347,10 @@ export const GitView: React.FC<GitViewProps> = ({ isActive }) => {
     }
 
     try {
-      await git.checkoutBranch(currentDirectory, normalized);
-      toast.success(t('gitView.toast.checkedOut', { name: normalized }));
+      // Picking a remote-tracking branch checks out the local branch that
+      // tracks it, so report the branch the repository actually landed on.
+      const result = await git.checkoutBranch(currentDirectory, normalized);
+      toast.success(t('gitView.toast.checkedOut', { name: result?.branch || normalized }));
       await refreshStatusAndBranches();
       await refreshLog();
     } catch (err) {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Picking a remote branch such as `origin/main` in the Git branch selector now switches you to that branch instead of leaving the repository on a detached `HEAD` with no branch name.
 - GitHub Copilot usage now shows a single AI Credits window, matching Copilot's token-based quota, in place of the old Chat Requests and Completions windows (thanks to @jakoss).
 - The context usage readout now reports the session cost including everything its subagents spent, matching the work status panel instead of showing a lower figure.
 

--- a/packages/vscode/src/gitService.ts
+++ b/packages/vscode/src/gitService.ts
@@ -763,24 +763,82 @@ async function getGitBranchesRaw(directory: string): Promise<GitBranchResult> {
   return { all, current, branches };
 }
 
+const gitRefExists = async (directory: string, ref: string): Promise<boolean> => {
+  const result = await execGit(['show-ref', '--verify', '--quiet', ref], directory);
+  return result.exitCode === 0;
+};
+
+/**
+ * The branch selector lists remote-tracking branches beside local ones, so
+ * picking `origin/main` means "work on main", not "detach HEAD at the remote's
+ * commit" — which is what a literal checkout of a remote-tracking ref does.
+ * Resolve such a pick to the local branch, creating it with tracking when it
+ * does not exist yet. Anything we cannot resolve is checked out as requested,
+ * leaving git's own DWIM behavior intact.
+ */
+const resolveBranchCheckoutTarget = async (
+  directory: string,
+  branch: string
+): Promise<{ branch: string; remoteRef: string | null }> => {
+  const requested = String(branch || '').trim();
+  const asRequested = { branch: requested, remoteRef: null };
+  if (!requested) {
+    return asRequested;
+  }
+
+  if (await gitRefExists(directory, `refs/heads/${requested}`)) {
+    return asRequested;
+  }
+
+  const remoteRef = requested.replace(/^remotes\//, '');
+  if (!(await gitRefExists(directory, `refs/remotes/${remoteRef}`))) {
+    return asRequested;
+  }
+
+  const remotesResult = await execGit(['remote'], directory);
+  const remotes = remotesResult.exitCode === 0
+    ? remotesResult.stdout.split('\n').map((line) => line.trim()).filter(Boolean)
+    : [];
+  const remote = remotes.find((name) => remoteRef.startsWith(`${name}/`));
+  if (!remote) {
+    return asRequested;
+  }
+
+  const localBranch = remoteRef.slice(remote.length + 1);
+  // `origin/HEAD` names no branch of its own; it is a pointer to one.
+  if (!localBranch || localBranch === 'HEAD') {
+    return asRequested;
+  }
+
+  const localExists = await gitRefExists(directory, `refs/heads/${localBranch}`);
+  return { branch: localBranch, remoteRef: localExists ? null : remoteRef };
+};
+
 /**
  * Checkout a branch
  */
 export async function checkoutBranch(directory: string, branch: string): Promise<{ success: boolean; branch: string }> {
+  const target = await resolveBranchCheckoutTarget(directory, branch);
+
+  if (target.remoteRef) {
+    const tracked = await execGit(['checkout', '-b', target.branch, '--track', target.remoteRef], directory);
+    return { success: tracked.exitCode === 0, branch: target.branch };
+  }
+
   const repo = await getRepository(directory);
-  
+
   if (repo) {
     try {
-      await repo.checkout(branch);
-      return { success: true, branch };
+      await repo.checkout(target.branch);
+      return { success: true, branch: target.branch };
     } catch (error) {
       console.error('[GitService] Failed to checkout branch:', error);
     }
   }
 
   // Fallback to raw git
-  const result = await execGit(['checkout', branch], directory);
-  return { success: result.exitCode === 0, branch };
+  const result = await execGit(['checkout', target.branch], directory);
+  return { success: result.exitCode === 0, branch: target.branch };
 }
 
 /**

--- a/packages/web/server/lib/git/DOCUMENTATION.md
+++ b/packages/web/server/lib/git/DOCUMENTATION.md
@@ -40,7 +40,7 @@ The following functions are exported and used by the web server:
 ### Branch Operations
 - `getBranches(directory)`: Get list of local and remote branches (filtered to active remote branches).
 - `createBranch(directory, branchName, options)`: Create and checkout a new branch.
-- `checkoutBranch(directory, branchName)`: Checkout an existing branch.
+- `checkoutBranch(directory, branchName)`: Checkout an existing branch. A remote-tracking name (`origin/main`, or the `remotes/`-prefixed form) resolves to the local branch of that name, created with `--track` when it does not exist yet, because the branch selector offers remote branches as places to work rather than commits to inspect — a literal checkout of the remote ref would detach HEAD. A local branch whose own name looks like a remote ref wins over that resolution, and anything unresolvable is checked out as requested. The returned `branch` is the branch that was actually checked out, which callers should report instead of the requested name.
 - `deleteBranch(directory, branch, options)`: Delete a branch (supports force flag).
 - `renameBranch(directory, oldName, newName)`: Rename a branch and preserve upstream tracking.
 - `getRemotes(directory)`: Get list of configured remotes.

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -3773,12 +3773,69 @@ export async function createBranch(directory, branchName, options = {}) {
   }
 }
 
+// Deliberately not `--quiet`: simple-git resolves a quiet non-zero exit as
+// success, so the ref itself has to be echoed for the answer to mean anything.
+const gitRefExists = async (git, ref) => {
+  try {
+    const output = await git.raw(['show-ref', '--verify', ref]);
+    return String(output).trim().length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * The branch selector lists remote-tracking branches beside local ones, so
+ * picking `origin/main` means "work on main", not "detach HEAD at the remote's
+ * commit" — which is what a literal checkout of a remote-tracking ref does.
+ * Resolve such a pick to the local branch, creating it with tracking when it
+ * does not exist yet. Anything we cannot resolve is checked out as requested,
+ * leaving git's own DWIM behavior intact.
+ */
+const resolveBranchCheckoutTarget = async (git, branchName) => {
+  const requested = String(branchName || '').trim();
+  if (!requested) {
+    throw new Error('Branch name is required');
+  }
+
+  const asRequested = { branch: requested, remoteRef: null };
+
+  if (await gitRefExists(git, `refs/heads/${requested}`)) {
+    return asRequested;
+  }
+
+  const remoteRef = requested.replace(/^remotes\//, '');
+  if (!(await gitRefExists(git, `refs/remotes/${remoteRef}`))) {
+    return asRequested;
+  }
+
+  const remotes = await git.getRemotes();
+  const remote = remotes.find((entry) => entry?.name && remoteRef.startsWith(`${entry.name}/`));
+  if (!remote) {
+    return asRequested;
+  }
+
+  const localBranch = remoteRef.slice(remote.name.length + 1);
+  // `origin/HEAD` names no branch of its own; it is a pointer to one.
+  if (!localBranch || localBranch === 'HEAD') {
+    return asRequested;
+  }
+
+  const localExists = await gitRefExists(git, `refs/heads/${localBranch}`);
+  return { branch: localBranch, remoteRef: localExists ? null : remoteRef };
+};
+
 export async function checkoutBranch(directory, branchName) {
   const { git } = await createRepositoryGitContext(directory);
 
   try {
-    await git.checkout(branchName);
-    return { success: true, branch: branchName };
+    const target = await resolveBranchCheckoutTarget(git, branchName);
+    if (target.remoteRef) {
+      await git.raw(['checkout', '-b', target.branch, '--track', target.remoteRef]);
+    } else {
+      await git.checkout(target.branch);
+    }
+    return { success: true, branch: target.branch };
   } catch (error) {
     console.error('Failed to checkout branch:', error);
     throw error;

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -6,6 +6,7 @@ import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import simpleGit from 'simple-git';
 
 import {
+  checkoutBranch,
   checkoutCommit,
   cherryPick,
   createWorktree,
@@ -1049,6 +1050,66 @@ describe('checkoutCommit', () => {
   it('throws an error for an invalid/nonexistent hash', async () => {
     const { tmpDir } = await createTempRepo();
     await expect(checkoutCommit(tmpDir, 'invalidhash123')).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkoutBranch
+// ---------------------------------------------------------------------------
+
+describe('checkoutBranch', () => {
+  it('checks out a local branch by name', async () => {
+    const { repository } = createRepositoryWithRemote();
+    runGit(repository, ['branch', 'feature']);
+
+    const result = await checkoutBranch(repository, 'feature');
+
+    expect(result).toEqual({ success: true, branch: 'feature' });
+    expect(runGit(repository, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('feature');
+  });
+
+  it('creates a tracking local branch instead of detaching HEAD on a remote branch', async () => {
+    const { repository } = createRepositoryWithRemote({ defaultBranch: 'react' });
+
+    const result = await checkoutBranch(repository, 'origin/react');
+
+    expect(result).toEqual({ success: true, branch: 'react' });
+    expect(runGit(repository, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('react');
+    expect(runGit(repository, ['rev-parse', '--abbrev-ref', 'react@{upstream}']).trim()).toBe('origin/react');
+  });
+
+  it('checks out the existing local branch when a remote branch is picked', async () => {
+    const { repository } = createRepositoryWithRemote({ defaultBranch: 'react' });
+    runGit(repository, ['branch', 'react', 'origin/react']);
+
+    const result = await checkoutBranch(repository, 'origin/react');
+
+    expect(result).toEqual({ success: true, branch: 'react' });
+    expect(runGit(repository, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('react');
+  });
+
+  it('accepts the remotes/ prefixed form of a remote branch', async () => {
+    const { repository } = createRepositoryWithRemote({ defaultBranch: 'react' });
+
+    const result = await checkoutBranch(repository, 'remotes/origin/react');
+
+    expect(result).toEqual({ success: true, branch: 'react' });
+    expect(runGit(repository, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('react');
+  });
+
+  it('prefers a local branch whose name looks like a remote ref', async () => {
+    const { repository } = createRepositoryWithRemote({ defaultBranch: 'react' });
+    runGit(repository, ['branch', 'origin/react']);
+
+    const result = await checkoutBranch(repository, 'origin/react');
+
+    expect(result).toEqual({ success: true, branch: 'origin/react' });
+    expect(runGit(repository, ['symbolic-ref', 'HEAD']).trim()).toBe('refs/heads/origin/react');
+  });
+
+  it('rejects an unknown branch', async () => {
+    const { repository } = createRepositoryWithRemote();
+    await expect(checkoutBranch(repository, 'does-not-exist')).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
## Intent

Picking a remote branch in the Git branch selector left the repository on a detached `HEAD`. The dropdown lists `origin/main` right next to `main`, so choosing it reads as "work on main". A checkout of a remote-tracking ref does something else: it detaches HEAD, so the header shows `HEAD` instead of a branch name, the sync counts stop meaning anything, and commits land on no branch.

`checkoutBranch` now resolves a remote-tracking name to the local branch of that name, creating it with `--track` when it does not exist yet. It returns the branch that was actually checked out, and the toast reports that instead of the requested name.

Resolution order, identical in both Git runtimes:

1. A local branch with the requested name wins. A local branch literally named `origin/react` is still honored.
2. Otherwise, if the name resolves as a remote-tracking ref under a configured remote, check out the local branch of that name and create it with `--track` when missing. The `remotes/` prefixed form is accepted.
3. Anything unresolvable is checked out as requested, so git's own DWIM behavior stays intact. `origin/HEAD` names no branch of its own and is left alone.

## Non-goals

- Checking out a commit still detaches HEAD on purpose. That is the one place where a detached HEAD is the point, and the confirmation copy already says so.
- The dropdown's contents, grouping and copy are unchanged.
- Nothing here deletes stale local branches or changes fetch and sync behavior.

## Affected surfaces

| Surface | Change |
|---|---|
| `packages/web/server/lib/git/service.js` | `checkoutBranch` resolves remote-tracking picks. Serves web, desktop through the in-process backend, and mobile |
| `packages/vscode/src/gitService.ts` | Same resolution ahead of the VS Code Git API and the raw-git fallback, because the extension serves Git through its own bridge |
| `packages/ui/src/components/views/GitView.tsx` | The toast reports the branch from the response rather than the requested name |

No shared UI contract moves. `checkoutBranch(directory, branch)` already returned `{ success, branch }`, and callers pass the same strings as before. Both Git backends carry the fix, so every runtime behaves the same way.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` runtime boundaries and "prefer authoritative state over heuristics" | The fix spans shared UI and two runtime Git backends | Resolution lives in the runtime modules that own Git, never in shared UI. The branch shown to the user comes from the server's answer, not from the string the UI sent |
| `openchamber-change-discipline` | Executable source change with a cross-runtime contract | One helper per Git backend, no new exports or layers. Focused tests cover the new behavior, and unresolvable input keeps the previous behavior |
| `ui-api-decoupling` | Shared UI calls a Git capability served by two different runtimes | Both runtimes have intentional behavior. The UI consumes the trusted `branch` from the response instead of assuming its own input |
| `packages/web/server/lib/git/DOCUMENTATION.md` | Owning docs for the changed function | The `checkoutBranch` entry now states the resolution rules and what the returned `branch` means |
| `changelog-authoring` | User-facing fix | One bullet in `CHANGELOG.md` and one in `packages/vscode/CHANGELOG.md`, written in the extension's own voice |

## Validation

| Check | Result |
|---|---|
| `bun run test -- server/lib/git/service.test.js` (packages/web) | Pass, 80 tests. Six of them are new `checkoutBranch` cases against real temp repositories with a real remote: local branch by name, remote branch creating a tracking local branch with upstream asserted as `origin/react`, remote branch when the local one already exists, the `remotes/` prefixed form, a local branch named like a remote ref, and an unknown branch rejected |
| `bun run test` (packages/vscode) | Pass, 26/26 test files |
| `bunx oxlint` on the three changed source files | No findings in the added code. The file's pre-existing `anti-slop` backlog is untouched |
| `bun run type-check` (packages/ui, packages/vscode) | Pass |
| `bun run dead-code` | No new entries |
| CI on this HEAD | `checks`, `automation` and `label` all pass |

Not verified: the VS Code path never ran in an Extension Development Host. Its resolution reads the same rules through `execGit`, which reports exit codes directly, so it is covered by review rather than by an executed test.

One trap worth recording. The web helper deliberately avoids `show-ref --quiet`, because simple-git resolves a quiet non-zero exit as success. The first draft used `--quiet`, silently resolved nothing, and fell through to the old behavior. The tests caught it, and a comment in the code marks the reason.

## Visual evidence

No screenshot. The visible change is the branch name in the Git panel header, and reproducing it in the UI means detaching HEAD in a real checkout. The tests assert the equivalent: after picking `origin/react`, `git rev-parse --abbrev-ref HEAD` reports `react` where it previously reported `HEAD`, and `react@{upstream}` reports `origin/react`. Layout, styling and theming are untouched.

## Risks and failure behavior

- Creating the tracking branch is a single `git checkout -b <branch> --track <remote>`. If it fails, say because the branch is checked out in another worktree or a dirty tree blocks the switch, git leaves the repository where it was and the error reaches the user's toast unchanged. Nothing is half applied.
- This changes an existing habit. Someone who wanted a detached HEAD from the branch dropdown now lands on a branch instead. Checking out a specific commit from history still detaches, which is where that intent belongs.
- A local branch that already exists is checked out as it is. Its upstream is never rewritten, so no tracking configuration changes behind the user's back.
- The added lookups are `show-ref` and `git remote` calls on an already resolved repository context, a few milliseconds on an action that is already a checkout.
