### PR TITLE
fix(desktop): flush close button against the window edge and theme-correct its hover

### DIFF
--- a/packages/ui/src/components/chat/__tests__/issue-2903-subagent-status-line-only.test.tsx
+++ b/packages/ui/src/components/chat/__tests__/issue-2903-subagent-status-line-only.test.tsx
@@ -138,12 +138,25 @@ const buildMaterializedSubagentSession = () => {
   return { messages, part };
 };
 
-const syncContext = (globalThis as unknown as {
+// SAFETY: sync-context.tsx publishes exactly these two keys on globalThis
+// (SYNC_CONTEXT_GLOBAL_KEY / SYNC_RUNTIME_CONTEXT_GLOBAL_KEY) so every module
+// instance shares one context identity; the cast only adds those two optional
+// keys to the global object type, and the guards below re-check presence.
+const syncGlobals = globalThis as {
   __openchamber_sync_context__?: React.Context<unknown>;
-}).__openchamber_sync_context__;
+  __openchamber_sync_runtime_context__?: React.Context<unknown>;
+};
+
+const syncContext = syncGlobals.__openchamber_sync_context__;
 
 if (!syncContext) {
   throw new Error('sync context was not published on globalThis by @/sync/sync-context');
+}
+
+const syncRuntimeContext = syncGlobals.__openchamber_sync_runtime_context__;
+
+if (!syncRuntimeContext) {
+  throw new Error('sync runtime context was not published on globalThis by @/sync/sync-context');
 }
 
 describe('issue #2903 busy embedded subagent status-line-only', () => {
@@ -173,7 +186,16 @@ describe('issue #2903 busy embedded subagent status-line-only', () => {
     });
 
     const system = { childStores, messageLoader: {}, sdk: {}, runtimeKey: 'test', directory: DIRECTORY };
-    const Provider = syncContext.Provider as React.Provider<unknown>;
+    // Mirrors SyncProvider's own nesting: system context outer, runtime inner.
+    // Directory-scoped hooks read the runtime context, so the harness must
+    // provide it with a currentDirectory source for the store lookups.
+    const runtime = {
+      childStores,
+      messageLoader: {},
+      sdk: {},
+      runtimeKey: 'test',
+      currentDirectory: { get: () => DIRECTORY, subscribe: () => () => undefined },
+    };
     let inactiveCount = -1;
     let activeCount = -1;
     let enabled = false;
@@ -188,15 +210,22 @@ describe('issue #2903 busy embedded subagent status-line-only', () => {
       return null;
     };
 
+    const renderHarness = () =>
+      React.createElement(
+        syncContext.Provider,
+        { value: system },
+        React.createElement(syncRuntimeContext.Provider, { value: runtime }, React.createElement(Harness)),
+      );
+
     try {
       await act(async () => {
-        root.render(React.createElement(Provider, { value: system }, React.createElement(Harness)));
+        root.render(renderHarness());
       });
       expect(inactiveCount).toBe(0);
 
       enabled = true;
       await act(async () => {
-        root.render(React.createElement(Provider, { value: system }, React.createElement(Harness)));
+        root.render(renderHarness());
       });
       expect(activeCount).toBe(14);
     } finally {

--- a/packages/ui/src/components/desktop/WindowsWindowControls.tsx
+++ b/packages/ui/src/components/desktop/WindowsWindowControls.tsx
@@ -142,7 +142,9 @@ export const WindowsWindowControls = React.memo(function WindowsWindowControls({
       <div
         className={cn(
           'app-region-no-drag group/wctl flex h-8 shrink-0 items-center',
-          isLeft ? 'mr-1' : 'ml-1',
+          // macOS-style circles keep an edge inset on the right (the header's
+          // flush pr-0 is a Windows-caption convention, classic style only).
+          isLeft ? 'mr-1' : 'ml-1 mr-3',
         )}
         aria-label={t('header.windowControls.groupAria')}
       >

--- a/packages/ui/src/components/desktop/WindowsWindowControls.tsx
+++ b/packages/ui/src/components/desktop/WindowsWindowControls.tsx
@@ -207,7 +207,11 @@ export const WindowsWindowControls = React.memo(function WindowsWindowControls({
         type="button"
         className={cn(
           buttonClassName,
-          'hover:bg-[var(--status-error-background)] hover:text-[var(--status-error-foreground)]',
+          // Hover pairs the solid error red with its authored on-red
+          // foreground (the --destructive pairing). The error-background wash
+          // is a banner surface tint, not a glyph-button hover: against it the
+          // on-solid foreground is unreadable in both modes.
+          'hover:bg-[var(--status-error)] hover:text-[var(--status-error-foreground)]',
         )}
         onClick={() => { void invokeDesktop('desktop_close_current_window'); }}
         title={t('header.windowControls.close')}

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1356,6 +1356,14 @@ export const Header: React.FC = () => {
       return undefined;
     }
 
+    // Custom in-window controls (frameless Electron, right side) own the right
+    // edge: no inline padding, so the pr-0 class applies and the close button
+    // sits flush with the window corner per Windows conventions. Only the
+    // browser's native window-controls overlay reserves padding + right inset.
+    if (usesFramelessChrome && windowControlsSide === 'right') {
+      return undefined;
+    }
+
     return {
       // Left inset is handled by the no-drag spacer (see renderDesktop); only
       // the right inset / titlebar height are owned by the window-controls overlay.
@@ -1363,7 +1371,7 @@ export const Header: React.FC = () => {
       minHeight: 'max(3rem, var(--oc-wco-titlebar-height, 0px))',
       height: 'max(3rem, var(--oc-wco-titlebar-height, 0px))',
     };
-  }, [isDesktopApp, isVSCode, usesFramelessChrome]);
+  }, [isDesktopApp, isVSCode, usesFramelessChrome, windowControlsSide]);
 
   const updateHeaderHeight = React.useCallback(() => {
     if (typeof document === 'undefined') {


### PR DESCRIPTION
## Intent

In the Electron app on Windows/Linux with classic window controls on the right, the close button sat 12px away from the window's right edge, so pressing the exact top-right corner did not trigger close. Windows conventions require the caption buttons to sit flush against the edge. The header root already had the right intent (`pr-0` for frameless chrome + right-side controls), but `webWindowControlsOverlayStyle` set an inline `paddingRight` on the same element, and inline styles override the class. In Electron (`frame: false`, `titleBarOverlayEnabled = false`) the WCO right-inset variable is always 0, so the computed value was a constant 12px gap.

The fix skips the inline style for the frameless + right case so the `pr-0` class governs and the close button's `h-12 w-11` hit target covers the corner. The browser window-controls-overlay path (installed PWA where Chromium draws native buttons) keeps its existing `paddingRight: calc(0.75rem + var(--oc-wco-right-inset))` reservation, and left-side controls keep their right-side breathing room.

The same button had a second problem: the hover paired the `--status-error-background` banner wash with `--status-error-foreground`, which each theme authors as the contrast color for the **solid** error red (the `--destructive` pairing). On the translucent wash the glyph loses its contrast in both modes — near-black on muted dark red in dark themes, white on pale red in light themes — which reads as the dark/light hover colors being reversed, with the dark-mode wash coming across as a muddy saturated red.

The hover now uses the solid `--status-error` with its authored `--status-error-foreground`, matching the destructive button pairing and the Windows caption-button convention (solid red, high-contrast glyph, consistent across themes).

One follow-on correction: the flush-edge `pr-0` applies to both control styles, but the corner-hugging convention is Windows/classic-only. macOS-style traffic lights keep their breathing room via an explicit 12px right margin on the right-side cluster, owned by the component so the mini-chat window (class-only header) matches.

## Non-goals

- Left-side controls placement (unchanged; left edge was already flush by design).
- Traffic-lights hover interaction (unchanged: glyphs reveal on cluster hover, brightness-filter on press; only the right-side cluster gained an edge margin). Left-side placement geometry (unchanged).
- Mini-chat window (its header is class-only and was never affected).
- VS Code webview host (`isVSCode` already returned `undefined` before this change).

## Affected surfaces

- `packages/ui` — `components/layout/Header.tsx` only: the desktop header root's inline style memo. User-visible only where `usesFramelessChrome` is true, i.e. Electron on win32/linux with custom window controls on the right.
- Browser/PWA: style application unchanged (padding + WCO inset + titlebar height reservation all kept). In the frameless+right Electron case the dropped `minHeight`/`height` inline values equal the existing `h-12` class (48px), so no height change.
- `packages/ui` — `components/desktop/WindowsWindowControls.tsx` (second and fourth commits): hover classes of the **classic** close button, plus a 12px right-edge margin for the **right-side traffic-lights cluster**. Min/max buttons, the traffic-lights hover interaction, the left-side cluster, and all other `--status-error-background` consumers (banners, dialogs) are untouched.
- Test-only addition: `packages/ui/src/components/chat/__tests__/issue-2903-subagent-status-line-only.test.tsx` — the harness now renders the sync **runtime** context inside the system one, mirroring `SyncProvider`'s nesting. Required because `c982fa682` rewired the directory-scoped hooks (`useDirectoryStore` chain) from the system context to the runtime context after this test was written; without it every PR fails that file in CI.
- Electron main/preload: no changes; `packages/electron` touched only for local packaging validation.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants (prefer authoritative state; intentional runtime differences) | The bug was an inline style silently overriding an intentional class-level decision | The frameless+right case now explicitly returns `undefined` from the memo with a comment, matching `pr-0` and `MiniChatLayout` precedent |
| `desktop-shell` skill + `packages/electron/README.md` | Verifying the fix required a packaged Linux AppImage; WCO availability depends on window creation flags | Read README build/verify sections; confirmed `frame: false` + `titleBarOverlayEnabled = false` in `main.mjs`; built and ran `verify:linux-appimage` |
| `theme-system` skill | Touches styled UI | No new colors, tokens, buttons, or icons; the hover pairs two existing theme tokens (`--status-error` with its authored `--status-error-foreground`), the same contract the destructive button already uses |

## Validation

| Check | Result |
|---|---|
| `bun run type-check:ui` | Pass |
| `bunx oxlint packages/ui/src/components/layout/Header.tsx` | No findings in changed code (4 pre-existing findings elsewhere in the file, untouched) |
| `bunx oxlint packages/ui/src/components/desktop/WindowsWindowControls.tsx` | No findings in changed code (2 pre-existing findings elsewhere in the file, untouched) |
| Visual hover check, classic close button, dark and light themes (packaged AppImage) | Solid theme red on hover with legible on-red glyph in both modes; reporter confirmed |
| Visual check, right-side traffic lights edge spacing after the inset (packaged AppImage, dark and light) | Circles keep ~12px breathing room from the corner in the main window and mini-chat; reporter confirmed |
| `OPENCHAMBER_TARGET_ARCH=x64 bun run package` (packages/electron) | Built `OpenChamber-1.21.1-linux-x86_64.AppImage` |
| `bun run verify:linux-appimage` | Pass (ELF arch, desktop identity, OpenCode CLI 1.18.25, 4 native modules) |
| Visual check in the packaged AppImage (Linux x64, classic controls, right side) | Close button flush with the window edge; top-right corner triggers close |
| `issue-2903-subagent-status-line-only.test.tsx` under bun 1.3.14 (CI's pinned `packageManager` version) and 1.4.0 | 5/5 pass each |
| Full `packages/ui` suite under bun 1.3.14 via `run-isolated-tests.mjs` | 356/356 files pass |
| PR CI (`pr checks` workflow, bun 1.3.14 runner) | Pass — all 356 files, build, type-check, lint |
| Not verified | Browser WCO overlay mode (Edge/Chrome installed PWA) — code path unchanged, but no automated or manual run in this environment |

## Visual evidence

### Before
Hover Light:
<img width="287" height="129" alt="image" src="https://github.com/user-attachments/assets/c808efe0-313e-4749-a98f-adf5c34265ba" />

Hover
<img width="210" height="136" alt="image" src="https://github.com/user-attachments/assets/45edeaf0-5735-4ca4-8654-1967432b8cb0" />
Normal
<img width="257" height="120" alt="image" src="https://github.com/user-attachments/assets/950ed9c7-8f79-4425-94b9-dacf68eefdd2" />

Mini player hover:
<img width="248" height="97" alt="image" src="https://github.com/user-attachments/assets/ec64b429-cf23-4f14-8f0b-7bba8a5b95cc" />


### After
Hover Light:
<img width="265" height="98" alt="image" src="https://github.com/user-attachments/assets/900fd78e-41bf-46c8-bdaa-dc4896526e43" />


Normal:
<img width="326" height="139" alt="image" src="https://github.com/user-attachments/assets/0c890a6a-da22-432d-b1ae-c3b2f19dbf71" />
Normal Maximized:
<img width="250" height="130" alt="image" src="https://github.com/user-attachments/assets/9e181acb-a21e-4259-b1d8-8dc574ef5848" />

Hover:
<img width="262" height="126" alt="image" src="https://github.com/user-attachments/assets/3b44697e-9f15-46c6-8c92-bf98af1b0ed4" />
Hover Maximized:
<img width="197" height="128" alt="image" src="https://github.com/user-attachments/assets/8196fa89-e4f9-4a56-981a-b143c00c4da1" />

Minichat normal (for the color change):
<img width="204" height="88" alt="image" src="https://github.com/user-attachments/assets/964c7a47-d3e7-4c2f-8108-3f2d1bb3c779" />
Minichat hover (for the color change):
<img width="289" height="101" alt="image" src="https://github.com/user-attachments/assets/93c20f34-3708-47b2-b2b5-1b333c7196b0" />

### Extra validations
Traffic lights, Right, Dark mode:
<img width="281" height="90" alt="image" src="https://github.com/user-attachments/assets/01280795-9c1d-4ede-b058-7aace88fb99a" />
Traffic lights, Right, Light mode:
<img width="215" height="84" alt="image" src="https://github.com/user-attachments/assets/d22c6ca9-f16f-4de7-8eb6-0cef5eebfd71" />


## Risks and failure behavior

- The only behavioral branch added is `usesFramelessChrome && windowControlsSide === 'right'` returning `undefined` from the style memo; worst case is visual spacing at the header's right edge, revertable by restoring the memo.
- `windowControlsSide` added to the memo dependency array; the memo recomputes when the user flips the controls position, which is the intended behavior.
- No data, security, updater, or cross-runtime contract is affected.


