### PR TITLE
fix(web): scope UI session cookie by request port for LAN multi-instance

### DIFF
--- a/packages/web/bin/lib/cli-http.js
+++ b/packages/web/bin/lib/cli-http.js
@@ -3,6 +3,10 @@ import { readDesktopLocalClientTokenFromSettings, readDesktopLocalPortFromSettin
 import { getInstanceFilePath, readInstanceOptions } from './cli-process.js';
 
 const UI_SESSION_COOKIE_NAME = 'oc_ui_session';
+// The server folds the request port into the cookie name (oc_ui_session_<port>)
+// so LAN instances on different ports don't share one jar (issue #2377). Accept
+// both the bare name and any per-port variant when extracting.
+const UI_SESSION_COOKIE_PATTERN = new RegExp(`(?:^|,\\s*)(${UI_SESSION_COOKIE_NAME}(?:_\\d+)?=[^;]+)`);
 
 function extractUiSessionCookie(response) {
   const values = [];
@@ -23,7 +27,7 @@ function extractUiSessionCookie(response) {
   }
 
   for (const setCookie of values) {
-    const match = setCookie.match(new RegExp(`(?:^|,\\s*)(${UI_SESSION_COOKIE_NAME}=[^;]+)`));
+    const match = setCookie.match(UI_SESSION_COOKIE_PATTERN);
     if (match?.[1]) return match[1];
   }
   return null;

--- a/packages/web/server/lib/security/request-security.js
+++ b/packages/web/server/lib/security/request-security.js
@@ -1,3 +1,5 @@
+import { isSessionCookieName, sessionCookieNameForRequest } from '../ui-auth/session-cookie.js';
+
 export const createRequestSecurityRuntime = (deps) => {
   const { readSettingsFromDiskMigrated } = deps;
   // Origins of packaged (non-browser) clients whose WebView origin never
@@ -17,20 +19,27 @@ export const createRequestSecurityRuntime = (deps) => {
     if (!cookieHeader || typeof cookieHeader !== 'string') {
       return null;
     }
-    const segments = cookieHeader.split(';');
-    for (const segment of segments) {
-      const [rawName, ...rest] = segment.split('=');
-      const name = rawName?.trim();
-      if (!name) continue;
-      if (name !== 'oc_ui_session') continue;
-      const value = rest.join('=').trim();
+    // This instance's own cookie name for the host:port the request arrived on.
+    const preferred = sessionCookieNameForRequest(req);
+    const decode = (value) => {
       try {
         return decodeURIComponent(value || '');
       } catch {
         return value || null;
       }
+    };
+    let fallback = null;
+    for (const segment of cookieHeader.split(';')) {
+      const [rawName, ...rest] = segment.split('=');
+      const name = rawName?.trim();
+      if (!name || !isSessionCookieName(name)) continue;
+      const value = decode(rest.join('=').trim());
+      if (name === preferred) return value;
+      // Remember any session cookie as a fallback so single-instance and
+      // port-less (e.g. loopback without an explicit port) flows keep working.
+      fallback ??= value;
     }
-    return null;
+    return fallback;
   };
 
   const rejectWebSocketUpgrade = (socket, statusCode, reason) => {

--- a/packages/web/server/lib/security/request-security.js
+++ b/packages/web/server/lib/security/request-security.js
@@ -1,4 +1,4 @@
-import { isSessionCookieName, sessionCookieNameForRequest } from '../ui-auth/session-cookie.js';
+import { sessionCookieNameForRequest } from '../ui-auth/session-cookie.js';
 
 export const createRequestSecurityRuntime = (deps) => {
   const { readSettingsFromDiskMigrated } = deps;
@@ -19,27 +19,23 @@ export const createRequestSecurityRuntime = (deps) => {
     if (!cookieHeader || typeof cookieHeader !== 'string') {
       return null;
     }
-    // This instance's own cookie name for the host:port the request arrived on.
-    const preferred = sessionCookieNameForRequest(req);
-    const decode = (value) => {
+    // Match the exact slot for the host:port this request arrived on. A browser
+    // shares one jar across ports on a host, so reading by the request's own
+    // port is what keeps two LAN instances (issue #2377) from consuming each
+    // other's session. This mirrors ui-auth's per-request cookie resolution,
+    // so the set side, this CSRF read, and ui-auth never diverge.
+    const expected = sessionCookieNameForRequest(req);
+    for (const segment of cookieHeader.split(';')) {
+      const [rawName, ...rest] = segment.split('=');
+      if (rawName?.trim() !== expected) continue;
+      const value = rest.join('=').trim();
       try {
         return decodeURIComponent(value || '');
       } catch {
         return value || null;
       }
-    };
-    let fallback = null;
-    for (const segment of cookieHeader.split(';')) {
-      const [rawName, ...rest] = segment.split('=');
-      const name = rawName?.trim();
-      if (!name || !isSessionCookieName(name)) continue;
-      const value = decode(rest.join('=').trim());
-      if (name === preferred) return value;
-      // Remember any session cookie as a fallback so single-instance and
-      // port-less (e.g. loopback without an explicit port) flows keep working.
-      fallback ??= value;
     }
-    return fallback;
+    return null;
   };
 
   const rejectWebSocketUpgrade = (socket, statusCode, reason) => {

--- a/packages/web/server/lib/security/request-security.test.js
+++ b/packages/web/server/lib/security/request-security.test.js
@@ -47,7 +47,7 @@ describe('request security runtime', () => {
     })).resolves.toBe(false);
   });
 
-  test('picks the cookie for this instance port when a browser shares jars across LAN ports', () => {
+  test('reads the slot for the request port when a browser shares jars across LAN ports', () => {
     const runtime = createRuntime();
     // Two instances on one LAN IP: the browser sends BOTH session cookies to
     // either port (browsers key cookie jars on host, not port — issue #2377).
@@ -60,7 +60,17 @@ describe('request security runtime', () => {
     expect(runtime.getUiSessionTokenFromRequest(req)).toBe('token-b');
   });
 
-  test('falls back to the bare cookie for loopback without an explicit port', () => {
+  test('never reads another port cookie when this port has none of its own', () => {
+    const runtime = createRuntime();
+    // Reaching :3001 with only the :3000 cookie in the jar must NOT borrow the
+    // other instance's session — it stays unauthenticated for this port.
+    const req = {
+      headers: { host: '192.168.0.1:3001', cookie: 'oc_ui_session_3000=token-a' },
+    };
+    expect(runtime.getUiSessionTokenFromRequest(req)).toBeNull();
+  });
+
+  test('reads the bare cookie for a host without an explicit port', () => {
     const runtime = createRuntime();
     const req = {
       headers: { host: '192.168.0.1', cookie: 'oc_ui_session=token-bare' },

--- a/packages/web/server/lib/security/request-security.test.js
+++ b/packages/web/server/lib/security/request-security.test.js
@@ -46,4 +46,31 @@ describe('request security runtime', () => {
       socket: {},
     })).resolves.toBe(false);
   });
+
+  test('picks the cookie for this instance port when a browser shares jars across LAN ports', () => {
+    const runtime = createRuntime();
+    // Two instances on one LAN IP: the browser sends BOTH session cookies to
+    // either port (browsers key cookie jars on host, not port — issue #2377).
+    const req = {
+      headers: {
+        host: '192.168.0.1:3001',
+        cookie: 'oc_ui_session_3000=token-a; oc_ui_session_3001=token-b',
+      },
+    };
+    expect(runtime.getUiSessionTokenFromRequest(req)).toBe('token-b');
+  });
+
+  test('falls back to the bare cookie for loopback without an explicit port', () => {
+    const runtime = createRuntime();
+    const req = {
+      headers: { host: '192.168.0.1', cookie: 'oc_ui_session=token-bare' },
+    };
+    expect(runtime.getUiSessionTokenFromRequest(req)).toBe('token-bare');
+  });
+
+  test('returns null when no session cookie is present', () => {
+    const runtime = createRuntime();
+    const req = { headers: { host: '192.168.0.1:3000', cookie: 'theme=dark; oc_url_token=x' } };
+    expect(runtime.getUiSessionTokenFromRequest(req)).toBeNull();
+  });
 });

--- a/packages/web/server/lib/ui-auth/DOCUMENTATION.md
+++ b/packages/web/server/lib/ui-auth/DOCUMENTATION.md
@@ -10,8 +10,16 @@ Pairing v2 is implemented by `packages/web/server/lib/client-auth/pairing.js`. I
 ## Entrypoints and structure
 - `packages/web/server/lib/ui-auth/ui-auth.js`: UI auth controller runtime, cookie/session issuance, rate limiting, and auth route handlers.
 - `packages/web/server/lib/ui-auth/ui-passkeys.js`: passkey store and WebAuthn registration/authentication verification helpers.
+- `packages/web/server/lib/ui-auth/session-cookie.js`: resolves the session cookie name from a request's `Host` port; shared by the set side (`ui-auth.js`) and the CSRF read side (`packages/web/server/lib/security/request-security.js`).
 - `packages/web/server/lib/client-auth/remote-clients.js`: trusted-device client token storage, bearer authentication, last-used tracking, and revocation.
 - `packages/web/server/lib/client-auth/pairing.js`: short-lived Pairing v2 sessions and one-time secret redemption into trusted-device client tokens.
+
+## Session cookie scoping
+Browsers key a cookie jar on the host only, never the port (RFC 6265). Two OpenChamber instances reached through the same LAN address on different ports (e.g. `http://192.168.0.1:3000` and `:3001`) therefore share a single `oc_ui_session` cookie, and logging into the second silently overwrote the first, logging both tabs out and breaking the CSRF token lookup (issue #2377).
+
+`sessionCookieNameForRequest(req, base)` folds the request `Host` port into the cookie name: `oc_ui_session_<port>` when the host carries an explicit port (including a port from `x-forwarded-host`), or the bare `oc_ui_session` when it does not. Loopback-only setups are unaffected because a browser keeps separate jars for `localhost` vs `127.0.0.1`, and a port-less host keeps the historical name. The **same** function is called on the set side and the CSRF read side so the two can never drift, and `request-security.js` selects the slot for the request's own port when several port cookies arrive together.
+
+Compatibility: upgrading renames the cookie for any explicit-port host, so already-signed-in browser sessions must log in once again. No on-disk format changes.
 
 ## Public exports (ui-auth.js)
 - `createUiAuth({ password, cookieName, sessionTtlMs, readSettingsFromDiskMigrated })`: creates UI auth controller with methods:

--- a/packages/web/server/lib/ui-auth/session-cookie.js
+++ b/packages/web/server/lib/ui-auth/session-cookie.js
@@ -1,0 +1,60 @@
+/**
+ * Session cookie naming that is stable per host:port.
+ *
+ * Browsers do not isolate cookies by port (RFC 6265 — the cookie jar is keyed
+ * on the host only). Two OpenChamber instances reached via the same LAN address
+ * but different ports (`http://192.168.0.1:3000` and `:3001`) therefore share
+ * one `oc_ui_session` cookie, and the instance logged into last silently
+ * overwrites the other, logging both tabs out and breaking CSRF (issue #2377).
+ *
+ * We fold the request port into the cookie name so each port owns its own
+ * cookie. The port is read from the request Host on BOTH the set side
+ * (`ui-auth.js`) and the CSRF read side (`request-security.js`) through this one
+ * function, so the names can never drift apart. Loopback URLs are unaffected:
+ * a browser keeps separate jars for `localhost` vs `127.0.0.1`, and a host with
+ * no explicit port keeps the bare `oc_ui_session` name for back-compat.
+ */
+export const SESSION_COOKIE_BASE = 'oc_ui_session';
+
+const forwardedHost = (headers) => {
+  const forwarded = headers?.['x-forwarded-host'];
+  if (typeof forwarded === 'string' && forwarded.trim().length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  const host = headers?.host;
+  return typeof host === 'string' ? host.trim() : '';
+};
+
+/**
+ * Extract the trailing port from a Host authority, or null when there is none.
+ * Handles bracketed IPv6 (`[::1]:3000`, `[::1]`) and plain host names.
+ */
+const hostPort = (host) => {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    if (end === -1) return null;
+    const rest = host.slice(end + 1);
+    if (!rest.startsWith(':')) return null;
+    return /^\d+$/.test(rest.slice(1)) ? rest.slice(1) : null;
+  }
+  const matches = host.match(/:(\d+)$/);
+  return matches ? matches[1] : null;
+};
+
+/**
+ * Resolve the session cookie name for a request. Returns the bare base name
+ * when the host carries no explicit port, otherwise `<base>_<port>`.
+ */
+export const sessionCookieNameForRequest = (req, base = SESSION_COOKIE_BASE) => {
+  const host = forwardedHost(req?.headers || {});
+  const port = host ? hostPort(host) : null;
+  if (!port) return base;
+  const portNumber = Number.parseInt(port, 10);
+  if (!Number.isFinite(portNumber) || portNumber <= 0) return base;
+  return `${base}_${port}`;
+};
+
+/** True when `name` is a session cookie for `base` (bare or a numeric-port variant). */
+export const isSessionCookieName = (name, base = SESSION_COOKIE_BASE) =>
+  name === base
+  || (name.startsWith(`${base}_`) && /^\d+$/.test(name.slice(base.length + 1)));

--- a/packages/web/server/lib/ui-auth/session-cookie.js
+++ b/packages/web/server/lib/ui-auth/session-cookie.js
@@ -53,8 +53,3 @@ export const sessionCookieNameForRequest = (req, base = SESSION_COOKIE_BASE) => 
   if (!Number.isFinite(portNumber) || portNumber <= 0) return base;
   return `${base}_${port}`;
 };
-
-/** True when `name` is a session cookie for `base` (bare or a numeric-port variant). */
-export const isSessionCookieName = (name, base = SESSION_COOKIE_BASE) =>
-  name === base
-  || (name.startsWith(`${base}_`) && /^\d+$/.test(name.slice(base.length + 1)));

--- a/packages/web/server/lib/ui-auth/session-cookie.test.js
+++ b/packages/web/server/lib/ui-auth/session-cookie.test.js
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test';
 import {
   SESSION_COOKIE_BASE,
   sessionCookieNameForRequest,
-  isSessionCookieName,
 } from './session-cookie.js';
 
 const req = (host, forwarded) => ({
@@ -43,18 +42,5 @@ describe('sessionCookieNameForRequest', () => {
   test('honours a custom base name', () => {
     expect(sessionCookieNameForRequest(req('127.0.0.1:3000'), 'my_app')).toBe('my_app_3000');
     expect(sessionCookieNameForRequest(req('127.0.0.1'), 'my_app')).toBe('my_app');
-  });
-});
-
-describe('isSessionCookieName', () => {
-  test('matches the bare name and any port variant', () => {
-    expect(isSessionCookieName('oc_ui_session')).toBe(true);
-    expect(isSessionCookieName('oc_ui_session_3000')).toBe(true);
-  });
-
-  test('rejects unrelated cookie names', () => {
-    expect(isSessionCookieName('oc_url_token_123')).toBe(false);
-    expect(isSessionCookieName('theme')).toBe(false);
-    expect(isSessionCookieName('oc_ui_session_extra_bad')).toBe(false);
   });
 });

--- a/packages/web/server/lib/ui-auth/session-cookie.test.js
+++ b/packages/web/server/lib/ui-auth/session-cookie.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  SESSION_COOKIE_BASE,
+  sessionCookieNameForRequest,
+  isSessionCookieName,
+} from './session-cookie.js';
+
+const req = (host, forwarded) => ({
+  headers: {
+    ...(host ? { host } : {}),
+    ...(forwarded ? { 'x-forwarded-host': forwarded } : {}),
+  },
+});
+
+describe('sessionCookieNameForRequest', () => {
+  test('keeps the bare base name when the host has no explicit port', () => {
+    expect(sessionCookieNameForRequest(req('192.168.0.1'))).toBe(SESSION_COOKIE_BASE);
+    expect(sessionCookieNameForRequest(req('example.com'))).toBe(SESSION_COOKIE_BASE);
+    expect(sessionCookieNameForRequest(req(''))).toBe(SESSION_COOKIE_BASE);
+    expect(sessionCookieNameForRequest(undefined)).toBe(SESSION_COOKIE_BASE);
+  });
+
+  test('folds the port into the name so LAN instances on one IP are isolated', () => {
+    expect(sessionCookieNameForRequest(req('192.168.0.1:3000'))).toBe('oc_ui_session_3000');
+    expect(sessionCookieNameForRequest(req('192.168.0.1:3001'))).toBe('oc_ui_session_3001');
+    expect(sessionCookieNameForRequest(req('192.168.0.1:8080'))).toBe('oc_ui_session_8080');
+  });
+
+  test('handles IPv6 authorities', () => {
+    expect(sessionCookieNameForRequest(req('[::1]:3000'))).toBe('oc_ui_session_3000');
+    expect(sessionCookieNameForRequest(req('[::1]'))).toBe(SESSION_COOKIE_BASE);
+  });
+
+  test('prefers the forwarded host port over the direct host', () => {
+    expect(sessionCookieNameForRequest(req('127.0.0.1:3902', '203.0.113.9:8443')))
+      .toBe('oc_ui_session_8443');
+  });
+
+  test('ignores malformed or non-numeric ports', () => {
+    expect(sessionCookieNameForRequest(req('192.168.0.1:notaport'))).toBe(SESSION_COOKIE_BASE);
+  });
+
+  test('honours a custom base name', () => {
+    expect(sessionCookieNameForRequest(req('127.0.0.1:3000'), 'my_app')).toBe('my_app_3000');
+    expect(sessionCookieNameForRequest(req('127.0.0.1'), 'my_app')).toBe('my_app');
+  });
+});
+
+describe('isSessionCookieName', () => {
+  test('matches the bare name and any port variant', () => {
+    expect(isSessionCookieName('oc_ui_session')).toBe(true);
+    expect(isSessionCookieName('oc_ui_session_3000')).toBe(true);
+  });
+
+  test('rejects unrelated cookie names', () => {
+    expect(isSessionCookieName('oc_url_token_123')).toBe(false);
+    expect(isSessionCookieName('theme')).toBe(false);
+    expect(isSessionCookieName('oc_ui_session_extra_bad')).toBe(false);
+  });
+});

--- a/packages/web/server/lib/ui-auth/ui-auth.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { createUiPasskeys } from './ui-passkeys.js';
+import { sessionCookieNameForRequest } from './session-cookie.js';
 
 const SESSION_COOKIE_NAME = 'oc_ui_session';
 const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
@@ -488,7 +489,7 @@ export const createUiAuth = ({
       const secure = isSecureRequest(req);
       const maxAgeSeconds = Math.floor(ttlMs / 1000);
       const header = buildCookie({
-        name: cookieName,
+        name: sessionCookieNameForRequest(req, cookieName),
         value: encodeURIComponent(token),
         maxAge: maxAgeSeconds,
         secure,
@@ -498,8 +499,9 @@ export const createUiAuth = ({
 
     const ensureSessionToken = async (req, res) => {
       const cookies = parseCookies(req.headers.cookie);
-      if (cookies[cookieName]) {
-        return cookies[cookieName];
+      const name = sessionCookieNameForRequest(req, cookieName);
+      if (cookies[name]) {
+        return cookies[name];
       }
       const token = crypto.randomBytes(32).toString('base64url');
       setSessionCookie(req, res, token, sessionTtlMs);
@@ -532,8 +534,9 @@ export const createUiAuth = ({
 
     const resolveAuthContext = async (req, res, { allowClientAuth = true, allowUrlToken = true } = {}) => {
       const cookies = parseCookies(req.headers.cookie);
-      if (cookies[cookieName]) {
-        return { type: 'session', token: cookies[cookieName] };
+      const name = sessionCookieNameForRequest(req, cookieName);
+      if (cookies[name]) {
+        return { type: 'session', token: cookies[name] };
       }
       if (allowClientAuth) {
         const clientAuth = await authenticateClientRequest(req, { allowUrlToken });
@@ -640,8 +643,9 @@ export const createUiAuth = ({
 
   const getTokenFromRequest = (req) => {
     const cookies = parseCookies(req.headers.cookie);
-    if (cookies[cookieName]) {
-      return cookies[cookieName];
+    const name = sessionCookieNameForRequest(req, cookieName);
+    if (cookies[name]) {
+      return cookies[name];
     }
     return null;
   };
@@ -650,7 +654,7 @@ export const createUiAuth = ({
     const secure = isSecureRequest(req);
     const maxAgeSeconds = Math.floor(ttlMs / 1000);
     const header = buildCookie({
-      name: cookieName,
+      name: sessionCookieNameForRequest(req, cookieName),
       value: encodeURIComponent(token),
       maxAge: maxAgeSeconds,
       secure,
@@ -661,7 +665,7 @@ export const createUiAuth = ({
   const clearSessionCookie = (req, res) => {
     const secure = isSecureRequest(req);
     const header = buildCookie({
-      name: cookieName,
+      name: sessionCookieNameForRequest(req, cookieName),
       value: '',
       maxAge: 0,
       secure,

--- a/packages/web/server/lib/ui-auth/ui-auth.test.js
+++ b/packages/web/server/lib/ui-auth/ui-auth.test.js
@@ -301,3 +301,59 @@ describe('ui auth client credential seam', () => {
     expect(expiresAt).toBeLessThanOrEqual(Date.now() + 124_000);
   });
 });
+
+// issue #2377: browsers key cookie jars on host only, so two instances on one
+// LAN IP (different ports) collided on `oc_ui_session`. Cookies are now scoped
+// by the request port so each instance owns its own slot.
+describe('ui auth port-scoped session cookies (issue #2377)', () => {
+  const loginHost = async (auth, host) => {
+    const req = { method: 'POST', headers: { host }, body: { password: 'secret' } };
+    const res = createResponse();
+    await auth.handleSessionCreate(req, res);
+    return String(res.getHeader('set-cookie') || '').split(';', 1)[0];
+  };
+
+  it('names the issued cookie with the request port', async () => {
+    const createUiAuth = await loadCreateUiAuth();
+    const auth = createUiAuth({ password: 'secret' });
+
+    const issued = await loginHost(auth, '192.168.0.1:3000');
+    expect(issued).toStartWith('oc_ui_session_3000=');
+    expect(issued.length).toBeGreaterThan('oc_ui_session_3000='.length);
+  });
+
+  it('keeps the bare cookie name when the host has no explicit port', async () => {
+    const createUiAuth = await loadCreateUiAuth();
+    const auth = createUiAuth({ password: 'secret' });
+
+    expect(await loginHost(auth, '192.168.0.1')).toStartWith('oc_ui_session=');
+  });
+
+  it('reads the slot for the request port and ignores another port cookie', async () => {
+    const createUiAuth = await loadCreateUiAuth();
+    const auth = createUiAuth({ password: 'secret' });
+
+    // Valid token issued against :3000.
+    const portCookie = await loginHost(auth, '192.168.0.1:3000');
+    const validToken = portCookie.slice('oc_ui_session_3000='.length);
+
+    // A request that lands on :3001 must read the :3001 slot, NOT the :3000 one,
+    // even though the browser ships both cookies to either port.
+    const wrongSlot = {
+      method: 'GET',
+      headers: { host: '192.168.0.1:3001', cookie: `oc_ui_session_3000=${validToken}; oc_ui_session_3001=stale` },
+    };
+    const wrongRes = createResponse();
+    await auth.handleSessionStatus(wrongSlot, wrongRes);
+    expect(wrongRes.body.authenticated).toBe(false);
+
+    // The same token read on its own port authenticates.
+    const rightSlot = {
+      method: 'GET',
+      headers: { host: '192.168.0.1:3000', cookie: `oc_ui_session_3000=${validToken}` },
+    };
+    const rightRes = createResponse();
+    await auth.handleSessionStatus(rightSlot, rightRes);
+    expect(rightRes.body.authenticated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Maintainer follow-up

Completed in [6991c1d08](https://github.com/openchamber/openchamber/commit/6991c1d08): CLI retry coverage now checks both cookie-header APIs with bare and port-scoped names, the auth assertions run under Vitest, and the documentation distinguishes session identity from CSRF. Workspace type-check, lint, build and the full test suite passed on integration HEAD `0667e739d`.

## Intent

Two OpenChamber instances running on the same LAN address but different ports (e.g. `http://192.168.0.1:3000` and `http://192.168.0.1:3001`) share a single `oc_ui_session` cookie, because browsers key cookie jars on the host and ignore the port (RFC 6265). Logging into the second instance silently overwrites the first's cookie, so refreshing **any** tab drops to the login screen and session create/send fail with "Failed to start session" / notification/session identity lookup failure. This folds the request port into the session cookie name (`oc_ui_session_<port>`) so each instance owns its own cookie slot; a host without an explicit port keeps the bare `oc_ui_session` name.

Closes #2377.

## Non-goals

- Same-host loopback instances on different ports receive separate cookie names too. A host without an explicit port keeps the historical bare name.
- Bearer-token validation and pairing are unchanged. Browser passkey login calls `issueSession` and receives the renamed session cookie.
- Does not migrate or honor an existing `oc_ui_session` cookie after upgrade — see Risks.

## Affected surfaces

- `packages/web/server/lib/ui-auth/ui-auth.js` — Set-Cookie / read / clear now derive the name per request.
- `packages/web/server/lib/ui-auth/session-cookie.js` (new) — single resolver shared by the set side, `ui-auth`'s own cookie read, and the notification/session identity read side, so the three can't drift.
- `packages/web/server/lib/security/request-security.js` — `getUiSessionTokenFromRequest` matches the exact slot for the request's own port.
- `packages/web/bin/lib/cli-http.js` — CLI session-cookie extraction accepts the per-port variant.
- Runtimes: Web/Desktop/Mobile browser sessions reached over HTTP. Desktop/VS Code/relay clients that authenticate with a bearer token or `oc_url_token` are unaffected (they don't read this cookie). WebSocket/SSE transports carry the cookie header through unchanged, so origin / URL-token minting / allowlists are untouched.
- Persisted/external contract: cookie name only; nothing on disk or in any stored file changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Server-side cookie/session contract + a new source file + notification/session identity consumer. | Smallest complete change; traced every `oc_ui_session` consumer (grep: set side, `ui-auth` read, notification/session identity read, CLI) and updated each to the same resolution; kept set/read symmetric (no divergence); updated the owning `DOCUMENTATION.md`; no changelog touch; removed a helper that became unused rather than leave it as dead surface. |
| `ui-auth/DOCUMENTATION.md` | Owns the cookie/session issuance truth. | Added a "Session cookie scoping" section documenting the port-folding rule, the shared-resolver invariant, and the upgrade re-login compatibility note. |
| `relay-transport` | Session cookie crosses SSE/WS. | Reviewed; the cookie rides existing request headers and the change does not touch origin handling, WS URL-token minting, or allowlists, so relay is unchanged. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/ui-auth/ packages/web/server/lib/security/ packages/web/bin/cli.test.js` | 111 pass / 0 fail. Includes: new `session-cookie.test.js` resolver cases; a notification/session identity case where a request on `:3001` with both port cookies present reads its **own** slot; a **cross-port isolation** case proving a request on `:3001` with only `oc_ui_session_3000` returns **null** (never borrows another instance's session); and `ui-auth` integration cases driving the real `handleSessionCreate`/`handleSessionStatus`. |
| `bun run type-check:web` (`tsc --noEmit`) | clean |
| `eslint` on all changed files | clean (exit 0) |
| `bun run dead-code` | new module is consumed (not reported dead) |
| Real two-instance browser repro over a LAN IP | **Not run** — needs two servers + a real browser on one LAN IP, unavailable here. Covered by integration tests through the real auth/notification/session identity code paths (not mocks). |

## Visual evidence

No rendered UI change: the fix is server-side cookie naming. The observable outcome (both tabs stay signed in) is a browser auth behavior, demonstrated by the regression tests rather than a rendered state.

## Risks and failure behavior

- **Compatibility (intended):** after upgrade, any explicit-port host has a renamed cookie, so currently-signed-in browser sessions must sign in once again. The notification/session identity read is exact-match (no cross-port or bare-name borrowing), so a stale cookie is simply ignored rather than causing a split-brain "logged in on some routes, out on others" state.
- **Security:** when multiple port cookies share a jar, both `ui-auth` and the notification/session identity path read only the slot for the request's own port, so one instance cannot consume another's session. Token verification (`jwtVerify`) is unchanged.
- **Failure behavior:** a missing/mismatched/malformed cookie yields `null` (unauthenticated), exactly as the bare-name path did before.
