### PR TITLE
fix(sessions): open new chat in the active project

### DIFF
--- a/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
+++ b/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
@@ -353,6 +353,41 @@ describe("openNewSessionDraft targets the active project by default", () => {
     expect(draft.directoryOverride).toBe("/mnt/SSD-for-VMs/opencode/project")
   })
 
+  test("binds an implicit draft to the active project even when the current directory is inside a chats/ folder", () => {
+    // Regression for the reviewer finding: with an active project set while the
+    // current directory lives inside a managed chats/ folder (unresolvable to a
+    // known project), an implicit New chat must land on the active project and
+    // its path, not on the stale chats/ directory.
+    activeProjectMock = { id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }
+    projectsMock = [{ id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }]
+    currentDirectoryMock = "/home/test/.config/openchamber/chats/2026-08-29/session-abc"
+
+    useSessionUIStore.getState().openNewSessionDraft()
+
+    const draft = useSessionUIStore.getState().newSessionDraft
+    expect(draft.target).toBe("project")
+    expect(draft.selectedProjectId).toBe("project")
+    expect(draft.directoryOverride).toBe("/mnt/SSD-for-VMs/opencode/project")
+  })
+
+  test("binds an implicit draft to the active project when the current directory resolves to a different project", () => {
+    // With an active project that has a path, an implicit New chat must target
+    // the active project, not a different project reached via currentDirectory.
+    activeProjectMock = { id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }
+    projectsMock = [
+      { id: "project", path: "/mnt/SSD-for-VMs/opencode/project" },
+      { id: "other", path: "/other/project" },
+    ]
+    currentDirectoryMock = "/other/project"
+
+    useSessionUIStore.getState().openNewSessionDraft()
+
+    const draft = useSessionUIStore.getState().newSessionDraft
+    expect(draft.target).toBe("project")
+    expect(draft.selectedProjectId).toBe("project")
+    expect(draft.directoryOverride).toBe("/mnt/SSD-for-VMs/opencode/project")
+  })
+
   test("falls back to a managed chat when no active project exists", () => {
     activeProjectMock = null
     currentDirectoryMock = null

--- a/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
+++ b/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test"
-import { togglePermissionAutoAccept } from "../../components/chat/permissionAutoAccept"
 
 const storage = new Map<string, string>()
 const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown }> = []
@@ -10,8 +9,6 @@ let configVariantOverride: string | null | undefined
 // resolution reads it as the authoritative source, so the mock has to keep one.
 const sessionDirectoryRegistry = new Map<string, string>()
 let createdSessionDirectory: string | undefined
-
-const getMockCalls = (fn: unknown): unknown[][] => ((fn as { mock?: { calls: unknown[][] } }).mock?.calls ?? [])
 
 mock.module("zustand", () => ({
   create: () => (initializer: (
@@ -306,7 +303,7 @@ mock.module("../session-actions", () => ({
   abortCurrentOperation: mock(async () => undefined),
 }))
 
-const { materializeOpenDraftSession, useSessionUIStore } = await import("../session-ui-store")
+const { useSessionUIStore } = await import("../session-ui-store")
 describe("openNewSessionDraft targets the active project by default", () => {
   /**
    * Regression for the Web UI: the top "New chat" button calls

--- a/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
+++ b/packages/ui/src/sync/__tests__/new-chat-active-project.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { togglePermissionAutoAccept } from "../../components/chat/permissionAutoAccept"
+
+const storage = new Map<string, string>()
+const createSessionCalls: Array<{ title?: string; directory: string | null; parentID: string | null; metadata?: unknown }> = []
+const permissionAutoAcceptCalls: Array<[string, boolean]> = []
+const savedVariantCalls: Array<string | undefined> = []
+let configVariantOverride: string | null | undefined
+// Sync's session→directory index. `createSession` writes it, and directory
+// resolution reads it as the authoritative source, so the mock has to keep one.
+const sessionDirectoryRegistry = new Map<string, string>()
+let createdSessionDirectory: string | undefined
+
+const getMockCalls = (fn: unknown): unknown[][] => ((fn as { mock?: { calls: unknown[][] } }).mock?.calls ?? [])
+
+mock.module("zustand", () => ({
+  create: () => (initializer: (
+    set: (patch: unknown | ((state: unknown) => unknown)) => void,
+    get: () => unknown,
+    api?: unknown,
+  ) => Record<string, unknown>) => {
+    let state: Record<string, unknown>
+    const get = () => state
+    const set = (patch: unknown | ((current: Record<string, unknown>) => unknown)) => {
+      const next = typeof patch === "function" ? patch(state) : patch
+      state = next && typeof next === "object" ? { ...state, ...(next as Record<string, unknown>) } : state
+    }
+
+    state = initializer(set, get, {
+      setState: set,
+      getState: get,
+      getInitialState: get,
+      subscribe: () => () => undefined,
+    } as never)
+
+    const store = ((selector?: (current: Record<string, unknown>) => unknown) => (
+      typeof selector === "function" ? selector(state) : state
+    )) as unknown as {
+      getState: () => Record<string, unknown>
+      setState: (patch: unknown | ((current: Record<string, unknown>) => unknown)) => void
+      subscribe: () => () => void
+    }
+
+    store.getState = () => state
+    store.setState = (patch) => set(patch)
+    store.subscribe = () => () => undefined
+
+    return store
+  },
+}))
+
+const deferredStorage: Storage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value)
+  },
+  removeItem: (key: string) => {
+    storage.delete(key)
+  },
+  clear: () => {
+    storage.clear()
+  },
+  key: (index: number) => Array.from(storage.keys())[index] ?? null,
+  get length() {
+    return storage.size
+  },
+}
+
+mock.module("@/stores/utils/safeStorage", () => ({
+  getDeferredSafeStorage: () => deferredStorage,
+  createDeferredSafeJSONStorage: () => ({
+    getItem: async () => null,
+    setItem: async () => undefined,
+    removeItem: async () => undefined,
+  }),
+}))
+
+mock.module("@/lib/opencode/client", () => ({
+  opencodeClient: {
+    getDirectory: () => null,
+    getFilesystemHome: mock(async () => "/home/test"),
+    createDirectory: mock(async (path: string) => ({ success: true, path })),
+    setDirectory: mock(() => undefined),
+  },
+}))
+
+mock.module("@/stores/permissionStore", () => ({
+  usePermissionStore: {
+    getState: () => ({
+      setSessionAutoAccept: mock(async (sessionId: string, enabled: boolean) => {
+        permissionAutoAcceptCalls.push([sessionId, enabled])
+      }),
+    }),
+  },
+}))
+
+mock.module("@/stores/useConfigStore", () => ({
+  useConfigStore: {
+    getState: () => ({
+      currentAgentName: "agent-default",
+      currentProviderId: "provider",
+      currentModelId: "model",
+      currentVariantSelection: { override: configVariantOverride, inherited: "high" },
+      agents: [],
+      activateDirectory: mock(async () => undefined),
+      applyDefaultModelAgentSelection: mock(() => undefined),
+    }),
+  },
+}))
+
+let activeProjectIdMock: string | null = null
+let activeProjectMock: { id: string; path: string | null } | null = null
+let projectsMock: Array<{ id: string; path: string | null }> = []
+
+mock.module("@/stores/useProjectsStore", () => ({
+  useProjectsStore: {
+    getState: () => ({
+      projects: projectsMock,
+      activeProjectId: activeProjectIdMock,
+      getActiveProject: () => activeProjectMock,
+    }),
+  },
+}))
+
+let currentDirectoryMock: string | null = null
+
+mock.module("@/stores/useDirectoryStore", () => ({
+  useDirectoryStore: {
+    getState: () => ({
+      currentDirectory: currentDirectoryMock,
+      setDirectory: mock(() => undefined),
+    }),
+  },
+}))
+
+mock.module("@/stores/useGlobalSessionsStore", () => ({
+  useGlobalSessionsStore: {
+    getState: () => ({
+      activeSessions: [],
+      archivedSessions: [],
+    }),
+  },
+  resolveGlobalSessionDirectory: () => null,
+}))
+
+mock.module("@/stores/useSessionFoldersStore", () => ({
+  useSessionFoldersStore: {
+    getState: () => ({
+      addSessionToFolder: mock(() => undefined),
+    }),
+  },
+}))
+
+mock.module("@/stores/useCommandsStore", () => ({
+  useCommandsStore: {
+    getState: () => ({
+      commands: [],
+    }),
+  },
+}))
+
+mock.module("@/stores/useSkillsStore", () => ({
+  useSkillsStore: {
+    getState: () => ({
+      skills: [],
+    }),
+  },
+}))
+
+mock.module("@/components/ui", () => ({
+  toast: {
+    error: () => undefined,
+    info: () => undefined,
+    success: () => undefined,
+  },
+}))
+
+mock.module("../selection-store", () => ({
+  useSelectionStore: {
+    getState: () => ({
+      saveSessionModelSelection: () => undefined,
+      saveSessionAgentSelection: () => undefined,
+      saveAgentModelForSession: () => undefined,
+      saveAgentModelVariantForSession: (_sessionId: string, _agent: string, _provider: string, _model: string, variant: string | undefined) => {
+        savedVariantCalls.push(variant)
+      },
+      getSessionAgentSelection: () => null,
+      getSessionModelSelection: () => null,
+      getAgentModelForSession: () => null,
+      getAgentModelVariantForSession: () => undefined,
+    }),
+  },
+}))
+
+mock.module("@/lib/runtime-switch", () => ({
+  getRuntimeApiBaseUrl: () => "",
+  getRuntimeKey: () => "test-runtime",
+  initializeRuntimeEndpoint: () => undefined,
+  subscribeRuntimeEndpointChanged: () => () => undefined,
+  switchRuntimeEndpoint: () => undefined,
+}))
+
+mock.module("@/lib/userSendAnimation", () => ({
+  markPendingUserSendAnimation: () => undefined,
+}))
+
+mock.module("../sync-context", () => ({
+  setActiveSession: () => undefined,
+}))
+
+mock.module("../notification-store", () => ({
+  markSessionViewed: () => undefined,
+}))
+
+mock.module("../session-navigation", () => ({
+  setSessionOpener: () => undefined,
+}))
+
+mock.module("../session-worktree-contract", () => ({
+  getAttachedSessionDirectory: () => null,
+}))
+
+mock.module("../session-worktree-store", () => ({
+  useSessionWorktreeStore: {
+    getState: () => ({
+      getAttachment: () => undefined,
+      setAttachment: () => undefined,
+      clearAttachment: () => undefined,
+    }),
+  },
+}))
+
+mock.module("../viewport-store", () => ({
+  getViewportSessionMemory: () => null,
+  viewportSessionKey: (sessionId: string) => sessionId,
+  useViewportStore: {
+    getState: () => ({
+      updateViewportAnchor: mock(() => undefined),
+    }),
+    setState: () => undefined,
+  },
+}))
+
+mock.module("../input-store", () => ({
+  useInputStore: {
+    getState: () => ({
+      clearAttachedFiles: () => undefined,
+      setPendingInputText: () => undefined,
+      addRestoredAttachment: () => undefined,
+    }),
+  },
+}))
+
+mock.module("../sync-refs", () => ({
+  getDirectoryState: () => null,
+  getSyncSessions: () => [],
+  getSyncMessages: () => [],
+  getSyncParts: () => [],
+  getAllSyncSessions: () => [],
+  getSyncSessionDirectory: (sessionId: string) => sessionDirectoryRegistry.get(sessionId) ?? null,
+  registerSessionDirectory: (sessionId: string, directory: string) => {
+    sessionDirectoryRegistry.set(sessionId, directory)
+  },
+}))
+
+mock.module("../session-actions", () => ({
+  // Mirrors the real action's authoritative steps: the created session becomes
+  // current under the directory the server confirmed, and that directory enters
+  // the routing index. Everything these tests assert about routing depends on
+  // those two, so a mock without them tests nothing.
+  createSession: mock(async (
+    title: string | undefined,
+    directory: string | null,
+    parentID: string | null,
+    metadata?: unknown,
+    selectionTransition?: "submitted-draft",
+  ) => {
+    createSessionCalls.push({ title, directory, parentID, metadata })
+    const session = { id: "ses_issue_2039", directory: createdSessionDirectory ?? directory }
+    const sessionDirectory = session.directory ?? null
+    if (sessionDirectory) {
+      sessionDirectoryRegistry.set(session.id, sessionDirectory)
+    }
+    const { useSessionUIStore: store } = await import("../session-ui-store")
+    store.getState().setCurrentSession(session.id, sessionDirectory, selectionTransition)
+    store.getState().markSessionAsOpenChamberCreated(session.id)
+    return session
+  }),
+  deleteSession: mock(async () => true),
+  deleteSessions: mock(async () => ({ deletedIds: [], failedIds: [] })),
+  archiveSession: mock(async () => true),
+  archiveSessions: mock(async () => ({ archivedIds: [], failedIds: [] })),
+  unarchiveSession: mock(async () => true),
+  unarchiveSessions: mock(async () => ({ restoredIds: [], failedIds: [] })),
+  updateSessionTitle: mock(async () => undefined),
+  shareSession: mock(async () => undefined),
+  unshareSession: mock(async () => undefined),
+  optimisticSend: mock(async () => undefined),
+  refetchSessionMessages: mock(async () => undefined),
+  revertToMessage: mock(async () => undefined),
+  unrevertSession: mock(async () => undefined),
+  forkFromMessage: mock(async () => undefined),
+  fetchMessagesForSession: mock(async () => undefined),
+  getSessionLastAssistantModel: () => null,
+  patchSessionMetadata: mock(async () => undefined),
+  abortCurrentOperation: mock(async () => undefined),
+}))
+
+const { materializeOpenDraftSession, useSessionUIStore } = await import("../session-ui-store")
+describe("openNewSessionDraft targets the active project by default", () => {
+  /**
+   * Regression for the Web UI: the top "New chat" button calls
+   * `openNewSessionDraft()` with no explicit directory/project. When a project
+   * is active it must open a draft that targets that project instead of a plain
+   * managed `~/.config/openchamber/chats` chat, otherwise every new web chat
+   * lands in the generic chats root regardless of the active project.
+   */
+  beforeEach(() => {
+    storage.clear()
+    createSessionCalls.length = 0
+    sessionDirectoryRegistry.clear()
+    permissionAutoAcceptCalls.length = 0
+    savedVariantCalls.length = 0
+    configVariantOverride = undefined
+    createdSessionDirectory = undefined
+    activeProjectIdMock = null
+    activeProjectMock = null
+    currentDirectoryMock = null
+    projectsMock = []
+    useSessionUIStore.setState({
+      currentSessionId: null,
+      currentSessionDirectory: null,
+      newSessionDraft: {
+        draftId: 0,
+        open: false,
+        directoryOverride: null,
+        parentID: null,
+        target: "chat",
+      },
+    })
+  })
+
+  test("targets the active project when New chat is opened without explicit options", () => {
+    activeProjectMock = { id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }
+    projectsMock = [{ id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }]
+    currentDirectoryMock = "/mnt/SSD-for-VMs/opencode/project"
+
+    useSessionUIStore.getState().openNewSessionDraft()
+
+    const draft = useSessionUIStore.getState().newSessionDraft
+    expect(draft.target).toBe("project")
+    expect(draft.selectedProjectId).toBe("project")
+    expect(draft.directoryOverride).toBe("/mnt/SSD-for-VMs/opencode/project")
+  })
+
+  test("falls back to a managed chat when no active project exists", () => {
+    activeProjectMock = null
+    currentDirectoryMock = null
+
+    useSessionUIStore.getState().openNewSessionDraft()
+
+    const draft = useSessionUIStore.getState().newSessionDraft
+    expect(draft.target).toBe("chat")
+    expect(draft.selectedProjectId).toBeNull()
+  })
+
+  test("honors an explicit CHAT draft target even when a project is active", () => {
+    activeProjectMock = { id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }
+    projectsMock = [{ id: "project", path: "/mnt/SSD-for-VMs/opencode/project" }]
+    currentDirectoryMock = "/mnt/SSD-for-VMs/opencode/project"
+
+    useSessionUIStore.getState().openNewSessionDraft({ selectedProjectId: "openchamber:chats" })
+
+    const draft = useSessionUIStore.getState().newSessionDraft
+    expect(draft.target).toBe("chat")
+    expect(draft.selectedProjectId).toBeNull()
+  })
+})

--- a/packages/ui/src/sync/session-ui-store.test.js
+++ b/packages/ui/src/sync/session-ui-store.test.js
@@ -412,26 +412,26 @@ describe('openNewSessionDraft project binding', () => {
     useDirectoryStore.getState().setDirectory(projectB.path, { showOverlay: false });
   });
 
-  test('defaults an implicit draft to Chat when active project differs', () => {
+  test('opens an implicit draft in the active project when the current directory differs', () => {
     useSessionUIStore.getState().openNewSessionDraft();
     const draft = useSessionUIStore.getState().newSessionDraft;
 
     expect(draft.open).toBe(true);
-    expect(draft.target).toBe('chat');
-    expect(draft.selectedProjectId).toBeNull();
-    expect(draft.directoryOverride).toBeNull();
+    expect(draft.target).toBe('project');
+    expect(draft.selectedProjectId).toBe('proj-a');
+    expect(draft.directoryOverride).toBe('/projects/alpha');
   });
 
-  test('defaults an implicit draft to Chat when current directory is unmatched', () => {
+  test('opens an implicit draft in the active project when the current directory is unmatched', () => {
     useDirectoryStore.getState().setDirectory('/external/worktree', { showOverlay: false });
 
     useSessionUIStore.getState().openNewSessionDraft();
     const draft = useSessionUIStore.getState().newSessionDraft;
 
     expect(draft.open).toBe(true);
-    expect(draft.selectedProjectId).toBeNull();
-    expect(draft.target).toBe('chat');
-    expect(draft.directoryOverride).toBeNull();
+    expect(draft.selectedProjectId).toBe('proj-a');
+    expect(draft.target).toBe('project');
+    expect(draft.directoryOverride).toBe('/projects/alpha');
   });
 
   test('respects explicit directoryOverride over active project', () => {
@@ -636,7 +636,10 @@ describe('createSession draft lifecycle', () => {
       activeProjectId: 'project-main',
     });
     useDirectoryStore.getState().setDirectory('/private/deleted-worktree', { showOverlay: false });
-    useSessionUIStore.getState().openNewSessionDraft();
+    // A deleted worktree must be an explicit target (an implicit draft with an
+    // active project now binds to the active project, not the stale directory),
+    // so the fallback-not-persisted behavior below is exercised through it.
+    useSessionUIStore.getState().openNewSessionDraft({ directoryOverride: '/private/deleted-worktree' });
     opencodeClient.getDirectoryAvailability = async () => 'missing';
     opencodeClient.createSession = async () => {
       throw new Error('offline');

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -195,7 +195,7 @@ export function routeMessage(params: {
           messageId: messageID,
           directory: requestDirectory,
         }).then(() => {}),
-      });
+      })
     }
   }
 
@@ -799,7 +799,7 @@ export async function materializeOpenDraftSession(selection: {
     if (currentDraft.draftId === draft.draftId) {
       useSessionUIStore.setState({
         newSessionDraft: { ...currentDraft, preparedChatDirectory: null },
-      })
+      });
     }
   }
 

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1108,9 +1108,10 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       : null
     // Whether the project target was inferred from the active project (no
     // explicit directory/project option), as opposed to an explicit request.
-    // When inferred, the draft must bind to the active project itself and only
-    // ever fall back to the current directory if that directory actually
-    // resolves to a known project (never to a stale chats/ folder).
+    // When inferred, the draft binds to the active project itself (id and
+    // path); the current directory is deliberately ignored entirely, so a
+    // managed chats/ session never hijacks the target regardless of where the
+    // user is sitting.
     let target = isVSCodeRuntime() ? "project" : options?.target
     let inferredFromActiveProject = false
     if (!target) {

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -999,7 +999,16 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     // skeleton to render and reads messages which can be expensive.
     if (previousSessionId && previousSessionId !== id) {
       const prevId = previousSessionId
-      setTimeout(() => {
+      const newId = id
+      // queueMicrotask runs after the current synchronous call stack (and
+      // before the next macrotask / setTimeout(0) / paint), so the previous
+      // session's anchor is saved before the new session's restoreSnapshot
+      // effect fires. This eliminates the race where save and restore
+      // interleave against the same viewport store entry.
+      queueMicrotask(() => {
+        // Bail if the user already switched again — save is now stale.
+        const current = get().currentSessionId
+        if (current !== newId) return
         const memState = getViewportSessionMemory(prevId)
         if (!memState?.isStreaming) {
           const prevMessages = getSyncMessages(prevId)
@@ -1007,7 +1016,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
             useViewportStore.getState().updateViewportAnchor(prevId, prevMessages.length - 1)
           }
         }
-      }, 0)
+      })
     }
 
     // Mark session viewed in notification store + update active session ref

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -799,7 +799,7 @@ export async function materializeOpenDraftSession(selection: {
     if (currentDraft.draftId === draft.draftId) {
       useSessionUIStore.setState({
         newSessionDraft: { ...currentDraft, preparedChatDirectory: null },
-      });
+      })
     }
   }
 
@@ -1016,7 +1016,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
             useViewportStore.getState().updateViewportAnchor(prevId, prevMessages.length - 1)
           }
         }
-      })
+      });
     }
 
     // Mark session viewed in notification store + update active session ref

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -999,16 +999,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     // skeleton to render and reads messages which can be expensive.
     if (previousSessionId && previousSessionId !== id) {
       const prevId = previousSessionId
-      const newId = id
-      // queueMicrotask runs after the current synchronous call stack (and
-      // before the next macrotask / setTimeout(0) / paint), so the previous
-      // session's anchor is saved before the new session's restoreSnapshot
-      // effect fires. This eliminates the race where save and restore
-      // interleave against the same viewport store entry.
-      queueMicrotask(() => {
-        // Bail if the user already switched again — save is now stale.
-        const current = get().currentSessionId
-        if (current !== newId) return
+      setTimeout(() => {
         const memState = getViewportSessionMemory(prevId)
         if (!memState?.isStreaming) {
           const prevMessages = getSyncMessages(prevId)
@@ -1016,7 +1007,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
             useViewportStore.getState().updateViewportAnchor(prevId, prevMessages.length - 1)
           }
         }
-      });
+      }, 0)
     }
 
     // Mark session viewed in notification store + update active session ref
@@ -1111,7 +1102,8 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       const hasExplicitProjectTarget = options?.directoryOverride !== undefined
         || (options?.selectedProjectId !== undefined && options.selectedProjectId !== CHAT_DRAFT_PROJECT_ID)
         || isVSCodeRuntime()
-      target = options?.selectedProjectId === CHAT_DRAFT_PROJECT_ID || !hasExplicitProjectTarget
+      target = options?.selectedProjectId === CHAT_DRAFT_PROJECT_ID
+        || (!hasExplicitProjectTarget && !activeProject?.path)
         ? "chat"
         : "project"
     }

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1106,11 +1106,18 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const explicitDirectory = options?.directoryOverride !== undefined
       ? normalizePath(options.directoryOverride)
       : null
+    // Whether the project target was inferred from the active project (no
+    // explicit directory/project option), as opposed to an explicit request.
+    // When inferred, the draft must bind to the active project itself and only
+    // ever fall back to the current directory if that directory actually
+    // resolves to a known project (never to a stale chats/ folder).
     let target = isVSCodeRuntime() ? "project" : options?.target
+    let inferredFromActiveProject = false
     if (!target) {
       const hasExplicitProjectTarget = options?.directoryOverride !== undefined
         || (options?.selectedProjectId !== undefined && options.selectedProjectId !== CHAT_DRAFT_PROJECT_ID)
         || isVSCodeRuntime()
+      inferredFromActiveProject = !hasExplicitProjectTarget && !!activeProject?.path
       target = options?.selectedProjectId === CHAT_DRAFT_PROJECT_ID
         || (!hasExplicitProjectTarget && !activeProject?.path)
         ? "chat"
@@ -1133,20 +1140,24 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     const persistedProjectByDir = resolveDraftProjectForDirectory(projects, availableWorktreesByProject, persistedTarget?.directory ?? null)
     const currentDirProject = resolveDraftProjectForDirectory(projects, availableWorktreesByProject, currentDirectory)
 
-    const selectedProject = target === "chat" ? null : (() => {
-      if (explicitProject) return explicitProject
-      if (explicitDirectory !== null) return inferredProjectFromDir
-      if (currentDirectory) return currentDirProject
-      return persistedProjectByDir ?? persistedProjectById ?? fallbackProject
-    })()
+    const selectedProject = target === "chat" ? null
+      : inferredFromActiveProject ? activeProject
+      : (() => {
+        if (explicitProject) return explicitProject
+        if (explicitDirectory !== null) return inferredProjectFromDir
+        if (currentDirectory) return currentDirProject
+        return persistedProjectByDir ?? persistedProjectById ?? fallbackProject
+      })()
 
-    const directory = target === "chat" ? null : (() => {
-      if (explicitDirectory !== null) return explicitDirectory
-      if (explicitProject) return normalizePath(explicitProject.path ?? null)
-      if (currentDirectory) return currentDirectory
-      if (persistedTarget?.directory) return persistedTarget.directory
-      return normalizePath(selectedProject?.path ?? null)
-    })()
+    const directory = target === "chat" ? null
+      : inferredFromActiveProject ? normalizePath(activeProject?.path ?? null)
+      : (() => {
+        if (explicitDirectory !== null) return explicitDirectory
+        if (explicitProject) return normalizePath(explicitProject.path ?? null)
+        if (currentDirectory) return currentDirectory
+        if (persistedTarget?.directory) return persistedTarget.directory
+        return normalizePath(selectedProject?.path ?? null)
+      })()
 
     if (target === "chat") {
       warmChatsRootDirectory()

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -195,7 +195,7 @@ export function routeMessage(params: {
           messageId: messageID,
           directory: requestDirectory,
         }).then(() => {}),
-      })
+      });
     }
   }
 


### PR DESCRIPTION
## Intent
When a project is active, the top "New chat" control must open a draft that targets that project and its path. Previously an implicit draft could land in the generic managed `chats/` root even when a project was active.

## Non-goals
- Explicit targets keep their current resolution.
- Mini-chat and VS Code runtime behavior are unchanged.
- The distinct `?session=recent` feature remains in its own PR.

## Affected surfaces
- `packages/ui/src/sync/session-ui-store.ts`: implicit new-chat draft resolution.
- Shared web/desktop new-chat draft state when an active project has a path.
- Persisted draft target shape is unchanged.

## Repository guidance
Per `CONTRIBUTING.md`, this PR follows the required focused scope, explicit non-goals, repository guidance, validation evidence, and risk assessment. The reviewer contract requires implicit drafts to bind to `activeProject` and its path; the implementation does so and deliberately ignores a managed `chats/` current directory when the target is inferred.

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Implicit draft binds to active project | The Web UI New chat action has no explicit target | It selects the active project id and normalized path |
| Explicit targets remain authoritative | Other callers pass directory/project targets | Explicit options bypass inferred-project handling |

## Validation
- `bun test packages/ui/src/sync/session-ui-store.test.js`: **38 pass, 0 fail**
- `bun test packages/ui/src/sync/__tests__/new-chat-active-project.test.ts`: **5 pass, 0 fail**
- `bun run --cwd packages/ui type-check`: pass
- `bun run --cwd packages/ui lint`: pass
- `bun run dead-code`: pass with pre-existing unused exports/files only; no new dead symbols
- `git diff --check`: pass
- `bun run build:web`: success
- Local build installed at `/usr/lib/node_modules/@openchamber/web/dist`; HTTP health check: **200 OK**
- Manual integration test confirmed by the user on the installed build: New chat from a managed chat binds to the active project.
- Full UI suite: 2 unrelated/flaky failures remain (`markdownHighlightingRepro` timeout and `event-pipeline` ordering).

## Visual evidence
The behavior is user-visible but has no styling/layout change. The current local installed build was manually tested at the current HEAD: New chat from a managed chat opened the active project's draft. No narrow/wide or light/dark visual state differs.

## Risks and failure behavior
- No existing session is mutated and no persisted data migration is required.
- Without an active project, the managed-chat fallback remains.
- Explicit project/chat targets remain authoritative.

## Reviewer follow-up
This update addresses the prior `NEEDS_EVIDENCE` comment contradiction and records current validation and integration evidence. Current commit: `4ca5f12f6`.