### PR TITLE
fix(chat): reliably render completed subagent Markdown

### DIFF
--- a/packages/ui/src/components/chat/message/parts/taskToolModel.test.ts
+++ b/packages/ui/src/components/chat/message/parts/taskToolModel.test.ts
@@ -56,4 +56,61 @@ describe('taskToolModel', () => {
         expect(prepareTaskToolOutput('done\n<task_metadata>{"sessionID":"child-1"}</task_metadata>')).toBe('done');
         expect(prepareTaskToolOutput(undefined)).toBe('');
     });
+
+    test('unwraps the task result envelope and preserves the result Markdown exactly', () => {
+        const result = [
+            '## Verdict',
+            '',
+            '- first item',
+            '- second item',
+            '',
+            '```ts',
+            'const answer = 42;',
+            '```',
+        ].join('\n');
+        const output = [
+            '<task id="ses_abc123" state="completed">',
+            '<task_result>',
+            result,
+            '</task_result>',
+            '</task>',
+        ].join('\n');
+
+        expect(prepareTaskToolOutput(output)).toBe(result);
+    });
+
+    test('unwraps a same-line task result envelope', () => {
+        const output = '<task id="ses_abc123" state="completed"><task_result>result</task_result></task>';
+
+        expect(prepareTaskToolOutput(output)).toBe('result');
+    });
+
+    test('leaves output without a complete task envelope untouched', () => {
+        const plainMarkdown = '## Verdict\n- first item';
+        expect(prepareTaskToolOutput(plainMarkdown)).toBe(plainMarkdown);
+
+        const taskTagWithoutResult = '<task id="ses_abc123" state="running">\nstill running';
+        expect(prepareTaskToolOutput(taskTagWithoutResult)).toBe(taskTagWithoutResult);
+
+        const unterminatedResult = '<task id="ses_abc123" state="running">\n<task_result>\nstill running';
+        expect(prepareTaskToolOutput(unterminatedResult)).toBe(unterminatedResult);
+
+        const resultWithoutEnvelope = 'literal <task_result>text</task_result> in prose';
+        expect(prepareTaskToolOutput(resultWithoutEnvelope)).toBe(resultWithoutEnvelope);
+    });
+
+    test('keeps parsing task metadata from the raw envelope output', () => {
+        const output = [
+            '<task id="ses_abc123" state="completed">',
+            '<task_result>',
+            '## Verdict',
+            '</task_result>',
+            '</task>',
+            '<task_metadata>{"sessionID":"child-1"}</task_metadata>',
+        ].join('\n');
+
+        expect(prepareTaskToolOutput(output)).toBe('## Verdict');
+        expect(readTaskSessionIdFromOutput(output)).toBe('child-1');
+        expect(parseTaskMetadataBlock(output).sessionId).toBe('child-1');
+    });
 });

--- a/packages/ui/src/components/chat/message/parts/taskToolModel.ts
+++ b/packages/ui/src/components/chat/message/parts/taskToolModel.ts
@@ -133,11 +133,29 @@ export const stripTaskMetadataFromOutput = (output: string): string => {
     return output.replace(/\n*<task_metadata>[\s\S]*?<\/task_metadata>\s*$/i, '').trimEnd();
 };
 
+const TASK_ENVELOPE_OPEN_TAG_PATTERN = /^\s*<task(?:\s[^>]*)?>/i;
+const TASK_RESULT_BLOCK_PATTERN = /<task_result>\s*([\s\S]*?)\s*<\/task_result>/i;
+
+// OpenCode wraps a completed task result in an envelope:
+//   <task id="ses_…" state="completed">
+//   <task_result>…result Markdown…</task_result>
+//   </task>
+// `marked` treats the leading tag line as a raw HTML block, so the Markdown
+// below it stays literal (issue #3238). Only unwrap when the output actually
+// starts with the envelope tag and carries a complete result block; other
+// outputs pass through untouched.
+const unwrapTaskResultEnvelope = (output: string): string => {
+    if (!TASK_ENVELOPE_OPEN_TAG_PATTERN.test(output)) return output;
+    const resultBlock = output.match(TASK_RESULT_BLOCK_PATTERN);
+    if (!resultBlock) return output;
+    return resultBlock[1];
+};
+
 // The task tool renders its output through the markdown parser instead of the
 // shared tool-output path, so it needs the same size guard as
 // `getToolOutputText` (issue #2265): an unbounded single string reaching the
 // parser can exhaust V8's Zone allocator and crash the renderer.
 export const prepareTaskToolOutput = (output: string | undefined): string => {
     if (!output) return '';
-    return capToolOutputText(stripTaskMetadataFromOutput(output));
+    return capToolOutputText(stripTaskMetadataFromOutput(unwrapTaskResultEnvelope(output)));
 };


### PR DESCRIPTION
## Intent

Fixes #3238. Completed `task` (subagent) output rendered as raw Markdown because OpenCode wraps the result in an envelope:

```text
<task id="ses_…" state="completed">
<task_result>
## heading
…
</task_result>
</task>
```

`prepareTaskToolOutput` stripped only `<task_metadata>`, so the envelope reached `marked`, which treats the leading `<task …>` line as a raw HTML block and never parses the result Markdown.

The fix unwraps a complete `<task_result>` block in `prepareTaskToolOutput` only when the output starts with a `<task …>` tag and actually contains the result block; everything else passes through unchanged. The live task render path (`TaskToolSummary`) already routes through `prepareTaskToolOutput`, so the helper change is the whole fix.

This candidate is a shrink of the earlier version: it no longer touches `MarkdownRendererImpl` or detached-DOM caching — the stale provisional-fallback race could not be shown to outlive normal async resolution, so that half was dropped rather than carried on inertia.

## Non-goals

- No change to subagent payloads, session lifecycle, streaming first-mount behavior, the shared Markdown parser, or sanitization.
- No change to detached DOM cache identity.
- Failed-task `<task_error>` envelopes are not unwrapped here.

## Affected surfaces

- `packages/ui/src/components/chat/message/parts/taskToolModel.ts` — envelope unwrap in `prepareTaskToolOutput`.
- `packages/ui/src/components/chat/message/parts/taskToolModel.test.ts` — regression coverage.
- Shared UI: web, desktop, VS Code, and mobile render task output through the same helper. No backend, persistence, or API changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Shared React UI chat rendering | Change stays in the owning task-output helper; no renderer/DOM lifecycle touched |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | Chat message rendering architecture | No tool rendering contracts change |
| `openchamber-change-discipline` | Source change in shared UI | Focused two-file diff, no dependencies, tests beside the helper |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/message/parts/taskToolModel.test.ts` | 9 pass / 0 fail; 3 new envelope tests fail if the helper change is reverted |
| `bun test packages/ui/src/components/chat/message/parts/ToolPart.test.ts packages/ui/src/components/chat/message/toolRenderers.test.ts` | 40 pass / 0 fail |
| `bun run type-check:ui` | Passed |
| `bunx oxlint` on changed files | No new findings (pre-existing backlog only) |
| `git diff --check` | Clean |
| Whole-PR review | PASS-WITH-FINDINGS, no blocking findings at `ad854d3bb` |

## Visual evidence

No screenshot: the regression is asserted at the helper boundary against the exact wrapped format; a capture would need the full app plus a completed subagent task.

## Risks and failure behavior

- Unwrap requires both the leading `<task …>` tag and a complete `<task_result>` block; partial/older payloads fall back to the raw output.
- A literal `</task_result>` inside the result text would truncate (contrived; the previous render was equally broken).
- `<task_error>` envelopes from failed tasks are not unwrapped; #3238 is about completed output.


---

CI note (2026-09-13): the `checks` job is red only on `packages/vscode/webview/api/settings.test.ts` ("propagates a failed bridge read and retries successfully"), which times out deterministically on clean current `main` (`961f1611c`, reproduced locally 3/3; the test was added by main commit `6cf247894`). It is unrelated to this diff — every fresh PR head on this base fails it. Do not treat this red check as a finding against this PR.
