### PR TITLE
Show inline thumbnails for image reads in the chat timeline

### DIFF
--- a/packages/ui/src/components/chat/MarkdownImageGallery.tsx
+++ b/packages/ui/src/components/chat/MarkdownImageGallery.tsx
@@ -3,12 +3,6 @@ import { toast } from 'sonner';
 import { Icon } from '@/components/icon/Icon';
 import { useEffectiveDirectory } from '@/hooks/useEffectiveDirectory';
 import { useI18n } from '@/lib/i18n';
-import {
-  acquireRuntimeUrlAuthToken,
-  refreshRuntimeUrlAuthToken,
-  subscribeRuntimeUrlAuthToken,
-} from '@/lib/runtime-auth';
-import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import type { ToolPopupContent } from './message/types';
 import {
@@ -24,43 +18,7 @@ import {
   resolveWorkspaceMarkdownImageSource,
   type PreparedMarkdownImage,
 } from './markdown/markdownImageAssets';
-
-const useAssetAuth = (enabled: boolean): { ready: boolean; nonce: number } => {
-  const [ready, setReady] = React.useState(false);
-  const [nonce, setNonce] = React.useState(0);
-  const apiBaseUrl = getRuntimeApiBaseUrl();
-
-  React.useEffect(() => {
-    if (!enabled) {
-      setReady(false);
-      return;
-    }
-    let cancelled = false;
-    let retryTimer: ReturnType<typeof setTimeout> | undefined;
-    const release = acquireRuntimeUrlAuthToken(apiBaseUrl);
-    const unsubscribe = subscribeRuntimeUrlAuthToken(() => {
-      if (!cancelled) setNonce((current) => current + 1);
-    });
-    const refresh = () => {
-      void refreshRuntimeUrlAuthToken(apiBaseUrl)
-        .then(() => {
-          if (!cancelled) setReady(true);
-        })
-        .catch(() => {
-          if (!cancelled) retryTimer = setTimeout(refresh, 1000);
-        });
-    };
-    refresh();
-    return () => {
-      cancelled = true;
-      if (retryTimer) clearTimeout(retryTimer);
-      release();
-      unsubscribe();
-    };
-  }, [apiBaseUrl, enabled]);
-
-  return { ready: !enabled || ready, nonce };
-};
+import { useRuntimeAssetAuth } from './markdown/useRuntimeAssetAuth';
 
 const MarkdownImageThumbnail: React.FC<{
   candidate: MarkdownImageCandidate;
@@ -268,7 +226,7 @@ export const MarkdownImageGallery: React.FC<{
 
   const visibleCandidates = candidates.filter((candidate) => prepared?.get(candidate.source)?.status !== 'missing');
   const hasPreparedAssets = [...(prepared?.values() ?? [])].some((value) => value.status === 'ready');
-  const assetAuth = useAssetAuth(hasPreparedAssets);
+  const assetAuth = useRuntimeAssetAuth(hasPreparedAssets);
   if (visibleCandidates.length === 0) return null;
 
   return (

--- a/packages/ui/src/components/chat/components/TurnActivity.tsx
+++ b/packages/ui/src/components/chat/components/TurnActivity.tsx
@@ -26,6 +26,7 @@ interface TurnActivityProps {
     animatedToolIds?: Set<string>;
     diffStats?: DiffStats;
     renderJustificationActions?: (activity: TurnActivityRecord) => React.ReactNode;
+    sessionId?: string;
 }
 
 const TurnActivity: React.FC<TurnActivityProps> = (props) => {

--- a/packages/ui/src/components/chat/markdown/useRuntimeAssetAuth.ts
+++ b/packages/ui/src/components/chat/markdown/useRuntimeAssetAuth.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  acquireRuntimeUrlAuthToken,
+  refreshRuntimeUrlAuthToken,
+  subscribeRuntimeUrlAuthToken,
+} from '@/lib/runtime-auth';
+import { getRuntimeApiBaseUrl } from '@/lib/runtime-switch';
+
+export interface RuntimeAssetAuthState {
+  ready: boolean;
+  nonce: number;
+}
+
+// `nonce` bumps on token rotation so consumers re-resolve URLs built from the previous token.
+export const useRuntimeAssetAuth = (enabled: boolean): RuntimeAssetAuthState => {
+  const [ready, setReady] = React.useState(false);
+  const [nonce, setNonce] = React.useState(0);
+  const apiBaseUrl = getRuntimeApiBaseUrl();
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setReady(false);
+      return;
+    }
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    const release = acquireRuntimeUrlAuthToken(apiBaseUrl);
+    const unsubscribe = subscribeRuntimeUrlAuthToken(() => {
+      if (!cancelled) setNonce((current) => current + 1);
+    });
+    const refresh = () => {
+      void refreshRuntimeUrlAuthToken(apiBaseUrl)
+        .then(() => {
+          if (!cancelled) setReady(true);
+        })
+        .catch(() => {
+          if (!cancelled) retryTimer = setTimeout(refresh, 1000);
+        });
+    };
+    refresh();
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      release();
+      unsubscribe();
+    };
+  }, [apiBaseUrl, enabled]);
+
+  return { ready: !enabled || ready, nonce };
+};

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -1740,6 +1740,7 @@ const AssistantMessageBody = React.memo(({
                         animatedToolIds={animatedToolIdsLookup}
                         diffStats={turnGroupingContext?.diffStats}
                         renderJustificationActions={renderJustificationActions}
+                        sessionId={sessionId}
                     />
                 </div>
             );
@@ -1926,6 +1927,8 @@ const AssistantMessageBody = React.memo(({
                                     },
                                 ]}
                                 animateTailText={animatedToolIdsLookup.has(toolPart.id)}
+                                sessionId={sessionId}
+                                onShowPopup={onShowPopup}
                             />
                         </ToolRevealOnMount>
                     </FadeInOnReveal>

--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -83,6 +83,10 @@ Use this doc when you ask an agent to change tool/header/description behavior.
   only when the server verifies the exact source in the owning assistant
   message and the real file is inside OpenCode's dedicated temporary directory.
 - `read` and `skill` are **static navigation tools** and render via `StaticToolRow`.
+  When a `read` target is an image, `StaticToolRow` also renders
+  `ReadToolImageThumbnail`, viewport-gated like the Markdown image gallery, and
+  opens the shared image preview dialog on click; the filename button keeps
+  navigating to the file, unchanged.
 - Every other tool, including search/fetch, OpenCode built-ins, custom tools, plugins, and MCP tools, is **expandable** and renders through `ToolPart`.
 - The managed `openchamber` plugin tool uses the expandable path and hides its broad protocol input. The plugin supplies the selected action's human description as the native tool title; the UI renders that metadata without owning an action map. The full versioned result envelope renders through the same neutral JSON summary/tree/raw views as other tools, without a tool-specific output card.
 - `ToolPart` defers expanded content after a user toggle, preventing large tool input/output payloads from mounting during the initial chat render.

--- a/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
+++ b/packages/ui/src/components/chat/message/parts/ProgressiveGroup.tsx
@@ -13,8 +13,9 @@ import { Text } from '@/components/ui/text';
 import { Icon } from "@/components/icon/Icon";
 import { FadeInOnReveal } from '../FadeInOnReveal';
 import { getToolIcon } from './toolPresentation';
-import { getToolMetadata } from '@/lib/toolHelpers';
+import { getToolMetadata, isImageFile } from '@/lib/toolHelpers';
 import { isExpandableTool, isStandaloneTool, isStaticTool } from './toolRenderUtils';
+import { ReadToolImageThumbnail } from './ReadToolImageThumbnail';
 import { RuntimeAPIContext } from '@/contexts/runtimeAPIContext';
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { useUIStore } from '@/stores/useUIStore';
@@ -44,6 +45,7 @@ interface ProgressiveGroupProps {
     animateRows?: boolean;
     animatedToolIds?: Set<string>;
     renderJustificationActions?: (activity: TurnActivityPart) => React.ReactNode;
+    sessionId?: string;
 }
 
 const ExternalLinkFavicon: React.FC<{ href: string }> = ({ href }) => {
@@ -429,18 +431,24 @@ interface StaticGroupedToolRowProps {
     toolName: string;
     activities: TurnActivityPart[];
     animateTailText: boolean;
+    sessionId?: string;
+    onShowPopup?: (content: ToolPopupContent) => void;
 }
 
 const StaticGroupedToolRow: React.FC<StaticGroupedToolRowProps> = ({
     toolName,
     activities,
     animateTailText,
+    sessionId,
+    onShowPopup,
 }) => {
     const content = (
         <StaticToolRow
             toolName={toolName}
             activities={activities}
             animateTailText={animateTailText}
+            sessionId={sessionId}
+            onShowPopup={onShowPopup}
         />
     );
 
@@ -460,6 +468,8 @@ const StaticGroupedToolRow: React.FC<StaticGroupedToolRowProps> = ({
 const MemoStaticGroupedToolRow = React.memo(StaticGroupedToolRow, (prev, next) => {
     return prev.toolName === next.toolName
         && prev.animateTailText === next.animateTailText
+        && prev.sessionId === next.sessionId
+        && prev.onShowPopup === next.onShowPopup
         && areActivityListsEqual(prev.activities, next.activities);
 });
 
@@ -552,11 +562,21 @@ const areActivityListsEqual = (left: TurnActivityPart[], right: TurnActivityPart
     return true;
 };
 
+interface ReadFileEntry {
+    path: string;
+    displayPath: string;
+    offset?: number;
+    messageId: string;
+    isImage: boolean;
+}
+
 const StaticToolRowInner: React.FC<{
     toolName: string;
     activities: TurnActivityPart[];
     animateTailText: boolean;
-}> = ({ toolName, activities, animateTailText }) => {
+    sessionId?: string;
+    onShowPopup?: (content: ToolPopupContent) => void;
+}> = ({ toolName, activities, animateTailText, sessionId, onShowPopup }) => {
     const showToolFileIcons = useUIStore((state) => state.showToolFileIcons);
     const displayName = getToolMetadata(toolName).displayName;
     const icon = getToolIcon(toolName);
@@ -597,10 +617,10 @@ const StaticToolRowInner: React.FC<{
         return entries;
     }, [activities, skillByName, toolName]);
 
-    const readFileEntries = React.useMemo(() => {
-        if (!isReadGroup) return [] as Array<{ path: string; displayPath: string; offset?: number }>;
+    const readFileEntries = React.useMemo<ReadFileEntry[]>(() => {
+        if (!isReadGroup) return [];
 
-        const entries: Array<{ path: string; displayPath: string; offset?: number }> = [];
+        const entries: ReadFileEntry[] = [];
         for (const activity of activities) {
             const filePath = getToolFilePath(activity);
             const offset = getToolReadOffset(activity);
@@ -608,7 +628,7 @@ const StaticToolRowInner: React.FC<{
             if (entries.some((entry) => entry.path === filePath)) continue;
             const displayPath = getRelativeFilePath(filePath, currentDirectory);
             if (!displayPath) continue;
-            entries.push({ path: filePath, displayPath, offset });
+            entries.push({ path: filePath, displayPath, offset, messageId: activity.messageId, isImage: isImageFile(filePath) });
         }
         return entries;
     }, [activities, currentDirectory, isReadGroup]);
@@ -693,21 +713,32 @@ const StaticToolRowInner: React.FC<{
             </MinDurationShineText>
             {isReadGroup && readFileEntries.length > 0
                 ? readFileEntries.map((entry) => (
-                    <button
-                        key={entry.path}
-                        type="button"
-                        onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            handleFileClick(entry.path, entry.offset);
-                        }}
-                        className={cn('inline-flex !min-h-0 items-center justify-start gap-1 min-w-0 flex-1 text-left hover:opacity-90', TOOL_ROW_DESCRIPTION_CLASS)}
-                        style={{ color: 'var(--tools-description)' }}
-                        title={entry.offset ? `${entry.displayPath}:${entry.offset}` : entry.displayPath}
-                    >
-                        {showToolFileIcons ? <FileTypeIcon filePath={entry.path} className="h-3.5 w-3.5" /> : null}
-                        {renderReadFilePath(entry.displayPath, animateTailText)}
-                    </button>
+                    <span key={entry.path} className="inline-flex min-w-0 flex-1 items-center gap-1">
+                        {entry.isImage ? (
+                            <ReadToolImageThumbnail
+                                filePath={entry.path}
+                                filename={entry.displayPath}
+                                directory={currentDirectory}
+                                sessionId={sessionId}
+                                messageId={entry.messageId}
+                                onShowPopup={onShowPopup}
+                            />
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                handleFileClick(entry.path, entry.offset);
+                            }}
+                            className={cn('inline-flex !min-h-0 items-center justify-start gap-1 min-w-0 flex-1 text-left hover:opacity-90', TOOL_ROW_DESCRIPTION_CLASS)}
+                            style={{ color: 'var(--tools-description)' }}
+                            title={entry.offset ? `${entry.displayPath}:${entry.offset}` : entry.displayPath}
+                        >
+                            {showToolFileIcons && !entry.isImage ? <FileTypeIcon filePath={entry.path} className="h-3.5 w-3.5" /> : null}
+                            {renderReadFilePath(entry.displayPath, animateTailText)}
+                        </button>
+                    </span>
                 ))
                 : null}
             {isSearchGroup && descriptions.length > 0
@@ -777,6 +808,8 @@ const StaticToolRowInner: React.FC<{
 export const StaticToolRow = React.memo(StaticToolRowInner, (prev, next) => {
     return prev.toolName === next.toolName
         && prev.animateTailText === next.animateTailText
+        && prev.sessionId === next.sessionId
+        && prev.onShowPopup === next.onShowPopup
         && areActivityListsEqual(prev.activities, next.activities);
 });
 
@@ -826,6 +859,7 @@ const ProgressiveGroup: React.FC<ProgressiveGroupProps> = ({
     animateRows = true,
     animatedToolIds,
     renderJustificationActions,
+    sessionId,
 }) => {
     const previewCount = showHeader && !isExpanded
         ? Math.max(0, Math.floor(collapsedPreviewCount))
@@ -916,6 +950,8 @@ const ProgressiveGroup: React.FC<ProgressiveGroupProps> = ({
                         toolName={row.toolName}
                         activities={row.activities}
                         animateTailText={row.activities.some((activity) => animatedToolIds?.has(activity.id))}
+                        sessionId={sessionId}
+                        onShowPopup={onShowPopup}
                     />
                 );
 

--- a/packages/ui/src/components/chat/message/parts/ReadToolImageThumbnail.tsx
+++ b/packages/ui/src/components/chat/message/parts/ReadToolImageThumbnail.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Icon } from '@/components/icon/Icon';
+import { isVSCodeRuntime } from '@/lib/desktop';
+import type { ToolPopupContent } from '../types';
+import {
+  getPreparedMarkdownImageUrl,
+  prepareLocalMarkdownImages,
+  resolveWorkspaceMarkdownImageSource,
+} from '../../markdown/markdownImageAssets';
+import { useRuntimeAssetAuth } from '../../markdown/useRuntimeAssetAuth';
+
+interface ReadToolImageThumbnailProps {
+  filePath: string;
+  filename: string;
+  directory: string;
+  sessionId?: string;
+  messageId: string;
+  onShowPopup?: (content: ToolPopupContent) => void;
+}
+
+// Resolves the same way MarkdownImageGallery resolves workspace-local images
+// (VS Code fs bridge vs. session-scoped server grant + authenticated asset URL).
+export const ReadToolImageThumbnail: React.FC<ReadToolImageThumbnailProps> = ({
+  filePath,
+  filename,
+  directory,
+  sessionId,
+  messageId,
+  onShowPopup,
+}) => {
+  const useWorkspaceFsBridge = isVSCodeRuntime();
+  const thumbnailRef = React.useRef<HTMLButtonElement>(null);
+  const [shouldLoad, setShouldLoad] = React.useState(false);
+  const [image, setImage] = React.useState<{ url: string; status: 'loading' | 'ready' | 'error' }>({
+    url: '',
+    status: 'loading',
+  });
+  const assetAuth = useRuntimeAssetAuth(!useWorkspaceFsBridge && shouldLoad);
+
+  // Timeline rows are virtualized: mounting must not eagerly read every
+  // referenced image ahead of the viewport (parts/DOCUMENTATION.md).
+  React.useEffect(() => {
+    const thumbnail = thumbnailRef.current;
+    if (!thumbnail || shouldLoad) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setShouldLoad(true);
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      setShouldLoad(true);
+      observer.disconnect();
+    }, { rootMargin: '200px' });
+    observer.observe(thumbnail);
+    return () => observer.disconnect();
+  }, [shouldLoad]);
+
+  React.useEffect(() => {
+    if (!shouldLoad) return undefined;
+    if (useWorkspaceFsBridge) {
+      const controller = new AbortController();
+      void resolveWorkspaceMarkdownImageSource(filePath, directory, controller.signal)
+        .then((url) => {
+          if (!controller.signal.aborted) setImage({ url, status: 'ready' });
+        })
+        .catch(() => {
+          if (!controller.signal.aborted) setImage({ url: '', status: 'error' });
+        });
+      return () => controller.abort();
+    }
+
+    if (!sessionId || !assetAuth.ready) return undefined;
+    const controller = new AbortController();
+    void prepareLocalMarkdownImages({
+      sources: [filePath],
+      directory,
+      sessionId,
+      messageId,
+      signal: controller.signal,
+    }).then((prepared) => {
+      if (controller.signal.aborted) return;
+      const result = prepared.get(filePath);
+      if (result?.status !== 'ready') {
+        setImage({ url: '', status: 'error' });
+        return;
+      }
+      setImage({ url: getPreparedMarkdownImageUrl(result, directory), status: 'ready' });
+    }).catch(() => {
+      if (!controller.signal.aborted) setImage({ url: '', status: 'error' });
+    });
+    return () => controller.abort();
+  }, [assetAuth.nonce, assetAuth.ready, directory, filePath, messageId, sessionId, shouldLoad, useWorkspaceFsBridge]);
+
+  const openPreview = React.useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (image.status !== 'ready' || !onShowPopup) return;
+    onShowPopup({
+      open: true,
+      title: filename,
+      content: '',
+      metadata: { tool: 'image-preview', filename },
+      image: { url: image.url, filename },
+    });
+  }, [filename, image, onShowPopup]);
+
+  return (
+    <button
+      ref={thumbnailRef}
+      type="button"
+      onClick={openPreview}
+      disabled={image.status !== 'ready'}
+      className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center overflow-hidden rounded-sm border border-border/40 bg-muted/10 disabled:cursor-default"
+      title={filename}
+      aria-label={filename}
+    >
+      {image.status === 'ready' ? (
+        <img
+          src={image.url}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+          onError={() => setImage({ url: '', status: 'error' })}
+        />
+      ) : (
+        <Icon name="file-image" className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+    </button>
+  );
+};

--- a/packages/web/server/lib/markdown-image-grants/DOCUMENTATION.md
+++ b/packages/web/server/lib/markdown-image-grants/DOCUMENTATION.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This module lets the Markdown image gallery display images that an assistant
-explicitly referenced from OpenCode's temporary directory when the UI is on a
-different machine.
+This module lets the Markdown image gallery, and the `read`-tool inline image
+thumbnail, display images an assistant message explicitly referenced from
+OpenCode's temporary directory when the UI is on a different machine.
 
 ## Contract
 
@@ -16,7 +16,9 @@ different machine.
   message once and verifies every exact image source before reading files.
 - Authorization recognizes the same common inline and reference-style image
   destinations collected by the UI, including balanced parentheses, while
-  excluding fenced and inline code.
+  excluding fenced and inline code — plus any `read` tool call's file path in
+  that same assistant message, since that input is as authoritative as its
+  Markdown text.
 - Relative and workspace-contained absolute paths resolve against the active
   directory. Other absolute paths are accepted only inside
   `os.tmpdir()/opencode` after `realpath` resolution.

--- a/packages/web/server/lib/markdown-image-grants/routes.js
+++ b/packages/web/server/lib/markdown-image-grants/routes.js
@@ -191,6 +191,20 @@ const markdownImageSources = (message) => {
   return sources;
 };
 
+// The `read` tool's file path is as authoritative as markdown image syntax —
+// both come from the assistant's own message, not the requesting client — so
+// a grant for a read-tool target is scoped the same way.
+const readToolFilePaths = (message) => {
+  const paths = new Set();
+  for (const part of Array.isArray(message?.parts) ? message.parts : []) {
+    if (part?.type !== 'tool' || String(part?.tool).toLowerCase() !== 'read') continue;
+    const input = part?.state?.input;
+    const filePath = asString(input?.filePath || input?.file_path || input?.path);
+    if (filePath) paths.add(filePath);
+  }
+  return paths;
+};
+
 const fetchMessage = async ({ sessionId, messageId, directory, buildOpenCodeUrl, getOpenCodeAuthHeaders }) => {
   const url = new URL(buildOpenCodeUrl(
     `/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}`,
@@ -293,7 +307,7 @@ export const registerMarkdownImageGrantRoutes = (app, dependencies) => {
           return res.status(404).json({ error: 'Assistant message not found' });
         }
         // Assistant text is authoritative: a remote client cannot mint grants for unreferenced paths.
-        const referenced = markdownImageSources(message);
+        const referenced = new Set([...markdownImageSources(message), ...readToolFilePaths(message)]);
         const results = [];
         for (const source of sources) {
           if (!referenced.has(source)) {

--- a/packages/web/server/lib/markdown-image-grants/routes.test.js
+++ b/packages/web/server/lib/markdown-image-grants/routes.test.js
@@ -189,6 +189,25 @@ describe('session image assets', () => {
     ]);
   });
 
+  it('authorizes a read tool call target with no markdown reference', async () => {
+    const source = 'read-target.png';
+    const fixture = await createFixture({ sources: [source], markdown: 'No image markdown here.' });
+    await fs.writeFile(path.join(fixture.directory, source), PNG);
+    fixture.fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      info: { id: 'msg_1', role: 'assistant' },
+      parts: [
+        { type: 'text', text: 'No image markdown here.' },
+        { type: 'tool', tool: 'read', state: { status: 'completed', input: { filePath: source } } },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const response = await prepare(fixture.app, fixture.directory, [source]);
+
+    expect(response.body.results).toEqual([
+      expect.objectContaining({ source, status: 'ready' }),
+    ]);
+  });
+
   it('rejects a source that the message does not reference', async () => {
     const fixture = await createFixture({ markdown: 'No image here.' });
     const response = await prepare(fixture.app, fixture.directory, fixture.sources);


### PR DESCRIPTION
The read/skill static tool row only ever linked to the file path, even when the read target was an image, so the agent's screenshots and diagrams never surfaced next to the conversation the way diffs do.

Resolve image reads the same way MarkdownImageGallery resolves workspace-local markdown images (VS Code fs bridge vs. session-scoped server grant + authenticated asset URL) and render a small clickable thumbnail that opens the shared image preview dialog. Extracted the gallery's asset-auth-token hook into useRuntimeAssetAuth so both consumers share one implementation.