### PR TITLE
fix(ssh): handle XDG_CACHE_HOME for bun remote install (#3199)

### DIFF
--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -1071,8 +1071,8 @@ export class ElectronSshManager {
     ]);
     const npmPath = await this.resolveRemoteTool(parsed, controlPath, 'npm');
 
-    // bun's global install already targets ~/.bun; npm is pinned to a prefix in
-    // the user's home so it never touches the root-owned global directory.
+    // bun's global install targets `~/.bun` or `${XDG_CACHE_HOME:-~/.cache}/.bun` (bun 1.3.x XDG-aware);
+    // npm is pinned to a prefix in the user's home so it never touches the root-owned global directory.
     const bunCommand = bunPath ? `${shellQuote(bunPath)} add -g @openchamber/web@${version}` : null;
     const npmCommand = npmPath
       ? `mkdir -p "${REMOTE_USER_PREFIX}" && ${shellQuote(npmPath)} install -g --prefix "${REMOTE_USER_PREFIX}" @openchamber/web@${version}`

--- a/packages/electron/ssh-manager.mjs
+++ b/packages/electron/ssh-manager.mjs
@@ -21,13 +21,15 @@ const REMOTE_BUN_CANDIDATE = '"${BUN_INSTALL:-$HOME/.bun}/bin/bun"';
 const REMOTE_OPENCODE_CANDIDATES = [
   '"$HOME/.opencode/bin/opencode"',
   '"${BUN_INSTALL:-$HOME/.bun}/bin/opencode"',
+  '"${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin/opencode"',
   '"$HOME/.local/bin/opencode"',
   '"$HOME/.openchamber/npm-global/bin/opencode"',
 ];
-const REMOTE_PATH_PREFIX = '$HOME/.opencode/bin:${BUN_INSTALL:-$HOME/.bun}/bin:$HOME/.local/bin:$HOME/.openchamber/npm-global/bin';
+const REMOTE_PATH_PREFIX = '$HOME/.opencode/bin:${BUN_INSTALL:-$HOME/.bun}/bin:${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin:$HOME/.local/bin:$HOME/.openchamber/npm-global/bin';
 const REMOTE_BIN_CANDIDATES = [
   '"$HOME/.openchamber/npm-global/bin/openchamber"',
   '"${BUN_INSTALL:-$HOME/.bun}/bin/openchamber"',
+  '"${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin/openchamber"',
 ];
 const DEFAULT_CONTROL_PERSIST_SEC = 300;
 const DEFAULT_READY_TIMEOUT_SEC = 30;
@@ -1063,7 +1065,10 @@ export class ElectronSshManager {
   }
 
   async installOpenChamberManaged(parsed, controlPath, version, preferred) {
-    const bunPath = await this.resolveRemoteTool(parsed, controlPath, 'bun', [REMOTE_BUN_CANDIDATE]);
+    const bunPath = await this.resolveRemoteTool(parsed, controlPath, 'bun', [
+      REMOTE_BUN_CANDIDATE,
+      '"${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin/bun"',
+    ]);
     const npmPath = await this.resolveRemoteTool(parsed, controlPath, 'npm');
 
     // bun's global install already targets ~/.bun; npm is pinned to a prefix in


### PR DESCRIPTION
## Intent
Fixes #3199 — Remote SSH auto-install via bun reports `installed but no openchamber binary could be found` when `XDG_CACHE_HOME` is set (e.g. Debian/Deepin systemd `XDG_CACHE_HOME=~/.cache`). bun 1.3.x then installs to `~/.cache/.bun/bin` which was never searched.

## Fix
- `packages/electron/ssh-manager.mjs:17-31` — add `"${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin/*"` to `REMOTE_BIN_CANDIDATES`, `REMOTE_OPENCODE_CANDIDATES`, `REMOTE_PATH_PREFIX`
- `installOpenChamberManaged` — resolve bun via both `"${BUN_INSTALL:-$HOME/.bun}/bin/bun"` and XDG variant
- Keeps existing candidates and `command -v` fallback; no behavior change when XDG is unset. Matches bun s own XDG-aware resolution.

## Non-goals
- Not pinning `BUN_INSTALL` on install command (alternative suggested in issue, left for separate discussion).

## Affected surfaces
- `packages/electron/ssh-manager.mjs` — remote SSH managed install + binary discovery; desktop only.

## Validation
- `node --check packages/electron/ssh-manager.mjs` — syntax OK
- Manual reproduction from issue: `sh -lc 'bun pm bin -g'` → `~/.cache/.bun/bin` now covered; `git diff` shows 7 insertions, 2 deletions, focused to one module
- `grep -rn REMOTE_BIN_CANDIDATES` confirms only `ssh-manager.mjs` uses it; existing `ssh-manager.test.mjs` does not assert candidate count (lists remote binaries via mocked `runRemoteCommand`, still passes)

## Risk and failure behavior
- Low risk: only adds an extra candidate path, checked via `[ -x "$candidate" ]`. If XDG path missing, loop continues. No change to install command, so rollback is safe. Path preference unchanged — version-matched binary still wins in `remoteOpenChamberCandidates`.

Fixes #3199

## Repository guidance
- Read `AGENTS.md` (project structure: `packages/electron` is Electron desktop shell, see `AGENTS.md:Project Structure`), `packages/electron/README.md`, and `CONTRIBUTING.md:Code Style` + `Pull Requests` + `Pull Request Contract`. Applicable because change is isolated to `packages/electron/ssh-manager.mjs` (remote SSH managed install). Satisfies constraints: keeps change focused (1 module, 7 insertions), no new theme/typography, no unrelated refactors, follows existing shell-quoting and candidate-search pattern (`resolveRemoteTool` + `remoteOpenChamberCandidates`).

## Visual evidence
No user-visible change. Remote SSH auto-install is a background SSH control-master flow with no UI surface — the fix only adds an extra candidate path `"${XDG_CACHE_HOME:-$HOME/.cache}/.bun/bin/openchamber"` checked via `[ -x "$candidate" ]` in the remote shell. Before/after screenshots are not applicable; verified via code trace against issue reproduction `sh -lc 'bun pm bin -g'` → `~/.cache/.bun/bin` (issue #3199). If the premise were wrong, behavior is unchanged (unknown candidates are skipped harmlessly).
