### PR TITLE
fix(ui): persist manual model selection across restarts

### DIFF
--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -504,6 +504,51 @@ describe('useConfigStore provider persistence', () => {
     expect(persisted.state.directoryScoped[DIRECTORY].selectedProviderId).toBe('');
   });
 
+  test('[issue-1801] round-trips a manual model selection through restart hydration', async () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [
+        provider('opencode', 'big-pickle'),
+        provider('deepseek', 'deepseek-v4-pro', { low: {}, high: {} }),
+      ],
+      agents: [testAgent('build')],
+      currentProviderId: 'opencode',
+      currentModelId: 'big-pickle',
+      currentAgentName: 'build',
+      settingsDefaultModel: 'opencode/big-pickle',
+      directoryScoped: {},
+    });
+    useConfigStore.getState().setProvider('deepseek');
+    useConfigStore.getState().setCurrentVariantOverride('low', 'high');
+
+    const persisted = storage.get(STORAGE_KEY);
+    expect(JSON.parse(persisted ?? '{}').state.selectionSource).toBe('manual');
+
+    useConfigStore.setState({
+      providers: [],
+      agents: [],
+      currentProviderId: '',
+      currentModelId: '',
+      currentVariant: undefined,
+      currentVariantSelection: { override: undefined, inherited: undefined },
+      currentAgentName: undefined,
+      selectionSource: 'auto',
+      directoryScoped: {},
+    });
+    if (persisted) {
+      storage.set(STORAGE_KEY, persisted);
+    }
+
+    await useConfigStore.persist.rehydrate();
+    useConfigStore.getState().applyDefaultModelAgentSelection();
+
+    const restarted = useConfigStore.getState();
+    expect(restarted.currentProviderId).toBe('deepseek');
+    expect(restarted.currentModelId).toBe('deepseek-v4-pro');
+    expect(restarted.currentVariant).toBe('low');
+    expect(restarted.selectionSource).toBe('manual');
+  });
+
   test('setAgent applies settings default variant for an agent configured model', () => {
     useSessionUIStore.setState({ currentSessionId: 'ses_agent_default_variant' });
     useConfigStore.setState({
@@ -828,7 +873,7 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentVariant).toBe('high');
   });
 
-  test('a fresh session applies the settings thinking level instead of the previous override', () => {
+  test('an automatic fresh session applies the settings thinking level instead of the previous override', () => {
     useConfigStore.setState({
       activeDirectoryKey: DIRECTORY,
       providers: [provider('openai', 'gpt-5.5', { low: {}, high: {} })],
@@ -839,7 +884,7 @@ describe('useConfigStore provider persistence', () => {
       currentVariantSelection: { override: 'low', inherited: 'high' },
       settingsDefaultModel: 'openai/gpt-5.5',
       settingsDefaultVariant: 'high',
-      selectionSource: 'manual',
+      selectionSource: 'auto',
       directoryScoped: {},
     });
 
@@ -849,6 +894,60 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentVariant).toBe('high');
     expect(state.currentVariantSelection).toEqual({ override: 'high', inherited: 'high' });
     expect(state.directoryScoped[DIRECTORY]?.currentVariant).toBe('high');
+  });
+
+  test('[issue-1801] a fresh draft preserves a valid manual model selection', () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [
+        provider('opencode', 'big-pickle'),
+        provider('deepseek', 'deepseek-v4-pro', { low: {}, high: {} }),
+      ],
+      agents: [testAgent('build')],
+      currentProviderId: 'deepseek',
+      currentModelId: 'deepseek-v4-pro',
+      currentVariant: 'low',
+      currentVariantSelection: { override: 'low', inherited: 'high' },
+      currentAgentName: 'build',
+      selectionSource: 'manual',
+      settingsDefaultModel: 'opencode/big-pickle',
+      directoryScoped: {},
+    });
+
+    useConfigStore.getState().applyDefaultModelAgentSelection();
+
+    const state = useConfigStore.getState();
+    expect(state.currentProviderId).toBe('deepseek');
+    expect(state.currentModelId).toBe('deepseek-v4-pro');
+    expect(state.currentVariant).toBe('low');
+    expect(state.currentVariantSelection).toEqual({ override: 'low', inherited: 'high' });
+    expect(state.selectionSource).toBe('manual');
+    expect(state.directoryScoped[DIRECTORY]?.currentModelId).toBe('deepseek-v4-pro');
+    expect(state.directoryScoped[DIRECTORY]?.selectionSource).toBe('manual');
+  });
+
+  test('[issue-1801] a fresh draft falls back when the manual model is unavailable', () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [provider('opencode', 'big-pickle')],
+      agents: [testAgent('build')],
+      currentProviderId: 'deepseek',
+      currentModelId: 'retired-model',
+      currentVariant: 'low',
+      currentVariantSelection: { override: 'low', inherited: 'low' },
+      currentAgentName: 'build',
+      selectionSource: 'manual',
+      settingsDefaultModel: 'opencode/big-pickle',
+      directoryScoped: {},
+    });
+
+    useConfigStore.getState().applyDefaultModelAgentSelection();
+
+    const state = useConfigStore.getState();
+    expect(state.currentProviderId).toBe('opencode');
+    expect(state.currentModelId).toBe('big-pickle');
+    expect(state.currentVariant).toBe(undefined);
+    expect(state.selectionSource).toBe('manual');
   });
 
   test('a thinking level the project model does not offer is ignored', async () => {

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -2666,8 +2666,8 @@ export const useConfigStore = create<ConfigStore>()(
                 // Re-applies the same priority cascade used at app startup (see loadAgents):
                 //   agent: settings.defaultAgent → build → first primary → first agent
                 //   model: project.defaultModel → settings.defaultModel → agent's preferred model → opencode/big-pickle → first
-                // Used when entering a fresh draft session so model/agent reset to defaults
-                // instead of sticking to the previously open session's selection.
+                // Used when entering a fresh draft session. A valid manual selection survives
+                // app restarts and draft changes; automatic or stale selections use defaults.
                 applyDefaultModelAgentSelection: (options) => {
                     const {
                         agents,
@@ -2683,12 +2683,7 @@ export const useConfigStore = create<ConfigStore>()(
                         return;
                     }
 
-                    const {
-                        agentName: resolvedAgentName,
-                        providerId: resolvedProviderId,
-                        modelId: resolvedModelId,
-                        variant: resolvedVariant,
-                    } = resolveDefaultAgentModelSelection({
+                    const resolvedDefault = resolveDefaultAgentModelSelection({
                         agents,
                         providers,
                         projectDefaultModel: options?.projectDefaultModel,
@@ -2700,11 +2695,28 @@ export const useConfigStore = create<ConfigStore>()(
                         opencodeDefaultModel,
                     });
 
-                    if (!resolvedAgentName) {
+                    if (!resolvedDefault.agentName) {
                         return;
                     }
 
                     set((state) => {
+                        const nextSelection = resolveSelectionWithManualGuard({
+                            agents,
+                            providers,
+                            currentAgentName: state.currentAgentName,
+                            currentProviderId: state.currentProviderId,
+                            currentModelId: state.currentModelId,
+                            currentVariant: state.currentVariant,
+                            selectionSource: state.selectionSource,
+                            resolvedAgentName: resolvedDefault.agentName,
+                            resolvedProviderId: resolvedDefault.providerId,
+                            resolvedModelId: resolvedDefault.modelId,
+                            resolvedVariant: resolvedDefault.variant,
+                        });
+                        const preservesManualVariantSelection = nextSelection.selectionSource === "manual"
+                            && nextSelection.providerId === state.currentProviderId
+                            && nextSelection.modelId === state.currentModelId
+                            && nextSelection.variant === state.currentVariant;
                         const directoryKey = state.activeDirectoryKey;
                         const baseSnapshot: DirectoryScopedConfig = state.directoryScoped[directoryKey] ?? {
                             providers: state.providers,
@@ -2720,34 +2732,35 @@ export const useConfigStore = create<ConfigStore>()(
 
                         const nextSnapshot: DirectoryScopedConfig = {
                             ...baseSnapshot,
-                            currentAgentName: resolvedAgentName,
-                            ...(resolvedProviderId && resolvedModelId
-                                ? {
-                                    currentProviderId: resolvedProviderId,
-                                    currentModelId: resolvedModelId,
-                                    currentVariant: resolvedVariant,
-                                }
-                                : {}),
-                            selectionSource: "auto",
+                            currentAgentName: nextSelection.agentName,
+                            selectionSource: nextSelection.selectionSource,
                         };
 
+                        if (nextSelection.providerId && nextSelection.modelId) {
+                            nextSnapshot.currentProviderId = nextSelection.providerId;
+                            nextSnapshot.currentModelId = nextSelection.modelId;
+                            nextSnapshot.currentVariant = nextSelection.variant;
+                        }
+
                         const nextState: Partial<ConfigStore> = {
-                            currentAgentName: resolvedAgentName,
-                            selectionSource: "auto",
+                            currentAgentName: nextSelection.agentName,
+                            selectionSource: nextSelection.selectionSource,
                             directoryScoped: {
                                 ...state.directoryScoped,
                                 [directoryKey]: nextSnapshot,
                             },
                         };
 
-                        if (resolvedProviderId && resolvedModelId) {
-                            nextState.currentProviderId = resolvedProviderId;
-                            nextState.currentModelId = resolvedModelId;
-                            nextState.currentVariant = resolvedVariant;
-                            nextState.currentVariantSelection = {
-                                override: resolvedVariant,
-                                inherited: resolvedVariant,
-                            };
+                        if (nextSelection.providerId && nextSelection.modelId) {
+                            nextState.currentProviderId = nextSelection.providerId;
+                            nextState.currentModelId = nextSelection.modelId;
+                            nextState.currentVariant = nextSelection.variant;
+                            if (!preservesManualVariantSelection) {
+                                nextState.currentVariantSelection = {
+                                    override: nextSelection.variant,
+                                    inherited: nextSelection.variant,
+                                };
+                            }
                         }
 
                         return nextState;
@@ -3450,6 +3463,7 @@ export const useConfigStore = create<ConfigStore>()(
                     currentVariant: state.currentVariant,
                     currentAgentName: state.currentAgentName,
                     selectedProviderId: sanitizePersistedSelectedProviderId(state.selectedProviderId),
+                    selectionSource: state.selectionSource,
                     agentModelSelections: state.agentModelSelections,
                     defaultProviders: state.defaultProviders,
                     settingsDefaultModel: state.settingsDefaultModel,

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1193,8 +1193,8 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     // came from a worktree session, `directory` is the worktree path, whose provider list does
     // not include project/global-scoped providers (e.g. the default agent's non-opencode model)
     // — resolving defaults against it would wrongly fall back to opencode/big-pickle. Activate
-    // the project's config instead so the default cascade matches app startup, then re-apply it
-    // (a fresh draft must start from defaults, not inherit the previous session's selection).
+    // the project's config instead so the default cascade matches app startup, then re-apply it.
+    // applyDefaultModelAgentSelection keeps a valid manual choice and uses the cascade otherwise.
     const configDirectory = normalizePath(selectedProject?.path ?? null) ?? directory
     void activateConfigForDirectory(configDirectory).then(() => {
       useConfigStore.getState().applyDefaultModelAgentSelection({


### PR DESCRIPTION
## Intent

Fix #1801 by preserving a valid manually selected provider, model, and variant when the app is restarted and a fresh chat draft opens. Persist `selectionSource` explicitly and route fresh-draft default resolution through the same manual-selection guard already used by provider refreshes.

If the saved provider, model, variant, or agent is no longer available, the existing default cascade still supplies a valid fallback.

## Non-goals

- Change the priority order for project, settings, agent, OpenCode, or Big Pickle defaults.
- Introduce a new persistence format or migration.
- Change session-specific model restoration or model-provider configuration.

## Affected surfaces

- `packages/ui` config persistence and fresh-draft selection state.
- Desktop and web restart behavior, plus other runtimes that consume the shared UI store.
- The existing browser-backed `config-store` persisted contract gains the optional top-level `selectionSource` field. Older snapshots remain compatible because the store defaults to `auto` and can still hydrate directory-scoped snapshots.
- No native bridge, network protocol, backend, dependency, or rendered layout changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Governs repository-wide change scope and validation. | Kept the change to the shared UI store, its caller comment, and focused tests; no dependency or changelog changes. |
| `openchamber-change-discipline` | Applies to executable source changes. | Used the smallest existing state-resolution path, added regression coverage, and ran focused tests plus package-scoped checks. |
| `sync-state-invariants` | The fix changes persisted state and a sync-store draft transition. | Preserved manual state only while referenced agent/model/variant values are valid; stale values fall back through the existing resolver. |
| `packages/ui/src/stores/DOCUMENTATION.md` | Defines config-store persistence and state ownership. | Kept model-selection ownership in `useConfigStore` and tested the persistence/hydration round trip. |
| `packages/ui/src/sync/DOCUMENTATION.md` | Defines shared session and draft state responsibilities. | Left session routing unchanged; the sync store continues to activate project config before asking the config store to resolve selection. |
| `communication-style` | Applies to comments and PR text. | Updated comments to describe the invariant directly and kept the PR focused on observable behavior. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/useConfigStore.test.ts` | Pass: 35 tests, 138 assertions, 0 failures. Includes persisted-state restart round trip, valid manual selection, automatic default, and unavailable-model fallback cases. |
| `bun run type-check:ui` | Pass. |
| `bun run lint:ui` | Pass. |
| `git diff --check` | Pass. |
| `node_modules/.bin/oxlint packages/ui/src/stores/useConfigStore.ts packages/ui/src/stores/useConfigStore.test.ts packages/ui/src/sync/session-ui-store.ts` | The full-file scan still reports existing anti-slop diagnostics elsewhere in these large files. A follow-up scan of the modified line ranges reports no diagnostics. |

The full desktop application was not manually restarted on Windows. The restart transition is covered by a focused store persistence/hydration test.

## Visual evidence

No screenshot is attached because this does not change layout, styling, or rendered components. The visible effect occurs across process restarts: the existing model picker keeps the saved value instead of switching to Big Pickle. The before/after state transition is covered by the focused restart round-trip test.

## Risks and failure behavior

- A valid manual selection now remains sticky for fresh drafts, matching the existing behavior during provider refreshes.
- If a saved model or variant disappears, `resolveSelectionWithManualGuard` uses the existing default cascade instead of retaining an invalid value.
- Persisted snapshots without the new top-level field remain compatible; directory-scoped state and the existing `auto` default still work.
- No new I/O, dependencies, credentials, or destructive state operations are introduced. Reverting this commit restores the prior selection behavior without a data migration.

Fixes #1801
