### PR TITLE
fix(session-goal): auto-continue length-truncated assistant turns

### DIFF
--- a/packages/web/server/lib/session-goal/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-goal/DOCUMENTATION.md
@@ -111,10 +111,11 @@ before touching the filesystem). Rationale: metadata rides every
    - terminal checks, cheapest first: assistant turn error → `blocked`;
      `tokensUsed >= tokenBudget` → `budgetLimited`;
      `turnsUsed >= MAX_AUTO_TURNS` (20) → `blocked`;
-   - if the latest message is a compaction summary, skip the audit and
-     continue unconditionally — running into the context window mid-work is
-     by definition "in progress, not finished" (the summary is a retelling,
-     not evidence, and must not be judged);
+    - if the latest message is a compaction summary or was cut off by output
+      token limits (finish: "length"), skip the audit and continue
+      unconditionally — running into the context/output window mid-work is
+      by definition "in progress, not finished" (a truncated reply is not
+      evidence, and must not be judged);
    - otherwise, small-model audit of the objective + the last assistant turn
      only — no conversation history and no continuation prompts
      (`restrictToPreferredProvider`, session's own provider/model preferred):

--- a/packages/web/server/lib/session-goal/runtime.js
+++ b/packages/web/server/lib/session-goal/runtime.js
@@ -608,6 +608,9 @@ export const createSessionGoalRuntime = ({
     // falls through to the continuation below (skipping the audit — an
     // aborted reply is not evidence of anything).
     const abortedTail = lastAssistantInfo.error?.name === 'MessageAbortedError';
+    const lengthTail = lastAssistantInfo.finish === 'length'
+      || lastAssistantInfo.stopReason === 'length'
+      || lastAssistantInfo.error?.name === 'MessageOutputLengthError';
     if (abortedTail && goal.statusReason !== 'resumed') {
       await writeGoal(sessionId, directory, goal.id, () => ({
         status: 'paused',
@@ -622,7 +625,8 @@ export const createSessionGoalRuntime = ({
     }
 
     // Turn error → blocked (prevents runaway auto-continuation into failures).
-    if (!abortedTail && lastAssistantInfo.error && typeof lastAssistantInfo.error === 'object') {
+    // Length cutoffs are in-progress continuations, not hard failures.
+    if (!abortedTail && !lengthTail && lastAssistantInfo.error && typeof lastAssistantInfo.error === 'object') {
       const reason = typeof lastAssistantInfo.error.name === 'string' && lastAssistantInfo.error.name
         ? lastAssistantInfo.error.name
         : 'assistant turn failed';
@@ -652,13 +656,14 @@ export const createSessionGoalRuntime = ({
     // stops above (turn error, budget, continuation cap). The working agent
     // has no channel to settle its own goal.
     //
-    // Exception: when the latest message is a compaction summary, the agent
-    // by definition ran into the context window mid-work — that IS
-    // "in progress, not finished". No audit call; continue unconditionally.
+    // Exception: when the latest message is a compaction summary or was cut off
+    // by the output token limit (length stop), the agent by definition ran into
+    // the context/output limit mid-work — that IS "in progress, not finished".
+    // No audit call; continue unconditionally.
     let audit = null;
     let blockedStreak = 0;
     let auditFailStreak = goal.auditFailStreak;
-    if (lastAssistantInfo.summary === true || abortedTail) {
+    if (lastAssistantInfo.summary === true || abortedTail || lengthTail) {
       blockedStreak = goal.blockedStreak;
     } else {
       audit = await runAudit({ goal: { ...goal, objective: effectiveObjective }, assistantText, directory, lastAssistantInfo: executionInfo ?? lastAssistantInfo });

--- a/packages/web/server/lib/session-goal/runtime.test.js
+++ b/packages/web/server/lib/session-goal/runtime.test.js
@@ -176,4 +176,131 @@ describe('session goal live activity gate', () => {
     });
     runtime.stop();
   });
+
+  it('skips audit and sends continuation prompt when assistant message finishes with length stop', async () => {
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        return jsonResponse([{
+          info: {
+            id: 'msg_assistant_len',
+            sessionID: SESSION_ID,
+            role: 'assistant',
+            providerID: 'provider',
+            modelID: 'model',
+            finish: 'length',
+            time: { completed: 2 },
+            tokens: { input: 100, output: 4096, reasoning: 4096, cache: { read: 0 } },
+          },
+          parts: [{ type: 'reasoning', text: 'Drafting extensive implementation...' }],
+        }]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Audit must be skipped on length-truncated turn
+    expect(service.generateSmallModelText).not.toHaveBeenCalled();
+
+    // Goal accounting is persisted and turnsUsed incremented
+    const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
+    expect(patch).toBeDefined();
+    const writtenGoal = JSON.parse(patch.body).metadata.openchamber.goal;
+    expect(writtenGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 2,
+    });
+
+    // Continuation prompt is dispatched
+    const promptAsync = requests.find((request) => request.pathname === `/session/${SESSION_ID}/prompt_async` && request.method === 'POST');
+    expect(promptAsync).toBeDefined();
+    const promptBody = JSON.parse(promptAsync.body);
+    expect(promptBody.parts[0].text).toContain('Continue working toward the active session goal.');
+    runtime.stop();
+  });
+
+  it('skips audit and sends continuation prompt when assistant message carries MessageOutputLengthError', async () => {
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        return jsonResponse([{
+          info: {
+            id: 'msg_assistant_len_err',
+            sessionID: SESSION_ID,
+            role: 'assistant',
+            providerID: 'provider',
+            modelID: 'model',
+            error: { name: 'MessageOutputLengthError', message: 'Maximum token limit reached' },
+            time: { completed: 2 },
+            tokens: { input: 100, output: 4096, reasoning: 4096, cache: { read: 0 } },
+          },
+          parts: [{ type: 'reasoning', text: 'Drafting extensive implementation...' }],
+        }]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Audit must be skipped on MessageOutputLengthError
+    expect(service.generateSmallModelText).not.toHaveBeenCalled();
+
+    // Goal remains active and turnsUsed incremented
+    const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
+    expect(patch).toBeDefined();
+    const writtenGoal = JSON.parse(patch.body).metadata.openchamber.goal;
+    expect(writtenGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 2,
+    });
+
+    // Continuation prompt is dispatched
+    const promptAsync = requests.find((request) => request.pathname === `/session/${SESSION_ID}/prompt_async` && request.method === 'POST');
+    expect(promptAsync).toBeDefined();
+    runtime.stop();
+  });
 });
+


### PR DESCRIPTION
## Intent

Resolves #3255.

When an assistant message finishes with `finish: 'length'` (or `stopReason: 'length'` / `error: { name: 'MessageOutputLengthError' }`) before completing its response—such as when a reasoning model generates extensive thought and exhausts its completion token ceiling—it frequently yields zero `text` parts.

Previously, `session-goal/runtime.js` fell through to the small-model audit with an empty transcript (`assistantText = ""`), which caused audit failures and left the session idle with an active goal, locking the UI into an indefinite `Evaluating…` spinner until manually prompted.

This PR treats length-truncated assistant messages as in-progress turns (matching compaction summaries and resumed aborted turns):
1. Detects `lengthTail` via `finish === 'length'`, `stopReason === 'length'`, or `error.name === 'MessageOutputLengthError'`.
2. Bypasses the small-model progress audit (which has no complete reply to judge).
3. Directly dispatches a continuation prompt while accounting tokens and incrementing `turnsUsed`.

## Non-goals

- Altering client/provider `max_tokens` configuration.
- Modifying UI components in `packages/ui` (the UI naturally exits `Evaluating…` once the continuation prompt is dispatched and the session resumes `busy`).

## Affected surfaces

- `packages/web` (`packages/web/server/lib/session-goal/runtime.js`)

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `packages/web/server/lib/session-goal/DOCUMENTATION.md` | Defines the lifecycle, terminal conditions, and audit exceptions for session goals. | Follows the documented exception pattern where in-progress turns (compaction summaries / length stops) bypass progress audits and continue unconditionally. |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/session-goal/runtime.test.js` | 6 passed (including new tests for `finish: 'length'` and `MessageOutputLengthError`) |
| `bun run --cwd packages/web test` | 157 test files passed, 1548 tests passed |
| `bun run type-check:web` | Passed (0 errors) |
| `bun run lint:web` | Passed (0 errors) |

## Visual evidence

No frontend UI components were modified. Behavior change is in the backend session-goal loop: length-truncated turns now immediately dispatch a continuation prompt and transition to `busy` instead of remaining in `idle` with a spinning `Evaluating…` indicator.

## Risks and failure behavior

None identified. Auto-continuation remains strictly bounded by `turnsUsed >= maxAutoTurns` (20 turns max) and `tokensUsed >= tokenBudget`.