### PR TITLE
feat(chat): configurable send and newline keybindings

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -88,7 +88,7 @@ import { sessionEvents } from '@/lib/sessionEvents';
 import { fetchResponseStyleInstruction } from '@/lib/responseStyle';
 import { wrapSystemReminder } from '@/lib/systemReminder';
 import { getSyncMessages } from '@/sync/sync-refs';
-import { eventMatchesShortcut, getEffectiveShortcutCombo, normalizeCombo } from '@/lib/shortcuts';
+import { eventMatchesShortcut, getEffectiveShortcutCombo, keyToShortcutToken, normalizeCombo, parseShortcut, resolveShortcutEventKey } from '@/lib/shortcuts';
 import {
     assignImageAttachmentFilenames,
     buildAttachmentCitationText,
@@ -440,6 +440,14 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     const cycleAgentShortcut = React.useMemo(() => (
         getEffectiveShortcutCombo('cycle_agent', cycleAgentShortcutOverride ? { cycle_agent: cycleAgentShortcutOverride } : undefined)
     ), [cycleAgentShortcutOverride]);
+    const sendMessageShortcutOverride = useUIStore((state) => state.shortcutOverrides.send_message);
+    const sendMessageShortcut = React.useMemo(() => (
+        getEffectiveShortcutCombo('send_message', sendMessageShortcutOverride ? { send_message: sendMessageShortcutOverride } : undefined)
+    ), [sendMessageShortcutOverride]);
+    const insertNewlineShortcutOverride = useUIStore((state) => state.shortcutOverrides.insert_newline);
+    const insertNewlineShortcut = React.useMemo(() => (
+        getEffectiveShortcutCombo('insert_newline', insertNewlineShortcutOverride ? { insert_newline: insertNewlineShortcutOverride } : undefined)
+    ), [insertNewlineShortcutOverride]);
     const { currentTheme } = useThemeSystem();
     const chatSearchDirectory = useChatSearchDirectory();
     const isGitRepo = useIsGitRepo(currentDirectory);
@@ -1720,12 +1728,22 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
             return;
         }
 
-        // Handle Enter/Ctrl+Enter based on selected follow-up behavior. On
-        // mobile, and in desktop focus mode, plain Enter writes a newline and
-        // only Cmd/Ctrl+Enter sends: both are surfaces for composing long
+        // Handle send vs newline from the configurable chat input bindings.
+        // Defaults preserve the classic behavior: Enter sends, Shift+Enter
+        // writes a newline. On mobile, and in desktop focus mode, a bare send
+        // binding (plain Enter) writes a newline instead and only the primary
+        // modifier variant (Ctrl/Cmd+Enter) sends — both surfaces compose long
         // prompts, where an accidental send costs more than an extra keypress.
         const requiresModifierToSend = isMobile || isDesktopExpanded;
-        if (e.key === 'Enter' && !e.shiftKey && (!requiresModifierToSend || e.ctrlKey || e.metaKey)) {
+        const sendChord = parseShortcut(sendMessageShortcut)?.chords[0];
+        const sendIsBare = sendChord !== undefined && sendChord.modifiers.size === 0;
+        const isSendBinding = eventMatchesShortcut(e, sendMessageShortcut)
+            && (!sendIsBare || !requiresModifierToSend);
+        const isModifierSend = sendIsBare && (e.ctrlKey || e.metaKey)
+            && keyToShortcutToken(resolveShortcutEventKey(e)) === keyToShortcutToken(sendChord?.key ?? '');
+        const isNewlineBinding = eventMatchesShortcut(e, insertNewlineShortcut);
+
+        if ((isSendBinding || isModifierSend) && !isNewlineBinding) {
             e.preventDefault();
 
             const isCtrlEnter = e.ctrlKey || e.metaKey;
@@ -1749,6 +1767,8 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                 }
             }
         }
+        // Any other Enter — including the insert-newline binding — falls
+        // through to the editor, which inserts the newline.
     };
 
     // Focus mode places the open picker at the caret; elsewhere each picker

--- a/packages/ui/src/lib/i18n/messages/de.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/de.settings.ts
@@ -1076,6 +1076,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': 'Gehe zu Zeile (Datei-Editor)',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': 'Befehlspalette öffnen',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': 'Eingabe fokussieren',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'Nachricht senden',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': 'Neue Zeile einfügen',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': 'Einstellungen öffnen',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': 'Terminal-Dock umschalten',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': 'Terminal erweitert umschalten',

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1138,6 +1138,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': 'Go to line (files editor)',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': 'Open command palette',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': 'Focus input',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'Send message',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': 'Insert newline',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': 'Open settings',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': 'Toggle terminal dock',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': 'Toggle terminal expanded',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1106,6 +1106,8 @@ export const settingsDict = {
   "settings.openchamber.keyboardShortcuts.action.open_go_to_line.label": "Ir a línea (editor de archivos)",
   "settings.openchamber.keyboardShortcuts.action.open_command_palette.label": "Abrir paleta de comandos",
   "settings.openchamber.keyboardShortcuts.action.focus_input.label": "Enfocar entrada",
+  "settings.openchamber.keyboardShortcuts.action.send_message.label": "Enviar mensaje",
+  "settings.openchamber.keyboardShortcuts.action.insert_newline.label": "Insertar nueva línea",
   "settings.openchamber.keyboardShortcuts.action.open_settings.label": "Abrir configuración",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal.label": "Mostrar u ocultar panel de terminal",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label": "Expandir o contraer terminal",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1024,6 +1024,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': 'Aller à la ligne (éditeur de fichiers)',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': 'Ouvrir la palette de commandes',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': 'Entrée de mise au point',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'Envoyer un message',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': 'Insérer une nouvelle ligne',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': 'Ouvrir les paramètres',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': 'Basculer la station d\'accueil du terminal',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': 'Terminal à bascule étendu',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1139,6 +1139,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': '指定行に移動（ファイルエディター）',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': 'コマンドパレットを開く',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': '入力をフォーカス',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'メッセージを送信',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': '改行を挿入',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': '設定を開く',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': 'ターミナルドックの切替',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': 'ターミナル拡大の切替',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1106,6 +1106,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': '줄로 이동(파일 편집기)',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': '명령 팔레트 열기',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': '입력에 포커스',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': '보내기 메시지',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': '새 줄 삽입',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': '설정 열기',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': '터미널 dock 토글',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': '터미널 확장 토글',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -824,6 +824,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.expand_input.label': 'Rozwiń pole wprowadzania',
   'settings.openchamber.keyboardShortcuts.action.toggle_prompt_navigator.label': 'Przełącz nawigator promptów',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': 'Skup pole wprowadzania',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'Wyślij wiadomość',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': 'Wstaw nową linię',
   'settings.openchamber.keyboardShortcuts.action.new_chat.label': 'Nowa sesja',
   'settings.openchamber.keyboardShortcuts.action.switch_session_previous.label': 'Poprzednia sesja',
   'settings.openchamber.keyboardShortcuts.action.switch_session_next.label': 'Następna sesja',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1106,6 +1106,8 @@ export const settingsDict = {
   "settings.openchamber.keyboardShortcuts.action.open_go_to_line.label": "Ir para linha (editor de arquivos)",
   "settings.openchamber.keyboardShortcuts.action.open_command_palette.label": "Abrir paleta de comandos",
   "settings.openchamber.keyboardShortcuts.action.focus_input.label": "Focar entrada",
+  "settings.openchamber.keyboardShortcuts.action.send_message.label": "Enviar mensagem",
+  "settings.openchamber.keyboardShortcuts.action.insert_newline.label": "Inserir nova linha",
   "settings.openchamber.keyboardShortcuts.action.open_settings.label": "Abrir configurações",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal.label": "Mostrar ou ocultar painel de terminal",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label": "Expandir ou recolher terminal",

--- a/packages/ui/src/lib/i18n/messages/tr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/tr.settings.ts
@@ -1134,6 +1134,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': 'Satıra git (dosya düzenleyici)',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': 'Komut paletini aç',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': 'Girdi alanına odaklan',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': 'Mesaj gönder',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': 'Yeni satır ekle',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': 'Ayarları aç',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': 'Terminal dock\'unu aç/kapat',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': 'Terminali genişlet/daralt',

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1106,6 +1106,8 @@ export const settingsDict = {
   "settings.openchamber.keyboardShortcuts.action.open_go_to_line.label": "Перейти до рядка (редактор файлів)",
   "settings.openchamber.keyboardShortcuts.action.open_command_palette.label": "Відкрити палітру команд",
   "settings.openchamber.keyboardShortcuts.action.focus_input.label": "Фокус на полі вводу",
+  "settings.openchamber.keyboardShortcuts.action.send_message.label": "Надіслати повідомлення",
+  "settings.openchamber.keyboardShortcuts.action.insert_newline.label": "Вставити новий рядок",
   "settings.openchamber.keyboardShortcuts.action.open_settings.label": "Відкрити налаштування",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal.label": "Перемкнути панель терміналу",
   "settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label": "Розгорнути або згорнути термінал",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1106,6 +1106,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': '跳转到行（文件编辑器）',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': '打开命令面板',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': '聚焦输入框',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': '发送消息',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': '插入换行',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': '打开设置',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': '切换终端停靠区',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': '切换终端展开',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1013,6 +1013,8 @@ export const settingsDict = {
   'settings.openchamber.keyboardShortcuts.action.open_go_to_line.label': '跳轉到行（檔案編輯器）',
   'settings.openchamber.keyboardShortcuts.action.open_command_palette.label': '開啟命令面板',
   'settings.openchamber.keyboardShortcuts.action.focus_input.label': '聚焦輸入方塊',
+  'settings.openchamber.keyboardShortcuts.action.send_message.label': '傳送訊息',
+  'settings.openchamber.keyboardShortcuts.action.insert_newline.label': '插入換行',
   'settings.openchamber.keyboardShortcuts.action.open_settings.label': '開啟設定',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal.label': '切換終端機停靠區',
   'settings.openchamber.keyboardShortcuts.action.toggle_terminal_expanded.label': '切換終端機展開',

--- a/packages/ui/src/lib/shortcuts/DOCUMENTATION.md
+++ b/packages/ui/src/lib/shortcuts/DOCUMENTATION.md
@@ -4,6 +4,8 @@ Application commands use `useKeybind(actionId, handler)` or `useKeybinds(binding
 
 Do not add a component-level `window` or `document` keydown listener for an application command. Declare the action in `config.ts`, then register its handler near the state or UI it owns. This keeps definitions and dispatch centralized without lifting component state or passing callbacks through unrelated components.
 
+`send_message` and `insert_newline` are the exception to global registration: their defaults are bare `enter` and `shift+enter`, which must never trigger outside the chat composer (typing Enter in any other field would send). They stay in the schema so Settings can display and persist overrides, but the composer dispatches them itself from its editor keydown — the global dispatcher never registers them.
+
 # Schema contract
 
 `config.ts` is the declaration-only source for application commands. It organizes entries into `session`, `models`, `panels`, `navigation`, and `application` groups, then explicitly concatenates them into `SHORTCUT_SCHEMA`. Every entry declares an ID, default binding, and whether users can customize it. Customizable entries also declare their Settings translation key, so Settings must not maintain an action-ID switch or English fallback labels.

--- a/packages/ui/src/lib/shortcuts/config.ts
+++ b/packages/ui/src/lib/shortcuts/config.ts
@@ -39,6 +39,18 @@ const SHORTCUT_GROUPS = {
       settingsLabelKey: 'settings.openchamber.keyboardShortcuts.action.focus_input.label',
     },
     {
+      id: 'send_message',
+      defaultBinding: 'enter',
+      customizable: true,
+      settingsLabelKey: 'settings.openchamber.keyboardShortcuts.action.send_message.label',
+    },
+    {
+      id: 'insert_newline',
+      defaultBinding: 'shift+enter',
+      customizable: true,
+      settingsLabelKey: 'settings.openchamber.keyboardShortcuts.action.insert_newline.label',
+    },
+    {
       id: 'open_timeline_dialog',
       defaultBinding: 'mod+k t',
       customizable: true,

--- a/packages/ui/src/lib/shortcuts/schema.test.ts
+++ b/packages/ui/src/lib/shortcuts/schema.test.ts
@@ -49,6 +49,33 @@ describe('shortcut schema', () => {
     ))).toBe(true);
   });
 
+  test('declares configurable chat input send and newline bindings', () => {
+    const sendMessage = getShortcutAction('send_message');
+    expect(sendMessage?.category).toBe('session');
+    expect(sendMessage?.defaultBinding).toBe('enter');
+    expect(sendMessage?.customizable).toBe(true);
+    const insertNewline = getShortcutAction('insert_newline');
+    expect(insertNewline?.category).toBe('session');
+    expect(insertNewline?.defaultBinding).toBe('shift+enter');
+    expect(insertNewline?.customizable).toBe(true);
+    // The pair must not overlap: one Enter presses sends, the other newline.
+    expect(getShortcutBindingConflicts('send_message', 'enter')).toEqual([]);
+    expect(getShortcutBindingConflicts('insert_newline', 'shift+enter')).toEqual([]);
+  });
+
+  test('chat input bindings resolve overrides and block rebinds onto each other', () => {
+    expect(getEffectiveShortcutCombo('send_message', { send_message: 'mod+enter' })).toBe('mod+enter');
+    expect(getEffectiveShortcutCombo('insert_newline', { insert_newline: 'enter' })).toBe('enter');
+    expect(getEffectiveShortcutCombo('send_message')).toBe('enter');
+    expect(getEffectiveShortcutCombo('insert_newline')).toBe('shift+enter');
+    // Rebinding another action onto Enter collides with the send binding.
+    expect(
+      getShortcutBindingConflicts('new_chat', 'enter').some(
+        (conflict) => conflict.action.id === 'send_message' && conflict.kind === 'exact',
+      ),
+    ).toBe(true);
+  });
+
   test('keeps the mod+k leader for open/go actions', () => {
     expect(getShortcutAction('open_draft_project_picker')?.defaultBinding).toBe('mod+k p');
     expect(getShortcutAction('open_draft_worktree_picker')?.defaultBinding).toBe('mod+k g');


### PR DESCRIPTION
## Intent

Issue #1988: chat input send and newline were hardcoded (Enter sends, Shift+Enter inserts a newline). This adds two public, customizable shortcuts, `send_message` (default Enter) and `insert_newline` (default Shift+Enter), and makes the composer dispatch the effective bindings. Rebinding send to Ctrl+Enter gives the common chat-editor style where Enter writes a newline. The defaults are unchanged.

## Non-goals

- No OpenCode TUI shortcut sync (#608).
- No Chat Input preference toggle for send-with-Enter versus Ctrl+Enter; the two keybindings cover the same need.
- Other Enter-to-send surfaces (QuestionCard, dialogs, commit input) keep their local behavior.

## Affected surfaces

- `packages/ui`: shared ChatInput composer, `SHORTCUT_SCHEMA`, Keyboard Shortcuts settings page, shortcut-override persistence, and all 12 locale dicts (new label keys).
- Every runtime renders the same `ChatContainer`/`ChatInput` and shares the schema and overrides store: web, Electron desktop, VS Code webview, hosted mobile, and Capacitor mobile. Electron Mini Chat uses the same composer.
- Mobile and desktop focus-mode keep the existing rule that a bare send binding needs the primary modifier: plain Enter writes a newline, Ctrl/Cmd+Enter sends.
- The two actions are not registered in the global shortcut dispatcher. Bare Enter and Shift+Enter must never fire outside the composer, so the composer dispatches them from its own editor keydown. This is recorded in `lib/shortcuts/DOCUMENTATION.md`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md instruction order and CONTRIBUTING.md PR contract | Source change in the shared UI package | Followed both; template completed with current evidence |
| `openchamber-change-discipline` | Shared UI contract across runtimes | Scope kept to two schema actions plus composer dispatch; validated at package level |
| `locale-ui-patterns` | New user-facing settings labels | Keys added to all 12 locale dicts with real translations, no English placeholders |
| `settings-ui-patterns` | New rows in the Settings Keyboard Shortcuts page | Rows render through the existing shared `KeyboardShortcutsSettings` component; no new markup or search entry needed |
| `lib/shortcuts/DOCUMENTATION.md` | Adding shortcuts workflow | Followed its checklist; documented the composer-local registration exception |

## Validation

| Check | Result |
|---|---|
| `bun test src/lib/shortcuts` (packages/ui) | 66 pass, includes the new `send_message` / `insert_newline` tests |
| `bun run type-check` (packages/ui) | clean |
| `eslint` on the changed files (ui config) | clean |
| `bunx oxlint` on the changed files | no new findings; pre-existing anti-slop backlog untouched |
| `bun run dead-code` | no new findings |
| Manual verification (Windows, web HMR) | maintainer confirmed the feature works |
| `bun test src/lib/i18n/messages.test.ts` | still fails on 4 pre-existing `gitView.empty.*` keys missing from non-English locales; unrelated to this change, and both new keys are present in all 12 dicts |
| Full `bun run test` and `bun run build` | not run in this session; the repo had no `node_modules` until a fresh `bun install`, and the full suite was not executed |

## Visual evidence

No screenshots captured. The user-visible change is two rows in the existing Keyboard Shortcuts page, rendered by the same component that already lists the other shortcuts, plus the rebindable Enter behavior that the maintainer verified manually on Windows. The diff adds no new UI markup, so rendering follows the existing, already-shipped component.

## Risks and failure behavior

- Rebinding `send_message` away from Enter makes plain Enter insert a newline (the editor's default), which is the safe fallback.
- Overlapping send and newline combos are rejected by the existing recorder conflict checks; schema tests assert the defaults do not overlap.
- Unassigning `send_message` leaves Enter as newline; the send button still works.
- One intended behavior change: on desktop, Alt+Enter previously sent because the old `!e.shiftKey` gate caught any non-shift Enter; it now inserts a newline unless explicitly bound.
- No persisted-format change: overrides stay a flat `Record<string, string>`, and unknown ids remain inert (covered by the existing schema test).

Closes #1988