### PR TITLE
fix(quota): accept CREDIT_LIMIT in zhipuai-coding-plan provider

### DIFF
--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -4,11 +4,12 @@
  * API: https://open.bigmodel.cn/api/monitor/usage/quota/limit
  *
  * Response limits:
- * - TOKENS_LIMIT: Token usage (5-hour rolling window)
+ * - TOKENS_LIMIT / CREDIT_LIMIT: credit usage (5-hour rolling window); the API
+ *   renamed TOKENS_LIMIT to CREDIT_LIMIT on current Lite/Pro/Max plans
  * - TIME_LIMIT: MCP tools usage (monthly window)
  *
  * @typedef {Object} TokensLimit
- * @property {string} type - 'TOKENS_LIMIT'
+ * @property {string} type - 'TOKENS_LIMIT' or 'CREDIT_LIMIT'
  * @property {number} [unit]
  * @property {number} [number]
  * @property {number} [nextResetTime]
@@ -33,6 +34,7 @@ import {
   buildResult,
   toUsageWindow,
   resolveWindowSeconds,
+  resolveWindowLabel,
   normalizeTimestamp
 } from '../utils/index.js';
 
@@ -104,18 +106,20 @@ export const fetchQuota = async () => {
     const payload = await response.json();
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
-    const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');
     const mcpToolsTimeLimit = limits.find((limit) => limit?.type === 'TIME_LIMIT');
 
     const windows = {};
 
-    // Handle TOKENS_LIMIT (5-hour window for token usage)
-    if (tokensLimit) {
-      const windowSeconds = resolveWindowSeconds(tokensLimit);
-      const resetAt = tokensLimit?.nextResetTime ? normalizeTimestamp(tokensLimit.nextResetTime) : null;
-      const usedPercent = typeof tokensLimit?.percentage === 'number' ? tokensLimit.percentage : null;
+    // The API renamed TOKENS_LIMIT to CREDIT_LIMIT (observed on Lite/Pro/Max coding
+    // plans); field semantics stayed the same, so both limit types map to the same
+    // windows - mirrors the handling in zai.js.
+    for (const limit of limits.filter((entry) => entry?.type === 'TOKENS_LIMIT' || entry?.type === 'CREDIT_LIMIT')) {
+      const windowSeconds = resolveWindowSeconds(limit);
+      const windowLabel = resolveWindowLabel(windowSeconds);
+      const resetAt = limit?.nextResetTime ? normalizeTimestamp(limit.nextResetTime) : null;
+      const usedPercent = typeof limit?.percentage === 'number' ? limit.percentage : null;
 
-      windows['Tokens'] = toUsageWindow({
+      windows[windowLabel] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt


### PR DESCRIPTION
## Summary

Zhipu's coding-plan usage API (`https://open.bigmodel.cn/api/monitor/usage/quota/limit`) renamed the credit-window entry from `TOKENS_LIMIT` to `CREDIT_LIMIT` (observed on Lite/Pro/Max coding plans; field semantics are unchanged: `percentage`, `nextResetTime`, etc.). The `zhipuai-coding-plan` provider currently matches only `TOKENS_LIMIT`, so on current plans the 5-hour credit window silently disappears from the Usage panel and work status.

## Changes

- Accept both `TOKENS_LIMIT` and `CREDIT_LIMIT` entry types and map them to the same usage windows — mirroring the handling that already exists in the `zai.js` provider (`packages/web/server/lib/quota/providers/zai.js`).
- Use `resolveWindowLabel(windowSeconds)` for the window key instead of the hard-coded `'Tokens'`, so window labeling stays consistent with the rest of the quota pipeline (also mirrors `zai.js`).

## Testing

- Verified against a live Zhipu coding-plan account: the 5-hour credit window renders again (previously only the MCP/TIME window was shown).
- Multiple `CREDIT_LIMIT` entries (if the API ever returns more than one) are all mapped rather than only the first match.


The change is a single commit on `fix/zhipu-credit-limit`, mirroring `zai.js` line-for-line where possible (minus the credit-amount `valueLabel`, which the zhipu endpoint's percent-only usage here doesn't need).
