### PR TITLE
fix(small-model): send configured provider headers

### DIFF
--- a/packages/web/server/lib/small-model/DOCUMENTATION.md
+++ b/packages/web/server/lib/small-model/DOCUMENTATION.md
@@ -116,9 +116,11 @@ other runtime API.
      endpoint, (3) the endpoint OpenCode resolved at runtime, or (4) the
     provider's `api` field from the models.dev catalog. The credential follows
     the same shape: config `options.apiKey`, then the runtime credential, then
-    the auth.json entry. Configured API keys honor OpenCode's `{env:NAME}` and
-    `{file:path}` substitutions; file contents and resolved credentials remain
-    server-side.
+    the auth.json entry. `provider.<id>.options.headers` is sent with the
+    request and overrides the bearer default, so gateways that authenticate on
+    their own header work here exactly as they do in a chat turn. Configured API
+    keys and header values honor OpenCode's `{env:NAME}` and `{file:path}`
+    substitutions; file contents and resolved credentials remain server-side.
   - The runtime credential is refused for providers listed in
     `OWN_CREDENTIAL_HANDLING`. Their branches need the stored entry rather than
     a bearer token: the clearest case is the ChatGPT-plan `openai` login, whose

--- a/packages/web/server/lib/small-model/call.js
+++ b/packages/web/server/lib/small-model/call.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { readAuthFile, writeAuthFile } from '../opencode/auth.js';
-import { readConfig, readConfigLayers } from '../opencode/shared.js';
+import { readConfig, readConfigLayers, isPlainObject } from '../opencode/shared.js';
 import { getCatalogProvider } from './catalog.js';
 import { getAuthEntryForProvider } from './resolve.js';
 import { getRuntimeProvider } from './runtime-providers.js';
@@ -544,6 +544,29 @@ const resolveConfigApiKey = (value, workingDirectory, providerID) => {
   }
 };
 
+/**
+ * `options.headers` from the provider config, with the same `{env:…}`/`{file:…}`
+ * substitutions the API key gets.
+ *
+ * OpenCode sends these on every request, so dropping them here would have the
+ * small model authenticating differently from the request path against the same
+ * URL. Gateways fronted by an API-management layer reject a bearer-only request
+ * outright, because the header is the credential rather than a supplement to it.
+ */
+const readConfiguredHeaders = (providerCfg, workingDirectory, providerID) => {
+  const configured = providerCfg?.options?.headers;
+  if (!isPlainObject(configured)) return null;
+  const headers = {};
+  for (const [name, value] of Object.entries(configured)) {
+    // Config headers are strings; a malformed entry is skipped rather than
+    // stringified into a header the gateway would reject.
+    if (String(value) !== value) continue;
+    const resolved = resolveConfigApiKey(value.trim(), workingDirectory, providerID);
+    if (resolved) headers[name] = resolved;
+  }
+  return Object.keys(headers).length ? headers : null;
+};
+
 const readProviderConfig = (workingDirectory, providerID) => {
   try {
     const config = readConfig(workingDirectory);
@@ -554,6 +577,7 @@ const readProviderConfig = (workingDirectory, providerID) => {
     const apiKey = rawApiKey ? resolveConfigApiKey(rawApiKey, workingDirectory, providerID) : null;
     return {
       baseURL,
+      headers: readConfiguredHeaders(providerCfg, workingDirectory, providerID),
       // Shape the config-supplied key as a regular api-key auth entry so it
       // can win the precedence check below and flow through the dispatch's
       // `entry.type === 'api' ? entry.key : ...` branch unchanged.
@@ -753,7 +777,9 @@ export async function callSmallModel({ auth, catalog, workingDirectory, provider
 
   return callOpenaiCompatible({
     baseURL,
-    headers: { Authorization: `Bearer ${apiKey}` },
+    // Configured headers last: a gateway that authenticates on its own header
+    // must be able to override the bearer default rather than sit beside it.
+    headers: { Authorization: `Bearer ${apiKey}`, ...(providerConfig?.headers || {}) },
     modelID,
     prompt,
     system,

--- a/packages/web/server/lib/small-model/call.test.js
+++ b/packages/web/server/lib/small-model/call.test.js
@@ -10,6 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../opencode/shared.js', () => ({
   readConfig: vi.fn(),
   readConfigLayers: vi.fn(),
+  // Pure predicate with no disk access — the real implementation, so header
+  // parsing is exercised rather than stubbed.
+  isPlainObject: (value) => value instanceof Object && !Array.isArray(value),
 }));
 
 vi.mock('./runtime-providers.js', () => ({ getRuntimeProvider: vi.fn(async () => null) }));
@@ -120,6 +123,39 @@ describe('callSmallModel — custom provider config', () => {
       });
 
       expect(lastCall(fetchMock).init.headers.Authorization).toBe('Bearer sk-env-key');
+    });
+
+    it('sends configured provider headers alongside the bearer token', async () => {
+      process.env.OPENCHAMBER_TEST_GATEWAY_KEY = 'sub-key';
+      readConfig.mockReturnValue({
+        provider: {
+          custom: {
+            options: {
+              apiKey: 'sk-config',
+              baseURL: 'https://proxy.example.test/v1',
+              headers: {
+                'Ocp-Apim-Subscription-Key': '{env:OPENCHAMBER_TEST_GATEWAY_KEY}',
+                'x-tenant': 'team',
+              },
+            },
+          },
+        },
+      });
+      fetchMock.mockResolvedValue(ok('hello'));
+
+      await callSmallModel({
+        auth: {},
+        catalog: {},
+        workingDirectory: '/proj',
+        providerID: 'custom',
+        modelID: 'model',
+        prompt: 'hi',
+      });
+
+      const { init } = lastCall(fetchMock);
+      expect(init.headers['Ocp-Apim-Subscription-Key']).toBe('sub-key');
+      expect(init.headers['x-tenant']).toBe('team');
+      expect(init.headers.Authorization).toBe('Bearer sk-config');
     });
 
     it('uses apiKey and baseURL from provider config when no auth.json entry exists', async () => {


### PR DESCRIPTION
claude:

## Intent

Closes #3213.

`readProviderConfig` read only `options.baseURL` and `options.apiKey`, and the OpenAI-compatible dispatch hardcoded `{ Authorization: Bearer … }`. `provider.<id>.options.headers` never reached the request, so the small model authenticated differently from the request path against the same URL.

`Ocp-Apim-Subscription-Key` is the [default subscription-key header of Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/api-management-subscriptions), and APIM answers a request without it with `401 Access denied due to missing subscription key`. For a provider behind such a gateway, walkthroughs, session goal audits, session titles and commit summaries all failed while the same model answered normally in a chat turn.

After this change, `options.headers` is read alongside the API key, `{env:…}`/`{file:…}` are resolved in the values by the existing `resolveConfigApiKey`, and the headers are merged into the request. They are spread **after** the bearer default, because for these gateways the configured header *is* the credential and must be able to override rather than sit beside it. Both headers are sent, which is what APIM-fronted deployments require.

## Non-goals

- **The dedicated wire-format branches** (Anthropic `x-api-key`, Google `x-goog-api-key`, Copilot). They build their own auth headers and no report involves them; widening the change there would alter working auth paths for no evidenced benefit.
- **`runtime-providers.js`**, which surfaces only `apiKey`/`baseURL`, so plugin-registered providers still cannot contribute headers. That is a separate resolution source with its own tests, noted in #3213 as follow-up rather than folded in here.
- **Header support in the OpenCode config UI.** `packages/web/server/lib/opencode/providers.js` already normalizes and persists `options.headers`; this PR only consumes what that surface writes.

## Affected surfaces

`packages/web/server/lib/small-model/call.js` — the OpenAI-compatible branch of `callSmallModel`, shared by every small-model consumer: Changes Walkthrough, session goal auditor, session titles, commit summaries. Server-side only; runs identically under web, desktop, VS Code and mobile because they all reach it through the same OpenChamber server, so there is no runtime-specific behavior to differentiate.

No persisted format, route, export or entrypoint changes. `readConfiguredHeaders` is module-private. `isPlainObject` is newly imported from `../opencode/shared.js`, which already exports it.

Behavior for providers without `options.headers` is unchanged: `readConfiguredHeaders` returns `null` and the spread is a no-op, which the existing 37 tests cover.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` → Always-On Constraints | Executable server change touching credential handling | Kept to the smallest complete fix; no dependencies added; resolved header values and file contents stay server-side and are never logged — the existing diagnostics log provider/model/status only, and I added none |
| `openchamber-change-discipline` (required by the source-change trigger) | Modifies OpenChamber source and a documented module contract | Classified as **module contract**, not local: the credential/endpoint resolution rules are documented in the module's `DOCUMENTATION.md`, so that doc is updated in the same commit. One intention-revealing helper next to the code it serves, no new layer, no speculative generalization |
| `packages/web/server/lib/small-model/DOCUMENTATION.md` | Nearest owning doc; its "Everything else" bullet is the contract this PR changes | Extended that bullet to state that `options.headers` is sent and overrides the bearer default, and that header values honor `{env:…}`/`{file:…}` |
| Local precedent in `packages/web/server/lib/opencode/providers.js` | Already parses this exact config field when persisting a custom provider | Reused its `isPlainObject` guard and per-entry string check instead of inventing a second shape for the same data |
| `AGENTS.md` → changelog ownership (650d899) | Tempting to add an `[Unreleased]` bullet for a user-visible fix | Both CHANGELOG files left untouched: they are the maintainer's release-time work and a fix lands without a changelog line |
| Validation rules in `AGENTS.md` and `CONTRIBUTING.md` | Server JS is not covered by `lint:web`, which globs `./src/**/*.{ts,tsx}` | Ran focused vitest plus `bunx oxlint` on the changed files, and verified against a live gateway rather than inferring runtime behavior from static checks |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/small-model/call.test.js` | 38 passed (37 pre-existing + 1 new) |
| Negative control: revert only the merge line, rerun | Exactly the new test fails — `expected undefined to be 'sub-key'`. Confirms it pins the fix, not the mock |
| `bun test packages/web/server/lib/small-model/resolve.test.js` | 17 pass, 0 fail (sibling consumer of this module; it is a `bun:test` file and fails under vitest on `main` too) |
| `bunx oxlint packages/web/server/lib/small-model/call.js call.test.js` | No new findings. My first draft added two `anti-slop(no-runtime-typeof)` errors; rewritten to use the shared `isPlainObject` and an explicit string comparison. Remaining findings on both files are pre-existing and untouched |
| `bun run type-check:web` | Clean |
| `bun run lint:web` | Clean |
| Live end-to-end | Patched `call.js` loaded against a real Azure-APIM-fronted OpenAI-compatible gateway: `httpStatus: 200`, content returned. The same request with bearer only returns the 401 from #3213 |

Not verified: Anthropic/Google/Copilot branches (untouched), plugin-registered providers via `runtime-providers.js` (out of scope, see Non-goals), and the full workspace suite — this is a single server module with no cross-workspace contract, so `AGENTS.md` directs focused validation instead.

## Visual evidence

No UI diff. The change is confined to outgoing HTTP request headers in a server module with no React, style or copy changes. The user-visible effect is the absence of a failure: a Walkthrough that previously rendered the provider's 401 in its error banner now generates. There is no new or altered rendered state to screenshot.

## Risks and failure behavior

Low. `readConfiguredHeaders` returns `null` when `options.headers` is absent or not a plain object, making the merge a no-op — providers that work today take an unchanged code path.

- **Malformed config**: non-string header values are skipped rather than stringified into a header the gateway would reject; a config whose headers are all unresolvable yields `null`, not an empty-object header bag.
- **Unresolvable `{file:…}`**: `resolveConfigApiKey` throws, and the existing `try`/`catch` in `readProviderConfig` already degrades to catalog-only resolution — same as today's behavior for an unresolvable `apiKey`.
- **Precedence**: a configured `Authorization` header now overrides the derived bearer. That is the intended contract and matches what OpenCode does in a chat turn; a user who sets that header is asking for it.
- **Security**: header values are treated exactly like the API key — resolved server-side, never logged, never returned to a client.
- **Rollback**: stateless per-request change, nothing persisted or cached. Reverting the commit fully restores previous behavior.

Worth noting this failure mode is not specific to one gateway — the same "auxiliary path ignores configured headers" bug has been reported against [Continue #9527](https://github.com/continuedev/continue/issues/9527), [LiteLLM #4833](https://github.com/BerriAI/litellm/issues/4833), [Positron #15248](https://github.com/posit-dev/positron/issues/15248) and [VS Code AI Toolkit #238](https://github.com/microsoft/vscode-ai-toolkit/issues/238).
