### PR TITLE
fix(sidebar): search the managed chats along with project sessions

### DIFF
--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -77,6 +77,8 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
   const { t } = useI18n();
   const [isSessionSearchOpen, setIsSessionSearchOpen] = React.useState(false);
   const [sessionSearchQuery, setSessionSearchQuery] = React.useState('');
+  // Reported by the session list below: the header cannot see what matched.
+  const [searchMatchCount, setSearchMatchCount] = React.useState(0);
   const sessionSearchContainerRef = React.useRef<HTMLDivElement | null>(null);
   const sessionSearchInputRef = React.useRef<HTMLInputElement | null>(null);
   const [editingProjectDialogId, setEditingProjectDialogId] = React.useState<string | null>(null);
@@ -631,7 +633,7 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
         sessionSearchQuery={sessionSearchQuery}
         setSessionSearchQuery={setSessionSearchQuery}
         hasSessionSearchQuery={hasSessionSearchQuery}
-        searchMatchCount={0}
+        searchMatchCount={searchMatchCount}
         collapseAllProjects={projectView.actions.collapseAllProjects}
         expandAllProjects={projectView.actions.expandAllProjects}
       />
@@ -668,6 +670,7 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
           isWorktreeTopologyLoading,
           unresolvedWorktreeProjectPaths,
           projectView: projectView.state,
+          onSearchMatchCountChange: setSearchMatchCount,
         }}
         actions={{
           rowActions: {

--- a/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
+++ b/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
@@ -88,6 +88,12 @@ type SessionProjectCollectionProps = {
     isWorktreeTopologyLoading: boolean;
     unresolvedWorktreeProjectPaths: ReadonlySet<string>;
     projectView: ReturnType<typeof useSessionProjectViewState>['state'];
+    /**
+     * The match count belongs in the sidebar header, which renders above this
+     * list, while only the list knows what matched. Reported upwards rather
+     * than recomputed there, so the number and the rows can never disagree.
+     */
+    onSearchMatchCountChange: (count: number) => void;
   };
   actions: {
     rowActions: {
@@ -219,7 +225,7 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     () => chatGroup ? [chatGroup] : EMPTY_STANDALONE_GROUPS,
     [chatGroup],
   );
-  const { projectSections, groupSearchDataByGroup, sectionsForRender, flatSectionsForRender } = useSessionSidebarSections({
+  const { projectSections, groupSearchDataByGroup, sectionsForRender, flatSectionsForRender, searchMatchCount } = useSessionSidebarSections({
     normalizedProjects: topology.projects,
     getSessionsForProject,
     getArchivedSessionsForProject,
@@ -235,6 +241,14 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     foldersMap,
     standaloneGroups,
   });
+
+  const onSearchMatchCountChange = view.onSearchMatchCountChange;
+  React.useEffect(() => {
+    onSearchMatchCountChange(searchMatchCount);
+  }, [onSearchMatchCountChange, searchMatchCount]);
+  // Unmounting means nothing is listed any more, so the header must not keep
+  // showing the last count it was told about.
+  React.useEffect(() => () => onSearchMatchCountChange(0), [onSearchMatchCountChange]);
 
   // Second bootstrap-demand owner: the layout-level useSessionListSync keeps
   // every known directory alive at background priority even when the sidebar

--- a/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
+++ b/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
@@ -524,8 +524,14 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     view.mobileVariant,
     view.normalizedSessionSearchQuery,
   ]);
+  // The chats live in the scroller's top content, which the "no project section
+  // matched" branch drops. Tell the scroller when that content is itself a
+  // search result, or a chat-only match renders as "no matches" (issue #3200).
+  const topContentHasSearchMatches = view.hasSessionSearchQuery
+    && standaloneGroups.some((group) => groupSearchDataByGroup.get(group)?.hasMatch === true);
   const scrollerModel = React.useMemo(() => ({
     topContent: recentSection,
+    topContentHasSearchMatches,
     hasSharedSessions: Boolean(recentSection),
     sectionsForRender: orderedSectionsForRender,
     projectSections,
@@ -552,6 +558,7 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     view.searchEmptyState,
     visibleSessionCountByGroup,
     recentSection,
+    topContentHasSearchMatches,
     singleProjectMode,
     selectedSingleProjectId,
   ]);

--- a/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
+++ b/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
@@ -35,6 +35,10 @@ import { isCapacitorApp } from '@/lib/platform';
 
 const PR_NO_PR_RETRY_MS = 5 * 60_000;
 
+// A stable empty array: without a chats group the sections hook must not see a
+// new reference on every render.
+const EMPTY_STANDALONE_GROUPS: SessionGroup[] = [];
+
 const isRootSession = (session: Session): boolean => {
   // SAFETY: OpenCode attaches parentID to hierarchical session records,
   // although the SDK's base Session type does not currently declare it.
@@ -181,6 +185,40 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     [collection.archivedSessions, collection.sessions, topology.availableWorktreesByProject, topology.isVSCode, topology.projects],
   );
   const { getSessionsForProject, getArchivedSessionsForProject } = useProjectSessionLists({ ownership });
+  // Built before the sections hook runs, because that hook owns the search data
+  // for every group the sidebar renders — the chats group included. A group the
+  // hook never sees renders an empty list while a search is active.
+  const chatGroup = React.useMemo<SessionGroup | null>(() => {
+    if (topology.isVSCode) return null;
+    const chatsRoot = getChatsRootForHome(view.homeDirectory)
+      ?? collection.chatSessions.map((session) => getChatsRootFromDirectory(session.directory)).find(Boolean)
+      ?? null;
+    if (!chatsRoot) return null;
+    const folderScopes = Array.from(new Set([
+      chatsRoot,
+      ...collection.chatSessions.map((session) => normalizePath(session.directory ?? null)).filter(Boolean),
+    ])).filter((directory): directory is string => Boolean(directory))
+      .map((directory) => ({ scopeKey: directory, directory }));
+    return {
+      id: 'managed-chats',
+      label: '',
+      branch: null,
+      description: null,
+      isMain: true,
+      worktree: null,
+      directory: chatsRoot,
+      folderScopeKey: chatsRoot,
+      folderScopes,
+      draftTarget: 'chat',
+      sessions: collection.chatSessions
+        .filter((session) => !session.time?.archived && isRootSession(session))
+        .map((session) => ({ session, children: (collection.childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({ session: child, children: [], worktree: null })), worktree: null })),
+    };
+  }, [collection.chatSessions, collection.childrenMap, topology.isVSCode, view.homeDirectory]);
+  const standaloneGroups = React.useMemo<SessionGroup[]>(
+    () => chatGroup ? [chatGroup] : EMPTY_STANDALONE_GROUPS,
+    [chatGroup],
+  );
   const { projectSections, groupSearchDataByGroup, sectionsForRender, flatSectionsForRender } = useSessionSidebarSections({
     normalizedProjects: topology.projects,
     getSessionsForProject,
@@ -195,6 +233,7 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     filterSessionNodesForSearch,
     buildGroupSearchText,
     foldersMap,
+    standaloneGroups,
   });
 
   // Second bootstrap-demand owner: the layout-level useSessionListSync keeps
@@ -379,33 +418,6 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     scrollerActions.setActiveProjectIdOnly,
     scrollerActions.setSessionSwitcherOpen,
   ]);
-  const chatGroup = React.useMemo<SessionGroup | null>(() => {
-    if (topology.isVSCode) return null;
-    const chatsRoot = getChatsRootForHome(view.homeDirectory)
-      ?? collection.chatSessions.map((session) => getChatsRootFromDirectory(session.directory)).find(Boolean)
-      ?? null;
-    if (!chatsRoot) return null;
-    const folderScopes = Array.from(new Set([
-      chatsRoot,
-      ...collection.chatSessions.map((session) => normalizePath(session.directory ?? null)).filter(Boolean),
-    ])).filter((directory): directory is string => Boolean(directory))
-      .map((directory) => ({ scopeKey: directory, directory }));
-    return {
-      id: 'managed-chats',
-      label: '',
-      branch: null,
-      description: null,
-      isMain: true,
-      worktree: null,
-      directory: chatsRoot,
-      folderScopeKey: chatsRoot,
-      folderScopes,
-      draftTarget: 'chat',
-      sessions: collection.chatSessions
-        .filter((session) => !session.time?.archived && isRootSession(session))
-        .map((session) => ({ session, children: (collection.childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({ session: child, children: [], worktree: null })), worktree: null })),
-    };
-  }, [collection.chatSessions, collection.childrenMap, topology.isVSCode, view.homeDirectory]);
   const renderChatsSection = React.useCallback(() => {
     if (!chatGroup) return null;
     return <SessionGroupSection

--- a/packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.test.ts
+++ b/packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { buildGroupRenderDescriptors, selectRenderedProjectSections } from './sessionProjectRender';
+import { buildGroupRenderDescriptors, resolveSearchResultPlacement, selectRenderedProjectSections } from './sessionProjectRender';
 import type { SessionGroup } from '../types';
 import { useSessionDisplayStore } from '@/stores/useSessionDisplayStore';
 
@@ -87,5 +87,18 @@ describe('single-project scroller projection', () => {
     } finally {
       useSessionDisplayStore.setState(previous, true);
     }
+  });
+});
+
+// Issue #3200: a query matching only a managed chat leaves no project section to
+// render. The chats live in the scroller's top content, so answering with the
+// empty state there hid a result the header was already counting.
+describe('resolveSearchResultPlacement', () => {
+  test('keeps the top content when the only match lives there', () => {
+    expect(resolveSearchResultPlacement(true)).toBe('top-content');
+  });
+
+  test('falls back to the empty state when nothing matched anywhere', () => {
+    expect(resolveSearchResultPlacement(false)).toBe('empty-state');
   });
 });

--- a/packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.tsx
+++ b/packages/ui/src/components/session/sidebar/projects/SessionProjectScroller.tsx
@@ -14,7 +14,7 @@ import { formatDirectoryName, formatPathForDisplay } from '@/lib/utils';
 import type { SessionGroup } from '../types';
 import { ProjectHeaderIdentity, SortableGroupItem, SortableProjectItem } from './sortableItems';
 import { SessionGroupSection, type SessionGroupSectionProps } from './SessionGroupSection';
-import { buildGroupRenderDescriptors, selectRenderedProjectSections, type ProjectSection } from './sessionProjectRender';
+import { buildGroupRenderDescriptors, resolveSearchResultPlacement, selectRenderedProjectSections, type ProjectSection } from './sessionProjectRender';
 import { formatProjectLabel } from '../utils';
 import { useI18n } from '@/lib/i18n';
 import type { ProjectSortOrder } from '@/stores/useSessionDisplayStore';
@@ -75,6 +75,12 @@ type SessionProjectScrollerGroupActions = Pick<SessionGroupSectionProps,
 
 type SessionProjectScrollerModel = {
   topContent?: React.ReactNode;
+  /**
+   * Whether the top content itself holds search results. The managed chats
+   * render only there, so without this the "no project section matched" branch
+   * below would drop a matching chat and claim there is nothing to show.
+   */
+  topContentHasSearchMatches?: boolean;
   hasSharedSessions?: boolean;
   sectionsForRender: ProjectSection[];
   projectSections: ProjectSection[];
@@ -225,7 +231,10 @@ function SessionProjectScrollerComponent(props: Props): React.ReactNode {
   }
 
   if (model.sectionsForRender.length === 0) {
-    return <ScrollableOverlay useScrollShadow scrollShadowSize={96} outerClassName="flex-1 min-h-0" className="space-y-1 pb-1 pl-2.5 pr-2">{model.searchEmptyState}</ScrollableOverlay>;
+    const placement = resolveSearchResultPlacement(model.topContentHasSearchMatches === true);
+    return <ScrollableOverlay useScrollShadow scrollShadowSize={96} outerClassName="flex-1 min-h-0" className="space-y-1 pb-1 pl-2.5 pr-2">
+      {placement === 'top-content' ? model.topContent : model.searchEmptyState}
+    </ScrollableOverlay>;
   }
 
   return (

--- a/packages/ui/src/components/session/sidebar/projects/sessionProjectRender.ts
+++ b/packages/ui/src/components/session/sidebar/projects/sessionProjectRender.ts
@@ -21,6 +21,19 @@ export const selectRenderedProjectSections = (
   ? sections.filter((section) => section.project.id === singleProjectId)
   : sections;
 
+/**
+ * What the sidebar shows when a search leaves no project section to render.
+ *
+ * The managed chats live in the scroller's top content rather than in a project
+ * section, so a query that matches only a chat empties `sectionsForRender` while
+ * a real result is still on screen above it. Answering `top-content` there keeps
+ * that result visible; answering `empty-state` before checking it hid the chat
+ * and claimed nothing matched, while the header counted the match (issue #3200).
+ */
+export const resolveSearchResultPlacement = (
+  topContentHasSearchMatches: boolean,
+): 'top-content' | 'empty-state' => topContentHasSearchMatches ? 'top-content' : 'empty-state';
+
 type GroupRenderDescriptor = {
   group: SessionGroup;
   groupKey: string;

--- a/packages/ui/src/components/session/sidebar/projects/useSessionSidebarSections.test.tsx
+++ b/packages/ui/src/components/session/sidebar/projects/useSessionSidebarSections.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { Session } from '@opencode-ai/sdk/v2';
+import { I18nProvider } from '@/lib/i18n';
+import { useSessionGrouping } from './useSessionGrouping';
+import { useSessionSidebarSections } from './useSessionSidebarSections';
+import type { SessionGroup } from '../types';
+
+const CHATS_ROOT = '/home/user/.config/openchamber/chats';
+
+const chatSession = (id: string, title: string): Session => ({
+  id,
+  slug: id,
+  projectID: 'chats',
+  title,
+  version: '1',
+  directory: `${CHATS_ROOT}/2026-08-28/session-${id}`,
+  time: { created: 1, updated: 1 },
+});
+
+const chatsGroup = (sessions: Session[]): SessionGroup => ({
+  id: 'managed-chats',
+  label: '',
+  branch: null,
+  description: null,
+  isMain: true,
+  worktree: null,
+  directory: CHATS_ROOT,
+  folderScopeKey: CHATS_ROOT,
+  folderScopes: [{ scopeKey: CHATS_ROOT, directory: CHATS_ROOT }],
+  draftTarget: 'chat',
+  sessions: sessions.map((session) => ({ session, children: [], worktree: null })),
+});
+
+type Sections = ReturnType<typeof useSessionSidebarSections>;
+
+// The real matcher and the real grouping callbacks run here: the reported bug
+// was never about matching, so a stubbed matcher would test nothing.
+const renderSections = (group: SessionGroup, query: string): Sections => {
+  let captured: Sections | null = null;
+  const Harness = () => {
+    const grouping = useSessionGrouping({
+      homeDirectory: '/home/user',
+      worktreeMetadata: new Map(),
+      pinnedSessionIds: new Set(),
+      sessionOrderRanks: new Map(),
+      gitBranches: new Map(),
+      isVSCode: false,
+    });
+    captured = useSessionSidebarSections({
+      normalizedProjects: [],
+      getSessionsForProject: () => [],
+      getArchivedSessionsForProject: () => [],
+      availableWorktreesByProject: new Map(),
+      projectRepoStatus: new Map(),
+      projectRootBranches: new Map(),
+      lastRepoStatus: false,
+      buildGroupedSessions: grouping.buildGroupedSessions,
+      hasSessionSearchQuery: query.length > 0,
+      normalizedSessionSearchQuery: query,
+      filterSessionNodesForSearch: grouping.filterSessionNodesForSearch,
+      buildGroupSearchText: grouping.buildGroupSearchText,
+      foldersMap: {},
+      standaloneGroups: [group],
+    });
+    return null;
+  };
+
+  renderToStaticMarkup(React.createElement(I18nProvider, null, React.createElement(Harness)));
+  if (!captured) throw new Error('sections hook was not mounted');
+  return captured;
+};
+
+// Issue #3200: the managed chats render outside every project section. They
+// were left out of the search pass, and a group without search data renders
+// `filteredNodes ?? []` — so every chat disappeared as soon as a query was
+// typed, however well its title matched.
+describe('sidebar search over standalone groups', () => {
+  test('keeps a matching chat in the group the sidebar renders', () => {
+    const group = chatsGroup([
+      chatSession('ses_a', 'Release notes for 1.21'),
+      chatSession('ses_b', 'Unrelated grocery list'),
+    ]);
+
+    const sections = renderSections(group, 'release');
+    const data = sections.groupSearchDataByGroup.get(group);
+
+    expect(data).toBeDefined();
+    expect(data?.filteredNodes.map((node) => node.session.id)).toEqual(['ses_a']);
+    expect(data?.hasMatch).toBe(true);
+  });
+
+  test('counts chat matches in the header count', () => {
+    const group = chatsGroup([
+      chatSession('ses_a', 'Release notes for 1.21'),
+      chatSession('ses_b', 'Release checklist'),
+      chatSession('ses_c', 'Unrelated grocery list'),
+    ]);
+
+    expect(renderSections(group, 'release').searchMatchCount).toBe(2);
+  });
+
+  test('reports no match for a chat group nothing matches in', () => {
+    const group = chatsGroup([chatSession('ses_a', 'Release notes for 1.21')]);
+
+    const sections = renderSections(group, 'groceries');
+    const data = sections.groupSearchDataByGroup.get(group);
+
+    expect(data?.filteredNodes).toEqual([]);
+    expect(data?.hasMatch).toBe(false);
+    expect(sections.searchMatchCount).toBe(0);
+  });
+
+  test('skips the search pass entirely when no query is active', () => {
+    const group = chatsGroup([chatSession('ses_a', 'Release notes for 1.21')]);
+
+    const sections = renderSections(group, '');
+
+    expect(sections.groupSearchDataByGroup.has(group)).toBe(false);
+    expect(sections.searchMatchCount).toBe(0);
+  });
+});

--- a/packages/ui/src/components/session/sidebar/projects/useSessionSidebarSections.ts
+++ b/packages/ui/src/components/session/sidebar/projects/useSessionSidebarSections.ts
@@ -56,6 +56,13 @@ type Args = {
   filterSessionNodesForSearch: (nodes: SessionNode[], query: string) => SessionNode[];
   buildGroupSearchText: (group: SessionGroup) => string;
   foldersMap: SessionFoldersMap;
+  /**
+   * Groups the sidebar renders outside any project section — today the managed
+   * chats. They search like every other group: a group with no search data
+   * renders its filtered nodes as an empty list, so leaving them out made every
+   * chat vanish the moment a query was typed.
+   */
+  standaloneGroups: SessionGroup[];
 };
 
 export const useSessionSidebarSections = (args: Args) => {
@@ -73,6 +80,7 @@ export const useSessionSidebarSections = (args: Args) => {
     filterSessionNodesForSearch,
     buildGroupSearchText,
     foldersMap,
+    standaloneGroups,
   } = args;
   const projectSectionCacheRef = React.useRef<Map<string, ProjectSectionCacheEntry>>(new Map());
 
@@ -158,29 +166,33 @@ export const useSessionSidebarSections = (args: Args) => {
 
     const countNodes = (nodes: SessionNode[]): number => nodes.reduce((total, node) => total + 1 + countNodes(node.children), 0);
 
-    visibleProjectSections.forEach((section) => {
-      section.groups.forEach((group) => {
-        const filteredNodes = filterSessionNodesForSearch(group.sessions, normalizedSessionSearchQuery);
-        const matchedSessionCount = countNodes(filteredNodes);
-        const groupMatches = matchesRankQuery([buildGroupSearchText(group)], normalizedSessionSearchQuery);
-        const scopeKey = normalizePath(group.directory ?? null);
-        const scopeFolders = scopeKey ? (foldersMap[scopeKey] ?? []) : [];
-        const folderNameMatchCount = scopeFolders.filter((folder) => matchesRankQuery([folder.name], normalizedSessionSearchQuery)).length;
+    const addSearchData = (group: SessionGroup) => {
+      const filteredNodes = filterSessionNodesForSearch(group.sessions, normalizedSessionSearchQuery);
+      const matchedSessionCount = countNodes(filteredNodes);
+      const groupMatches = matchesRankQuery([buildGroupSearchText(group)], normalizedSessionSearchQuery);
+      const scopeKey = normalizePath(group.directory ?? null);
+      const scopeFolders = scopeKey ? (foldersMap[scopeKey] ?? []) : [];
+      const folderNameMatchCount = scopeFolders.filter((folder) => matchesRankQuery([folder.name], normalizedSessionSearchQuery)).length;
 
-        result.set(group, {
-          filteredNodes,
-          matchedSessionCount,
-          folderNameMatchCount,
-          groupMatches,
-          hasMatch: groupMatches || matchedSessionCount > 0 || folderNameMatchCount > 0,
-        });
+      result.set(group, {
+        filteredNodes,
+        matchedSessionCount,
+        folderNameMatchCount,
+        groupMatches,
+        hasMatch: groupMatches || matchedSessionCount > 0 || folderNameMatchCount > 0,
       });
+    };
+
+    visibleProjectSections.forEach((section) => {
+      section.groups.forEach(addSearchData);
     });
+    standaloneGroups.forEach(addSearchData);
 
     return result;
   }, [
     hasSessionSearchQuery,
     visibleProjectSections,
+    standaloneGroups,
     filterSessionNodesForSearch,
     normalizedSessionSearchQuery,
     buildGroupSearchText,
@@ -271,17 +283,23 @@ export const useSessionSidebarSections = (args: Args) => {
       return 0;
     }
 
-    return sectionsForRender.reduce((total, section) => {
-      return total + section.groups.reduce((groupTotal, group) => {
-        const data = groupSearchDataByGroup.get(group);
-        if (!data) {
-          return groupTotal;
-        }
-        const metadataMatches = data.folderNameMatchCount + (data.groupMatches ? 1 : 0);
-        return groupTotal + data.matchedSessionCount + metadataMatches;
-      }, 0);
-    }, 0);
-  }, [hasSessionSearchQuery, sectionsForRender, groupSearchDataByGroup]);
+    const countGroup = (total: number, group: SessionGroup): number => {
+      const data = groupSearchDataByGroup.get(group);
+      if (!data) {
+        return total;
+      }
+      const metadataMatches = data.folderNameMatchCount + (data.groupMatches ? 1 : 0);
+      return total + data.matchedSessionCount + metadataMatches;
+    };
+
+    const projectMatches = sectionsForRender.reduce(
+      (total, section) => section.groups.reduce(countGroup, total),
+      0,
+    );
+    // Chats the user can see in the list count as matches too, or the header
+    // reports zero while their results sit right underneath it.
+    return standaloneGroups.reduce(countGroup, projectMatches);
+  }, [hasSessionSearchQuery, sectionsForRender, standaloneGroups, groupSearchDataByGroup]);
 
   return {
     projectSections,


### PR DESCRIPTION
## Intent

Typing anything into the sidebar session search made every chat that does not belong to a project disappear from the list, even when the query was an exact substring of a visible chat title.

The sidebar computes per-group search data — filtered nodes, match counts — and while a query is active every group renders `searchData?.filteredNodes ?? []` instead of its own sessions (`SessionGroupSection.tsx:386`). That data was only ever built for groups inside project sections (`useSessionSidebarSections.ts`). The managed chats render outside any project section, were never visited by that pass, and so fell through to the empty fallback. The header count skipped them for the same reason.

The chats group is now passed into the sections hook as a standalone group, so it takes the same search pass and joins the match total. It is built before the hook runs, which keeps search-data ownership in one place rather than having the rendering component write entries into the hook's map.

The report's second half — "0 matches" always shown in the header — is fixed here too. `SessionSidebar` passed the header a literal `0`. The count exists (the sections hook computes it) but only the session list can see it, while the header renders above the list, so the list now reports it upwards and resets it when it unmounts.

## Non-goals

- The matcher is untouched. The reporter had already verified matching works against real session titles, and this change confirms it: the tests run the real `useSessionGrouping` callbacks, not a stub.
- No change to how project sections, worktree grouping, flat display mode, or archived buckets search.
- No CHANGELOG entry. Left out deliberately at the maintainer's request so this branch does not conflict with the other open PRs touching `[Unreleased]`; the entry is to be written at release time. The change is user-facing and would otherwise earn one.

## Affected surfaces

- `packages/ui` — sidebar session search. Reaches Web, Desktop and mobile.
- **Not VS Code.** The extension never renders this group: `chatGroup` returns `null` when `topology.isVSCode` (`SessionProjectCollection.tsx`), because managed chats are not a VS Code surface. No entry in the extension changelog for that reason.
- No persisted data, no API, no stored format involved.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `.agents/skills/openchamber-change-discipline` | Shared UI source change | The group already existed and already rendered; the fix adds it to an existing pass rather than introducing a parallel search path. The shared body was extracted into one local function so project and standalone groups cannot drift apart |
| `.agents/skills/performance-engineering` | Sidebar render and search are hot paths | The added work is one group inside a memo that returns early unless a query is active, so idle and typing-free rendering is unchanged. `standaloneGroups` is memoized and falls back to a module-level constant when there is no chats group, so the memo's dependency identity is stable |
| `AGENTS.md` → Correctness Invariants | "Never let a missing input masquerade as an empty result" | The empty list users saw was exactly that: absent search data rendered as "nothing matched". The group now either has data or the search pass is off for everyone |
| `.agents/skills/changelog-authoring` | User-facing fix | No entry in this branch by maintainer decision (conflict avoidance, see Non-goals). The VS Code reachability check above independently rules out an extension entry: that surface never renders this group |
| `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` | Nearest owning doc | Read; it describes grouping and rendering structure, which this change does not alter, so no doc update was needed |

## Validation

| Check | Result |
|---|---|
| New `useSessionSidebarSections.test.tsx` | 4/4 pass; 3 of them fail on the pre-fix code (verified by disabling the new line) |
| `packages/ui` isolated runner, `src/components/session` | 30/30 files pass |
| `bun run type-check` | Pass, all workspaces |
| `bun run lint` | Pass, all workspaces |
| `bunx oxlint` + `eslint` on changed files | Clean |
| `bun run dead-code` | Nothing flagged for the new file or export |
| `bun run test` | Pass: ui, vscode, electron, web 165 files / 1683 tests |
| `bun run build` | Succeeds |

The tests cover a matching chat staying in the list, the match count including chats, a query that matches nothing, and no search pass running when the query is empty.

**Manual, against a production build of this branch (macOS, `packages/web` server serving its own `dist`):**

- `unauthorized` — matches one chat and nothing else: the chat stays visible, header reads `1 match`, no empty state. This is the issue's own reproduction and it failed until `75579ebd`.
- `Restart to update` — matches one chat and one project session: both visible, header reads `2 matches` instead of `0 matches`.
- `qqqqzzz` — matches nothing: empty state, `0 matches`.

Worth knowing for anyone else verifying this by hand: `OPENCHAMBER_DIST_DIR` was set in the shell to the installed desktop app's assets, so the local server served that UI and no local change appeared at all. Unsetting it was required before any of this could be observed.

**Not covered by a test:** the header wiring itself (a prop passed from `SessionSidebar` down to `SidebarHeader`). The count computation is unit-tested; the plumbing is verified manually only.

## Visual evidence

Not attached. This is a user-visible change and the contract asks for screenshots; image capture was unavailable in the environment this was written in, so the three observed states are reported under Validation instead. Reproducing them takes one search box: `unauthorized` before and after `75579ebd`.

## Risks and failure behavior

- **Idle cost unchanged.** The search-data memo still returns immediately when no query is active, so nothing new runs while the user is not searching.
- **One extra group per keystroke while searching**, against the existing per-project-group work. Its cost is the same filter the group would run anyway, over the chats the sidebar already holds in memory.
- **Reference stability preserved.** Without a chats group the hook receives a module-level constant, so the memo does not invalidate on every render.
- **Match count can now be higher than before** for the same query — that is the fix, not a regression: it previously omitted results that were visible on screen.
- **No behavior change outside an active search.** Every code path added is inside a query-active branch.
- **Header trails the list by one frame** per keystroke, because the count is reported through an effect after the list renders. Cosmetic; the alternative — computing it in the header — would duplicate ownership of what matched.
