### PR TITLE
Fall back to browser history in native Android back handler

### DIFF
--- a/packages/ui/src/apps/MobileApp.tsx
+++ b/packages/ui/src/apps/MobileApp.tsx
@@ -310,6 +310,12 @@ const MobileShell: React.FC<{ onActiveConnectionDeleted: () => void }> = ({ onAc
       setSessionsSheetOpen(false);
       return true;
     }
+    // Session changes (e.g. subagent navigation) aren't tracked above, but
+    // useRouter() already pushed a history entry for them.
+    if (window.history.length > 1 && window.history.state?.route) {
+      window.history.back();
+      return true;
+    }
     return false;
   }, [activeSurface, closeSurface, closeWorkspace, openPlan, sessionsSheetOpen, workspaceOpen]);
 

--- a/packages/ui/src/hooks/useRouter.ts
+++ b/packages/ui/src/hooks/useRouter.ts
@@ -186,8 +186,12 @@ export function useRouter(): void {
         return;
       }
 
+      // A null -> session transition is the app arriving at its first session
+      // (cold-launch restore or initial pick), not forward navigation from a
+      // real screen — replace so back doesn't land on a phantom no-op step.
+      const isInitialSessionPick = prevSessionId === null;
       prevSessionId = sessionId;
-      syncURLFromState();
+      syncURLFromState({ replace: isInitialSessionPick });
     });
 
     return unsubscribe;


### PR DESCRIPTION
Session changes (e.g. opening a subagent) push a history entry via useRouter() but weren't in handleNativeBack's flag list, so hardware back minimized the app instead of navigating back.