### PR TITLE
fix(ui): clear session todos on revert and re-fetch on unrevert

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -689,25 +689,27 @@ class OpencodeService {
     return unwrapSdkData(response, 'session.messages');
   }
 
-  async getSessionTodos(sessionId: string): Promise<Array<{ id: string; content: string; status: string; priority: string }>> {
-    try {
-      const response = await this.client.session.todo({
-        sessionID: sessionId,
-        ...(this.currentDirectory ? { directory: this.currentDirectory } : {}),
-      });
-      if (response.error) {
-        return [];
-      }
-
-      const data = response.data;
-      if (!data || !Array.isArray(data)) {
-        return [];
-      }
-
-      return data as Array<{ id: string; content: string; status: string; priority: string }>;
-    } catch {
+  async getSessionTodos(
+    sessionId: string,
+    directory?: string,
+  ): Promise<Array<{ id: string; content: string; status: string; priority: string }>> {
+    // Authoritative re-fetch (used after revert/unrevert). Throws on transport or
+    // API error so callers can distinguish "no todos" (empty array) from "could
+    // not read todos" — swallowing to [] here previously let a transient failure
+    // wipe a session's visible todo list.
+    const resolvedDirectory = directory ?? this.currentDirectory;
+    const response = await this.client.session.todo({
+      sessionID: sessionId,
+      ...(resolvedDirectory ? { directory: resolvedDirectory } : {}),
+    });
+    if (response.error) {
+      throw new Error(`session.todo failed for ${sessionId}`);
+    }
+    const data = response.data;
+    if (!data || !Array.isArray(data)) {
       return [];
     }
+    return data as Array<{ id: string; content: string; status: string; priority: string }>;
   }
 
   /**

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -2277,6 +2277,7 @@ describe("revert/unrevert todo state (issue #2813)", () => {
 
     expect(replyCalls.some((call) => call.method === "session.todo" && call.params.sessionID === "root")).toBe(true)
     expect(store.getState().todo["root"]).toEqual(sessionTodosResult)
+    expect(useTodosPersistStore.getState().getSessionTodos("/tree", "root")).toEqual(sessionTodosResult)
   })
 
   test("unrevert leaves existing todos untouched when the re-fetch fails", async () => {

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -18,6 +18,8 @@ const failingRevertSessionIds = new Set<string>()
 const failingUnrevertSessionIds = new Set<string>()
 let afterUnrevertCall: ((sessionId: string) => void) | null = null
 let sessionDeleteError: unknown | null = null
+let sessionTodosResult: unknown[] = []
+let sessionTodosThrows = false
 let beforeSessionUpdateResolve: ((sessionId: string) => void) | null = null
 let beforeSessionDeleteResolve: ((sessionId: string) => void) | null = null
 const globalUpsertedSessions: unknown[] = []
@@ -142,6 +144,11 @@ mock.module("@/lib/opencode/client", () => ({
     getSessionMessages: mock((sessionId: string, _limit?: number, directory?: string | null) => {
       replyCalls.push({ method: "session.messages", params: { sessionID: sessionId, directory } })
       return Promise.resolve(sessionMessageRecords.get(sessionId) ?? [])
+    }),
+    getSessionTodos: mock((sessionId: string, directory?: string | null) => {
+      replyCalls.push({ method: "session.todo", params: { sessionID: sessionId, directory } })
+      if (sessionTodosThrows) return Promise.reject(new Error("session.todo failed"))
+      return Promise.resolve(sessionTodosResult)
     }),
     replyToPermission: mock((requestId: string, reply: string, options?: { directory?: string | null }) => {
       replyCalls.push({ method: "permission.reply", params: { requestID: requestId, reply, directory: options?.directory } })
@@ -270,6 +277,7 @@ mock.module("./sync-refs", () => ({
 
 import { create, type StoreApi } from "zustand"
 import { INITIAL_STATE } from "./types"
+import { useTodosPersistStore } from "@/stores/useTodosPersistStore"
 import type { DirectoryStore } from "./child-store"
 import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
 
@@ -2189,5 +2197,98 @@ describe("dismissOpenPermissionsForSession", () => {
     } finally {
       console.error = originalError
     }
+  })
+})
+
+// issue #2813: reverting a message must clear the session's todo list from both
+// the live sync store and the persist store; unreverting must re-fetch it.
+describe("revert/unrevert todo state (issue #2813)", () => {
+  const todo = { id: "t1", content: "task", status: "pending", priority: "medium" }
+  const revertDir = "/test/project"
+
+  beforeEach(() => {
+    replyCalls.length = 0
+    sessionMessageRecords.clear()
+    failingRevertSessionIds.clear()
+    failingUnrevertSessionIds.clear()
+    sessionRevertResult = {}
+    sessionMessagesResult = { data: [] }
+    sessionTodosResult = []
+    sessionTodosThrows = false
+    useTodosPersistStore.setState({ sessions: {} })
+  })
+
+  const seedSession = (state?: Partial<DirectoryStore>) => {
+    const session = { id: "session-a", time: { created: 1 } } as Session
+    const message = { id: "msg_2", sessionID: "session-a", role: "user", time: { created: 2 } } as Message
+    const part = { id: "prt_2", messageID: "msg_2", type: "text", text: "edit this" } as Part
+    const store = createStore({}, {
+      session: [session],
+      message: { "session-a": [message] },
+      part: { "msg_2": [part] },
+      ...state,
+    })
+    return store
+  }
+
+  test("clears live and persisted todos after a successful revert", async () => {
+    const store = seedSession({ todo: { "session-a": [todo] } as never })
+    useTodosPersistStore.getState().setSessionTodos(revertDir, "session-a", [todo])
+    sessionRevertResult = { data: { id: "session-a", time: { created: 1 }, revert: { messageID: "msg_2" } } }
+
+    const { setActionRefs, revertToMessage } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([[revertDir, store]]), () => revertDir)
+
+    await revertToMessage("session-a", "msg_2")
+
+    expect(store.getState().todo["session-a"]).toBe(undefined)
+    expect(useTodosPersistStore.getState().getSessionTodos(revertDir, "session-a")).toBe(undefined)
+  })
+
+  test("restores the todo list when the revert API call fails", async () => {
+    const store = seedSession({ todo: { "session-a": [todo] } as never })
+    useTodosPersistStore.getState().setSessionTodos(revertDir, "session-a", [todo])
+    sessionRevertResult = { error: { message: "rejected" }, response: { status: 500 } }
+
+    const { setActionRefs, revertToMessage } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([[revertDir, store]]), () => revertDir)
+
+    let thrown: unknown
+    try {
+      await revertToMessage("session-a", "msg_2")
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(Error)
+
+    expect(store.getState().todo["session-a"]).toEqual([todo])
+    expect(useTodosPersistStore.getState().getSessionTodos(revertDir, "session-a")).toEqual([todo])
+  })
+
+  test("unrevert re-fetches todos into the live and persisted stores", async () => {
+    const root = { id: "root", directory: "/tree", time: { created: 1 }, revert: { messageID: "root-target" } } as Session
+    const store = createStore({}, { session: [root] })
+    sessionTodosResult = [{ id: "t2", content: "restored", status: "pending", priority: "medium" }]
+
+    const { setActionRefs, unrevertSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/tree", store]]), () => "/tree")
+
+    await unrevertSession("root")
+
+    expect(replyCalls.some((call) => call.method === "session.todo" && call.params.sessionID === "root")).toBe(true)
+    expect(store.getState().todo["root"]).toEqual(sessionTodosResult)
+  })
+
+  test("unrevert leaves existing todos untouched when the re-fetch fails", async () => {
+    const root = { id: "root", directory: "/tree", time: { created: 1 }, revert: { messageID: "root-target" } } as Session
+    const store = createStore({}, { session: [root], todo: { root: [todo] } as never })
+    sessionTodosThrows = true
+
+    const { setActionRefs, unrevertSession } = await import("./session-actions")
+    setActionRefs(mockSdk as unknown as OpencodeClient, createChildStores([["/tree", store]]), () => "/tree")
+
+    await unrevertSession("root")
+
+    expect(store.getState().todo["root"]).toEqual([todo])
   })
 })

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -32,6 +32,7 @@ import { withLinkedIssue, type LinkedIssue } from "@/lib/linkedIssues"
 import { getImperativeSessionMessageLoader } from "./session-message-loader"
 import { cleanupPersistedSessionState } from "./session-deletion-cleanup"
 import { getRuntimeKey } from "@/lib/runtime-switch"
+import { useTodosPersistStore } from "@/stores/useTodosPersistStore"
 import { markAmbiguousTransportFailure } from "@/lib/relay/transport-error"
 import { getErrorStatus, isAmbiguousSendFailure } from "./send-failure-classification"
 import { getStaleRunningToolMessageID } from "./materialization"
@@ -2016,6 +2017,24 @@ export async function revertToMessage(sessionId: string, messageId: string): Pro
     patch.session = sessions
   }
 
+  // Reverting hides the messages at/after the revert point, so the todo list
+  // they produced must not linger in the composer status (which prefers the
+  // live list and falls back to the persisted one). Clear both optimistically
+  // and roll both back if the revert API fails.
+  const prevLiveTodos = state.todo?.[sessionId]
+  if (prevLiveTodos) {
+    const nextTodo = { ...state.todo }
+    delete nextTodo[sessionId]
+    patch.todo = nextTodo
+  }
+  const canPersist = !!directory && directory !== "global"
+  const prevPersistedTodos = canPersist
+    ? useTodosPersistStore.getState().getSessionTodos(directory!, sessionId)
+    : undefined
+  if (canPersist) {
+    useTodosPersistStore.getState().clearSessionTodos(getRuntimeKey(), directory!, sessionId)
+  }
+
   store.setState(patch)
 
   // Save input store state before mutations — if the API fails we need to
@@ -2061,9 +2080,16 @@ export async function revertToMessage(sessionId: string, messageId: string): Pro
     if (idx >= 0) {
       rollback[idx] = { ...rollback[idx], revert: prevRevert } as Session
     }
-    store.setState({
-      session: rollback,
-    })
+    // Restore the todo list we optimistically cleared so a failed revert does
+    // not leave the composer showing an empty task list.
+    const rollbackPatch: Record<string, unknown> = { session: rollback }
+    if (prevLiveTodos) {
+      rollbackPatch.todo = { ...current.todo, [sessionId]: prevLiveTodos }
+    }
+    store.setState(rollbackPatch)
+    if (canPersist && prevPersistedTodos) {
+      useTodosPersistStore.getState().setSessionTodos(directory!, sessionId, prevPersistedTodos)
+    }
     // Rollback input store: restore previous text and attachments
     useInputStore.setState({
       pendingInputText: prevInputText,
@@ -2136,6 +2162,22 @@ export async function unrevertSession(sessionId: string): Promise<void> {
     sessions[idx] = unrevertedSession
     store.setState({ session: sessions })
   }
+
+  // Unrevert restores messages that produced a todo list; re-fetch the
+  // authoritative todos so the composer status matches the restored session
+  // instead of staying empty (revert cleared them). Best-effort: on error, leave
+  // the current state untouched rather than wiping it to empty.
+  try {
+    const todos = await opencodeClient.getSessionTodos(sessionId, directory)
+    const after = store.getState()
+    store.setState({ todo: { ...after.todo, [sessionId]: todos } })
+    if (directory && directory !== "global") {
+      useTodosPersistStore.getState().setSessionTodos(directory, sessionId, todos)
+    }
+  } catch {
+    // ignore — a failed re-fetch must not fail the unrevert
+  }
+
   for (let attempt = 0; attempt < UNREVERT_REFETCH_ATTEMPTS; attempt += 1) {
     if (attempt > 0) await wait(UNREVERT_REFETCH_RETRY_MS)
     await refetchSessionMessages(sessionId)

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -511,6 +511,9 @@ async function fetchSessionMessages(sessionId: string, directory?: string | null
 }
 
 async function cascadeRevertToDescendants(rootId: string, cutoff: number): Promise<void> {
+  // NOTE: descendants' todo lists are intentionally not cleared/refetched here.
+  // #2813 covers the reverted session's own composer task list; cascading todo
+  // clear/refetch to subagent sessions is a known follow-up.
   for (const { session, directory } of getDescendantSessions(rootId)) {
     try {
       // A running descendant would keep writing messages past the revert


### PR DESCRIPTION
## Intent

"Revert from here" hides the messages at/after the revert point, but the todo list (the `todowrite` task list in the composer status, live `store.todo[sessionId]` with a `useTodosPersistStore` fallback) was never cleared — so a stale task list stayed visible after revert. Symmetrically, unrevert restored messages but not todos (#2813).

- `revertToMessage` now clears the todo list from **both** the live sync store and the persist store, and **rolls both back** if the revert API call fails.
- `unrevertSession` re-fetches the authoritative todos and writes both stores, leaving the existing list intact if the re-fetch errors.
- The previously-dead `getSessionTodos` helper now takes a `directory` and **throws on error** (instead of swallowing to `[]`), so callers distinguish "no todos" from "could not read" — a swallow-to-`[]` would have let a transient failure wipe the visible list.

Closes #2813.

## Non-goals

- Does not clear todos on the revert API *call* — clearing is optimistic and only persists on success (matches "cleared after a successful revert"); a failed revert restores the prior list.
- Does not add a live→persist write inside these actions (they set store state directly, mirroring `moveRecordEntries`); the persist write goes through `useTodosPersistStore` explicitly, as the deletion-cleanup path already does.

## Affected surfaces

- `packages/ui/src/sync/session-actions.ts` — `revertToMessage`, `unrevertSession`.
- `packages/ui/src/lib/opencode/client.ts` — `getSessionTodos` (was uncalled).
- Consumers of `store.todo[sessionId]` (ComposerStatusBar, WorkStatusTasksSection) and `useTodosPersistStore` — behavior unchanged except todos now track revert/unrevert. No persisted-format change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `sync-state-invariants` | Reverting mutates live sync store state that must stay consistent with the persisted mirror and survive failure. | Clears live + persisted together, and rolls both back on API failure (the function already had a rollback path for messages/input; todos now join it). No new cache, no speculative retry. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/session-actions.test.ts -t "issue #2813"` | 4 pass / 0 fail (revert clears live+persist; revert failure restores both; unrevert re-fetches into both; re-fetch failure leaves todos intact) |
| `bun test packages/ui/src/sync/` | 553 pass / 30 fail vs clean-main baseline **549 pass / 30 fail** → +4 new passing tests, **0 new failures** (the 30 are pre-existing vitest-API-in-`bun` failures, present on clean main) |
| `bun run --cwd packages/ui type-check` (`tsc --noEmit`) | clean (exit 0) |
| `eslint` on all changed files | clean (exit 0) |
| Real app revert/unrevert with a `todowrite` list | **Not run** — needs a running app with an active session; covered by the action-level tests above (they drive the real `revertToMessage`/`unrevertSession` against the real `useTodosPersistStore`). |

## Visual evidence

The change is in sync-store action logic, not a component. The observable effect (composer status todo list disappears on revert / returns on unrevert) is exercised by the action-level tests; the rendering components (ComposerStatusBar / WorkStatusTasksSection) are untouched and continue to prefer live then fall back to persisted.

## Risks and failure behavior

- If the todo re-fetch fails during unrevert, the existing list is left as-is rather than wiped to empty.
- Rollback restores both stores on revert failure, so a failed revert never leaves the composer showing an empty task list.
- `getSessionTodos` throwing is safe: it had no prior non-test caller, and the one new caller (`unrevertSession`) wraps it in a non-fatal try/catch.
