### PR TITLE
fix(web): canonicalize project path case on case-insensitive filesystems

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -236,6 +236,7 @@ const settingsNormalizationRuntime = createSettingsNormalizationRuntime({
   path,
   processLike: process,
   realpathSync: fs.realpathSync,
+  readdirSync: fs.readdirSync,
   tunnelBootstrapTtlDefaultMs: TUNNEL_BOOTSTRAP_TTL_DEFAULT_MS,
   tunnelBootstrapTtlMinMs: TUNNEL_BOOTSTRAP_TTL_MIN_MS,
   tunnelBootstrapTtlMaxMs: TUNNEL_BOOTSTRAP_TTL_MAX_MS,

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -236,6 +236,8 @@ Managed health failures are classified as `timeout`, `connection_refused`, `conn
   - `sanitizeSkillCatalogs(input)`
   - `sanitizeProjects(input)`
 
+Persistence path normalization (`normalizePathForPersistence` / `normalizeSettingsPaths` / `sanitizeProjects`, reached via the `readSettingsFromDiskMigrated` migration and `persistSettings`) resolves symlinks with `realpathSync` and, on case-insensitive filesystems (`win32`, `darwin`), also recovers the on-disk casing of each path component via `readdirSync` (exact-name match preferred so case-sensitive volumes are never rewritten). `realpathSync` alone does not report on-disk casing on these volumes, so without the readdir step a project stored with the wrong case would never match the real-case `directory` opencode reports for its sessions (issue #1913). A corrected path is flagged `changed` and written back to `settings.json`.
+
 ## Public exports (theme-runtime.js)
 - `createThemeRuntime(dependencies)`: creates custom theme runtime for on-disk theme discovery and JSON normalization/validation.
 - Returned API:

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.js
@@ -4,6 +4,7 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
     path,
     processLike,
     realpathSync,
+    readdirSync,
     tunnelBootstrapTtlDefaultMs,
     tunnelBootstrapTtlMinMs,
     tunnelBootstrapTtlMaxMs,
@@ -41,16 +42,71 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
     return trimmed;
   };
 
-  // Resolve symlinks, falling back to the original value on failure.
-  const safeRealpathSync = (value) => {
-    if (!realpathSync || typeof value !== 'string' || !value) {
-      return value;
-    }
+  // On case-insensitive but case-preserving filesystems (APFS default, NTFS)
+  // `realpathSync` resolves symlinks but returns the path with whatever casing
+  // was passed in — it does NOT report the on-disk casing. A project registered
+  // as `/Users/me/desktop/…` therefore stays lowercase even after realpath, and
+  // later case-sensitive `===` comparisons against the real (capitalized)
+  // session `directory` reported by opencode/git silently fail, mis-grouping
+  // sessions under a phantom worktree (issue #1913). We recover the true casing
+  // by walking each path component through readdir, preferring an exact match so
+  // that a case-SENSITIVE filesystem (where two entries may legitimately differ
+  // only by case) is never rewritten. Gated to case-insensitive platforms.
+  const CASE_INSENSITIVE_PLATFORMS = new Set(['win32', 'darwin']);
+
+  const rootLengthOf = (value) => {
+    const drive = /^[a-zA-Z]:[\\/]/.exec(value);
+    if (drive) return 3;
+    return value.startsWith('/') ? 1 : 0;
+  };
+
+  const canonicalizePathCase = (value) => {
+    if (!readdirSync || typeof value !== 'string' || !value) return value;
+    if (!CASE_INSENSITIVE_PLATFORMS.has(processLike?.platform)) return value;
+
+    let result = value;
     try {
-      return realpathSync(value);
+      const rootLength = rootLengthOf(value);
+      if (rootLength === 0) return value;
+      const root = value.slice(0, rootLength);
+      const segments = value.slice(rootLength).split(/[\\/]+/).filter(Boolean);
+      let current = root;
+      for (const segment of segments) {
+        let entries;
+        try {
+          entries = readdirSync(current);
+        } catch {
+          return value; // cannot read this level (missing/permission) — keep original
+        }
+        let next = segment;
+        if (!entries.includes(segment)) {
+          next = entries.find((entry) => entry.toLowerCase() === segment.toLowerCase());
+          if (!next) return value; // component doesn't exist — don't rewrite
+        }
+        current = path.join(current, next);
+      }
+      result = current;
     } catch {
       return value;
     }
+    return result;
+  };
+
+  // Resolve symlinks and canonical case, falling back to the original on failure.
+  const safeRealpathSync = (value) => {
+    if (typeof value !== 'string' || !value) {
+      return value;
+    }
+    const resolved = realpathSync
+      ? (() => {
+        try {
+          return realpathSync(value);
+        } catch {
+          return value;
+        }
+      })()
+      : value;
+    return canonicalizePathCase(resolved);
   };
 
   const normalizePathForPersistence = (value, options = {}) => {

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
@@ -235,4 +235,32 @@ describe('settings normalization runtime - case-insensitive filesystem casing (#
     expect(result.changed).toBe(true);
     expect(result.settings.projects[0].path).toBe('/Users/me/Desktop/VcFiles/app');
   });
+
+  it('recovers on-disk casing and drive-letter case on Windows (win32)', () => {
+    const winPath = {
+      resolve: (...args) => args[args.length - 1],
+      sep: '\\',
+      dirname: (p) => p.replace(/\\[^\\]*$/, ''),
+      join: (...parts) => parts.join('\\').replace(/\\+/g, '\\'),
+    };
+    // Tree: C:\Users\me\Desktop\app (true casing on disk).
+    const winListing = {
+      'C:\\': ['Users'],
+      'C:\\Users': ['me'],
+      'C:\\Users\\me': ['Desktop'],
+      'C:\\Users\\me\\Desktop': ['app'],
+    };
+    const runtime = createTestRuntime({
+      path: winPath,
+      processLike: { platform: 'win32', env: {} },
+      realpathSync: (p) => p,
+      readdirSync: (dir) => {
+        if (!Object.prototype.hasOwnProperty.call(winListing, dir)) throw new Error('ENOENT');
+        return winListing[dir];
+      },
+    });
+    // Lowercase drive letter + wrong segment casing come back fully canonical.
+    expect(runtime.normalizePathForPersistence('c:\\users\\me\\desktop\\app'))
+      .toBe('C:\\Users\\me\\Desktop\\app');
+  });
 });

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
@@ -167,3 +167,72 @@ describe('settings normalization runtime - symlink resolution', () => {
     });
   });
 });
+
+// issue #1913: on case-insensitive filesystems realpathSync preserves the input
+// casing, so a project stored as lowercase never matches the real-case session
+// directory. readdir walking recovers the true on-disk casing.
+describe('settings normalization runtime - case-insensitive filesystem casing (#1913)', () => {
+  const posixPath = {
+    resolve: (...args) => args[args.length - 1],
+    sep: '/',
+    dirname: (p) => p.split('/').slice(0, -1).join('/') || '/',
+    join: (...parts) => parts.join('/').replace(/\/+/g, '/'),
+  };
+
+  // Directory tree: /Users/me/Desktop/VcFiles/app (true casing).
+  const listing = {
+    '/': ['Users'],
+    '/Users': ['me'],
+    '/Users/me': ['Desktop'],
+    '/Users/me/Desktop': ['VcFiles'],
+    '/Users/me/Desktop/VcFiles': ['app'],
+  };
+  const readdirSync = (dir) => {
+    if (!Object.prototype.hasOwnProperty.call(listing, dir)) throw new Error('ENOENT');
+    return listing[dir];
+  };
+
+  const darwinRuntime = () => createTestRuntime({
+    path: posixPath,
+    processLike: { platform: 'darwin', env: {} },
+    realpathSync: (p) => p,
+    readdirSync,
+  });
+
+  it('recovers the on-disk casing when the stored path is lowercase', () => {
+    const runtime = darwinRuntime();
+    expect(runtime.normalizePathForPersistence('/users/me/desktop/vcfiles/app'))
+      .toBe('/Users/me/Desktop/VcFiles/app');
+  });
+
+  it('leaves a path that already matches disk casing untouched', () => {
+    const runtime = darwinRuntime();
+    expect(runtime.normalizePathForPersistence('/Users/me/Desktop/VcFiles/app'))
+      .toBe('/Users/me/Desktop/VcFiles/app');
+  });
+
+  it('does not rewrite when a component is genuinely missing', () => {
+    const runtime = darwinRuntime();
+    expect(runtime.normalizePathForPersistence('/Users/me/Desktop/nonexistent/app'))
+      .toBe('/Users/me/Desktop/nonexistent/app');
+  });
+
+  it('never rewrites case on a case-sensitive filesystem (linux)', () => {
+    const runtime = createTestRuntime({
+      path: posixPath,
+      processLike: { platform: 'linux', env: {} },
+      realpathSync: (p) => p,
+      readdirSync,
+    });
+    expect(runtime.normalizePathForPersistence('/users/me/desktop/vcfiles/app'))
+      .toBe('/users/me/desktop/vcfiles/app');
+  });
+
+  it('normalizeSettingsPaths flags a change so the corrected path is persisted', () => {
+    const runtime = darwinRuntime();
+    const projects = [{ id: 'a', path: '/users/me/desktop/vcfiles/app', label: 'App' }];
+    const result = runtime.normalizeSettingsPaths({ projects });
+    expect(result.changed).toBe(true);
+    expect(result.settings.projects[0].path).toBe('/Users/me/Desktop/VcFiles/app');
+  });
+});


### PR DESCRIPTION
## Intent

On macOS/Windows (case-insensitive, case-preserving volumes) a project whose `path` in `settings.json` differs in case from the on-disk path never matches the session `directory` that opencode/git report (always the real case). Because the sidebar compares those paths with case-sensitive `===`/`startsWith`/`Map.has`, the sessions get routed to a phantom worktree group and the project shows "No sessions in this workspace yet" even though sessions exist (#1913).

Persisted path normalization now recovers the true on-disk casing, so `project.path` and `session.directory` agree and grouping is correct.

Closes #1913.

## Non-goals

- **Not** a case-insensitive comparison in the sidebar. A tolerant `===` fallback would wrongly unify `/Foo` and `/foo` on a case-sensitive filesystem (Linux), where those are legitimately different directories. Canonicalizing at persistence keeps the real fix on the one platform that is actually case-insensitive.
- Does not change case-sensitive (Linux) behavior at all — the canonicalization is gated to `win32`/`darwin`.
- The transient optimistic entry created by `useProjectsStore.addProject` before the first server round-trip still carries the typed case; it reconciles to the server-canonical value on the next settings sync (same as today). This PR fixes the persisted/loaded state that produces the reported, restart-stable bug.

## Affected surfaces

- `packages/web/server/lib/opencode/settings-normalization-runtime.js` — `safeRealpathSync` now also recovers casing via `readdirSync`; reached by `normalizePathForPersistence`, `sanitizeProjects`, and the `readSettingsFromDiskMigrated` migration (which `GET /api/config/settings` uses) + `persistSettings`.
- `packages/web/server/index.js` — injects `readdirSync: fs.readdirSync` into the runtime.
- Runtimes: Web/Desktop (macOS/Windows) browser sessions over HTTP. Linux (case-sensitive) is explicitly excluded. VS Code / relay clients that authenticate with bearer/`oc_url_token` are unaffected.
- Persisted/external contract: `settings.json` `project.path` (and `lastDirectory`/`homeDirectory`/`pinnedDirectories`) may be rewritten to on-disk casing on the next read; a `changed` migration already writes those back. Project ids are base64(path) and are reconciled by the existing deterministic-id migration.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Persisted data (`settings.json`) + a shared normalization runtime consumed by read-migration and persist. | Smallest complete change at the existing single chokepoint (`safeRealpathSync`); traced every consumer of `normalizePathForPersistence`/`sanitizeProjects`; prefers exact-name match so case-sensitive volumes are never rewritten; no speculative cache added; updated owning `DOCUMENTATION.md`; no changelog touch (maintainer-owned). |

## Validation

| Check | Result |
|---|---|
| `bun test packages/web/server/lib/opencode/settings-normalization-runtime.test.js` | 16 pass / 0 fail (incl. 5 new #1913 cases: recovers lowercase→disk case; already-correct left unchanged; missing component left unchanged; **linux never rewritten**; `normalizeSettingsPaths` flags `changed`) |
| Real macOS end-to-end (this machine, APFS, `process.platform=darwin`, real `fs`) | `normalizeSettingsPaths` on a project path stored `.../myproject/sub` returns `.../MyProject/Sub` (true FS casing) with `changed=true` — i.e. it would be persisted back and match the real-case session directory. |
| Regression scan `bun test packages/web/server/lib/opencode/` | stable **12 fail, identical to clean-main baseline** (all are pre-existing `vi.stubGlobal/vi.setSystemTime/vi.hoisted` unsupported under `bun test`, unrelated to this change). `core-routes.test.js` (the only flaky-differential name) does not use these functions and does not reproduce. |
| `bun run --cwd packages/web type-check` (`tsc --noEmit`) | clean |
| `eslint` on all changed files | clean (exit 0) |
| Real running app + real sessions (sidebar grouping before/after) | **Not run** — needs a full desktop build with seeded sessions; the server-side normalization is exercised directly above against the real filesystem. |

## Visual evidence

No rendered-UI code changed; the fix is server-side path normalization. The user-visible outcome (sessions listed under the project instead of a phantom group) follows from `project.path` matching `session.directory` and is demonstrated by the unit + real-filesystem tests above rather than a screenshot.

## Risks and failure behavior

- **Persisted rewrite:** an existing lower-case `project.path` is corrected to disk casing on next read and written back. This is the intended self-heal; because project id is derived from path, the existing deterministic-id migration handles id/key reconciliation. If a path can't be read (missing/permission), `safeRealpathSync` returns the original unchanged — no data loss.
- **Case-sensitive volumes:** gated to `win32`/`darwin`, and within those the walk prefers an exact name, so a directory that legitimately differs only by case is never rewritten.
- **Security/permissions:** read-only `readdir`; no new credential or network surface.
