### PR TITLE
feat(questions): adopt native V2 question read path with V1 fallback

### DIFF
--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 type QuestionFixture = {
   id: string;
@@ -58,6 +58,7 @@ const makeV1ListResult = (items: QuestionFixture[]) => ({
 
 type V2Response =
   | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'v2-404' }
   | { kind: 'server-error' }
   | { kind: 'throw' };
 
@@ -80,6 +81,8 @@ const questionV2ListMock = mock((args?: { location?: { directory?: string } }) =
         // violates the QuestionFixture contract; the parser under test must
         // reject it.
         resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else if (r.kind === 'v2-404') {
+        resolve(makeV2ErrorResult(404));
       } else {
         resolve(makeV2ErrorResult(500));
       }
@@ -137,7 +140,13 @@ mock.module('@/lib/startupTrace', () => ({
   markStartupTrace: mock(() => undefined),
 }));
 
-const { opencodeClient } = await import(`./client?cache-test-questions=${Date.now()}`);
+const { opencodeClient, resetQuestionsV2FallbackWarningsForTests } = await import(`./client?cache-test-questions=${Date.now()}`);
+
+const consoleWarnCalls: string[] = [];
+const consoleWarnSpy = mock((message: string) => {
+  consoleWarnCalls.push(message);
+});
+const originalConsoleWarn = console.warn;
 
 const resolveV2Calls = (responses: V2Response[]) => {
   queueMicrotask(() => {
@@ -153,6 +162,13 @@ beforeEach(() => {
   v2ListArgs.length = 0;
   v1ListArgs.length = 0;
   v1ListResult = makeV1ListResult([]);
+  resetQuestionsV2FallbackWarningsForTests();
+  consoleWarnCalls.length = 0;
+  console.warn = consoleWarnSpy;
+});
+
+afterEach(() => {
+  console.warn = originalConsoleWarn;
 });
 
 describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
@@ -192,6 +208,40 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
 
     expect(result).toEqual([v1Question]);
     expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+  });
+
+  test('falls back to V1 on V2 404 route-miss without console.warn (pre-V2 compat path)', async () => {
+    const v1Question = makeQuestion('v1notfound');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'v2-404' },
+      { kind: 'v2-404' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+    expect(consoleWarnCalls).toEqual([]);
+  });
+
+  test('falls back to V1 on V2 network throw with a single stable-marker warn', async () => {
+    const v1Question = makeQuestion('v1net2');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'throw' },
+      { kind: 'throw' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('network-error');
+    expect(consoleWarnCalls[0]).toContain('falling back to V1');
   });
 
   test('falls back to V1 when the V2 SDK call throws (network failure)', async () => {
@@ -260,6 +310,29 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
     expect(result).toEqual([v1Question, scopedQuestion]);
     expect(v1ListArgs).toEqual([undefined]);
     expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('falls back to V1 with a warn when a 200 V2 payload is malformed (contract drift)', async () => {
+    // SAFETY: the malformed-payload test intentionally feeds a payload that
+    // violates the V2 contract; the reader under test must reject it.
+    const v1Question = makeQuestion('v1drift');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Same-version contract drift: the 200 envelope is valid, but the item
+      // itself is not — `questions` carries a string instead of the option
+      // array. Typed as `unknown` at the mock boundary on purpose.
+      { kind: 'ok', items: [{ ...makeQuestion('q-drift'), questions: 'missing' }] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('malformed-payload');
   });
 
   test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -56,8 +56,36 @@ const makeV1ListResult = (items: QuestionFixture[]) => ({
   response: new Response(null, { status: 200 }),
 });
 
+/**
+ * A closed set of non-array payload shapes the contract-drift test feeds.
+ * The reader under test only checks `Array.isArray(response.data?.data)`,
+ * so any non-array value triggers the warn-and-fall-back path. The closed
+ * union is intentional: this test is the parser-of-last-resort for the
+ * wire drift, not a generic value passthrough.
+ */
+type NonArrayPayload =
+  | { readonly tag: 'object' }
+  | null
+  | string
+  | number
+  | boolean;
+
+/**
+ * Build a 200 success result whose `data.data` is NOT an item array. This is
+ * the same-version contract-drift case where the typed SDK path no longer
+ * matches the wire envelope — the reader under test must reject it
+ * conservatively (warn once, fall back to V1).
+ */
+const makeV2NonArrayPayloadResult = (payload: NonArrayPayload) => ({
+  data: { data: payload },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
 type V2Response =
   | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'non-array-payload'; payload: unknown }
   | { kind: 'v2-404' }
   | { kind: 'server-error' }
   | { kind: 'throw' };
@@ -81,6 +109,14 @@ const questionV2ListMock = mock((args?: { location?: { directory?: string } }) =
         // violates the QuestionFixture contract; the parser under test must
         // reject it.
         resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else if (r.kind === 'non-array-payload') {
+        // SAFETY: the contract-drift test intentionally feeds a 200 status
+        // whose `data.data` is not an item array; the reader under test
+        // must reject it (warn once, fall back to V1). `r.payload` is
+        // intentionally typed `unknown` in the discriminator (any non-array
+        // value is valid here), so we narrow it to the closed
+        // `NonArrayPayload` union at the helper boundary by construction.
+        resolve(makeV2NonArrayPayloadResult(r.payload as NonArrayPayload));
       } else if (r.kind === 'v2-404') {
         resolve(makeV2ErrorResult(404));
       } else {
@@ -324,6 +360,31 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
       // itself is not — `questions` carries a string instead of the option
       // array. Typed as `unknown` at the mock boundary on purpose.
       { kind: 'ok', items: [{ ...makeQuestion('q-drift'), questions: 'missing' }] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('malformed-payload');
+  });
+
+  test('falls back to V1 with a warn when a 200 V2 payload is not an item array (contract drift)', async () => {
+    // SAFETY: the contract-drift test intentionally feeds a 200 status whose
+    // `data.data` is NOT an array (here: a bare object). The reader under
+    // test must reject it conservatively (warn once, fall back to V1) and
+    // must NOT treat it as an empty success.
+    const v1Question = makeQuestion('v1driftna');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Same-version contract drift: the 200 envelope is valid, but the
+      // payload the reader expects (an item array) is replaced by a plain
+      // object literal, satisfying the closed `NonArrayPayload` union.
+      { kind: 'non-array-payload', payload: { tag: 'object' } },
       { kind: 'ok', items: [] },
     ]);
     const result = await promise;

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type QuestionFixture = {
+  id: string;
+  sessionID: string;
+  questions: Array<{
+    question: string;
+    header: string;
+    options: Array<{ label: string; description: string }>;
+    multiple?: boolean;
+  }>;
+  tool?: { messageID: string; callID: string };
+};
+
+const makeQuestion = (id: string, overrides?: Partial<QuestionFixture>): QuestionFixture => ({
+  id,
+  sessionID: `ses_${id}`,
+  questions: [
+    {
+      question: `${id}: proceed with the plan?`,
+      header: 'Build',
+      options: [
+        { label: 'Yes', description: 'Proceed' },
+        { label: 'No', description: 'Cancel' },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+/**
+ * Build a HeyApi success result matching the wrapper's V2 expectations:
+ *   - error === undefined (success branch)
+ *   - data.data === the item array (200 status payload nests the list
+ *     under its own `data` field, same as session.permission.*)
+ *   - response.status === 200
+ */
+const makeV2SuccessResult = (items: QuestionFixture[]) => ({
+  data: { data: items },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+const makeV2ErrorResult = (status: number) => ({
+  data: undefined,
+  error: { name: 'ServerError', data: { message: 'err' } },
+  request: new Request('http://test/'),
+  response: new Response(null, { status }),
+});
+
+const makeV1ListResult = (items: QuestionFixture[]) => ({
+  data: items,
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+type V2Response =
+  | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'server-error' }
+  | { kind: 'throw' };
+
+/**
+ * Calls arrive in listPendingQuestions' fixed order: unscoped first, then
+ * one call per unique normalized directory. Each test resolves every call
+ * it triggered, so index-order resolution is unambiguous.
+ */
+const v2PendingResolutions: Array<(r: V2Response) => void> = [];
+const v2ListArgs: Array<{ location?: { directory?: string } } | undefined> = [];
+
+const questionV2ListMock = mock((args?: { location?: { directory?: string } }) => {
+  v2ListArgs.push(args);
+  return new Promise<unknown>((resolve, reject) => {
+    v2PendingResolutions.push((r: V2Response) => {
+      if (r.kind === 'throw') {
+        reject(new Error('network down'));
+      } else if (r.kind === 'ok') {
+        // SAFETY: the malformed-item test intentionally feeds a payload that
+        // violates the QuestionFixture contract; the parser under test must
+        // reject it.
+        resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else {
+        resolve(makeV2ErrorResult(500));
+      }
+    });
+  });
+});
+
+let v1ListResult: unknown = makeV1ListResult([]);
+const v1ListArgs: Array<{ directory?: string } | undefined> = [];
+
+const questionV1ListMock = mock((args?: { directory?: string }) => {
+  v1ListArgs.push(args);
+  return Promise.resolve(v1ListResult);
+});
+
+const createOpencodeClientMock = mock(() => ({
+  question: {
+    list: questionV1ListMock,
+  },
+  v2: {
+    question: {
+      request: {
+        list: questionV2ListMock,
+      },
+    },
+  },
+}));
+
+mock.module('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: createOpencodeClientMock,
+}));
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: mock(() => null),
+}));
+
+mock.module('@/lib/runtime-url', () => ({
+  getRuntimeUrlResolver: mock(() => ({
+    api: (path: string) => path,
+  })),
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: mock(() => ''),
+  getRuntimeKey: mock(() => 'test-runtime'),
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(async () => new Response(JSON.stringify([]), {
+    headers: { 'Content-Type': 'application/json' },
+  })),
+}));
+
+mock.module('@/lib/startupTrace', () => ({
+  markStartupTrace: mock(() => undefined),
+}));
+
+const { opencodeClient } = await import(`./client?cache-test-questions=${Date.now()}`);
+
+const resolveV2Calls = (responses: V2Response[]) => {
+  queueMicrotask(() => {
+    for (const [i, response] of responses.entries()) {
+      const resolver = v2PendingResolutions[i];
+      if (resolver) resolver(response);
+    }
+  });
+};
+
+beforeEach(() => {
+  v2PendingResolutions.length = 0;
+  v2ListArgs.length = 0;
+  v1ListArgs.length = 0;
+  v1ListResult = makeV1ListResult([]);
+});
+
+describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
+  test('maps V2 items 1:1, preserving unscoped + per-directory merge and id-dedupe', async () => {
+    // Same-id duplicate across the unscoped and per-directory results is
+    // deduped; the unscoped occurrence (first result) wins.
+    const globalQuestion = makeQuestion('q1', { tool: { messageID: 'msg_1', callID: 'call_1' } });
+    const duplicateQuestion = makeQuestion('q1');
+    const scopedQuestion = makeQuestion('q2', {
+      questions: [
+        { question: 'q2: pick one', header: 'Mode', options: [{ label: 'Fast', description: 'Fast' }], multiple: true },
+      ],
+    });
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'ok', items: [globalQuestion] },
+      { kind: 'ok', items: [duplicateQuestion, scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([globalQuestion, scopedQuestion]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+    expect(v1ListArgs).toEqual([]);
+  });
+
+  test('falls back to V1 per-directory results when every V2 call errors', async () => {
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'server-error' },
+      { kind: 'server-error' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+  });
+
+  test('falls back to V1 when the V2 SDK call throws (network failure)', async () => {
+    const v1Question = makeQuestion('v1net');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'throw' },
+      { kind: 'throw' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('rejects the V2 attempt when any item is malformed and falls back conservatively', async () => {
+    // Malformed unscoped item (missing questions array) → whole V2 attempt
+    // for that call is rejected; V1 answers unscoped while the scoped V2
+    // call still succeeds per call.
+    const scopedQuestion = makeQuestion('v2q');
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Malformed unscoped item (missing questions array): the parser under
+      // test must reject it; V1 answers unscoped while the scoped V2 call
+      // still succeeds per call.
+      { kind: 'ok', items: [{ id: 'broken', sessionID: 'ses_broken' }] },
+      { kind: 'ok', items: [scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question, scopedQuestion]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'ok', items: [] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+    expect(v1ListArgs).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -233,6 +233,35 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
     expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
   });
 
+  test('rejects the V2 attempt when a nested question entry is malformed and falls back conservatively', async () => {
+    // Valid top-level item, but its `questions` array contains a malformed
+    // entry (a bare string): the nested validation under test must reject
+    // the whole call; V1 answers unscoped while the scoped V2 call still
+    // succeeds per call.
+    const scopedQuestion = makeQuestion('v2q');
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      {
+        kind: 'ok',
+        items: [
+          // SAFETY: the malformed-item test intentionally feeds a payload
+          // that violates the QuestionFixture contract; the parser under
+          // test must reject it.
+          { ...makeQuestion('broken'), questions: ['not-a-question'] },
+        ],
+      },
+      { kind: 'ok', items: [scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question, scopedQuestion]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
   test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {
     const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
     resolveV2Calls([

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1,8 +1,6 @@
 import type { ContextPartMetadata } from '@/lib/messages/contextParts';
 import { createOpencodeClient, OpencodeClient } from "@opencode-ai/sdk/v2";
 import type { PermissionV2Request, PermissionV2Effect, PermissionV2Source } from "@opencode-ai/sdk/v2/client";
-import type { QuestionV2Request } from "@opencode-ai/sdk/v2/client";
-import { z } from 'zod';
 import type { FilesAPI } from "../api/types";
 import { getDesktopHomeDirectory } from "../desktop";
 import type {
@@ -19,6 +17,16 @@ import { isAmbiguousTransportFailure, markAmbiguousTransportFailure } from "@/li
 import { FilesystemError, parseFilesystemErrorReason } from "@/lib/api/files-errors";
 import type { PermissionRequest } from "@/types/permission";
 import type { QuestionRequest } from "@/types/question";
+
+import {
+  listPendingQuestionsViaV2,
+  resetQuestionsV2FallbackWarningsForTests,
+} from "./questions-v2";
+
+// Re-exported so existing callers (notably the V2 read test that destructures
+// `resetQuestionsV2FallbackWarningsForTests` from `./client`) keep working
+// after the helper moved into its own module.
+export { resetQuestionsV2FallbackWarningsForTests };
 
 /**
  * Tagged result of `OpencodeService.fetchPermission()`. The caller can
@@ -72,79 +80,6 @@ type SdkResult<T> = {
 };
 
 type DirectoryAvailability = "available" | "missing" | "unknown";
-
-/**
- * Parses one native V2 question item before it crosses into the shared
- * `QuestionRequest` contract. The SDK types the payload, but the
- * pending-question UI treats this read as authoritative, so a misbehaving
- * server must fail over to V1 instead of surfacing malformed items. The
- * schema validates every field the UI-consumed shape actually carries
- * (see `QuestionRequest` consumers) — values are mapped fresh from the
- * parsed payload, nothing is passed through unvalidated.
- */
-const questionV2ItemSchema = z.object({
-  id: z.string().min(1),
-  sessionID: z.string(),
-  questions: z.array(
-    z.object({
-      question: z.string(),
-      header: z.string(),
-      options: z.array(
-        z.object({
-          label: z.string(),
-          description: z.string(),
-        }),
-      ),
-      multiple: z.boolean().optional(),
-    }),
-  ),
-  tool: z
-    .object({
-      messageID: z.string(),
-      callID: z.string(),
-    })
-    .optional(),
-});
-
-const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
-  const parsed = questionV2ItemSchema.safeParse(item);
-  if (!parsed.success) return null;
-  const request: QuestionRequest = {
-    id: parsed.data.id,
-    sessionID: parsed.data.sessionID,
-    questions: parsed.data.questions.map((question) => ({
-      question: question.question,
-      header: question.header,
-      multiple: question.multiple,
-      options: question.options.map((option) => ({
-        label: option.label,
-        description: option.description,
-      })),
-    })),
-  };
-  if (parsed.data.tool) {
-    request.tool = parsed.data.tool;
-  }
-  return request;
-};
-
-/**
- * Warn once per process per failure kind for V2 question-read fallbacks
- * that are NOT the expected pre-V2 404 compat path, so a same-version
- * upstream contract break cannot silently degrade question reads to V1
- * forever (see {@link fetchPendingQuestionsV2} for the transition plan).
- */
-const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
-const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
-  if (questionsV2WarnedKinds.has(kind)) return;
-  questionsV2WarnedKinds.add(kind);
-  console.warn(`[questions-v2] ${kind}: ${detail}`);
-};
-
-/** Clear the once-per-process V2 fallback warnings between tests. */
-export const resetQuestionsV2FallbackWarningsForTests = (): void => {
-  questionsV2WarnedKinds.clear();
-};
 
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
@@ -1516,7 +1451,7 @@ class OpencodeService {
       const trimmed = typeof directory === 'string' ? directory.trim() : '';
       // Native V2 read first; the V1 `question.list` call below stays as the
       // fallback for pre-1.18 servers and any V2 failure (see
-      // {@link fetchPendingQuestionsV2}).
+      // {@link listPendingQuestionsViaV2}).
       const viaV2 = await this.fetchPendingQuestionsV2(trimmed || undefined);
       if (viaV2) {
         return viaV2;
@@ -1562,80 +1497,15 @@ class OpencodeService {
   }
 
   /**
-   * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
-   * `question.request.list` (unscoped for global pending items, or scoped
-   * via `location.directory`).
-   *
-   * Returns the pending questions on success, or `null` on failure so the
-   * caller can use the V1 `question.list` path unchanged. Each item is
-   * schema-validated before being accepted (see {@link parseQuestionV2Item})
-   * — any malformed item fails the whole V2 attempt conservatively.
-   *
-   * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
-   * malformed payload with a 200 status) are warned once per process per
-   * failure kind before the silent `null` fallback — read-only fallback is
-   * transitional, not a standing behavior.
-   *
-   * Removal condition: this V1 fallback is transitional. End-state is
-   * capability selection via runtime protocol detection (`openCodeProtocol`
-   * from `/health`, infra tracked in #3007, separate follow-up), or
-   * removal of the V1 path once the supported-runtime policy sets a
-   * minimum OpenCode version. Reference: #3259.
+   * Thin facade over the shared V2 question-read helper (see
+   * {@link listPendingQuestionsViaV2}). Kept on the class so the
+   * `OpencodeService.listPendingQuestions` call site reads as a single
+   * V2-then-V1 sequence; all V2 semantics (schema, warn-once, fallback
+   * classification) live in `questions-v2.ts` and are shared with the
+   * directory-bootstrap caller (#3288 / unit-5).
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
-    try {
-      const response = await this.client.v2.question.request.list(
-        directory ? { location: { directory } } : undefined,
-      );
-      // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
-      // payload nests the array under its own `data` field.
-      if (response.error !== undefined) {
-        const status = response.response?.status;
-        // A server-confirmed 404 is the expected pre-V2 route-miss compat
-        // path — silent fallback. Any other failure (5xx, auth/contract
-        // drift) must not degrade to V1 invisibly, so warn (once per kind).
-        if (status === 404) return null;
-        warnQuestionsV2FallbackOnce(
-          status === undefined ? 'network-error' : 'server-error',
-          `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
-        );
-        return null;
-      }
-      const items = response.data?.data;
-      if (!Array.isArray(items)) {
-        // Same-version contract drift: 200 status but a payload the typed
-        // SDK path no longer matches. Warn, then fall back to V1.
-        warnQuestionsV2FallbackOnce(
-          'malformed-payload',
-          'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
-        );
-        return null;
-      }
-      const validated: QuestionRequest[] = [];
-      for (const item of items) {
-        const parsed = parseQuestionV2Item(item);
-        // Malformed item: reject the whole V2 attempt conservatively — the
-        // caller falls back to V1 instead of returning partial data.
-        if (!parsed) {
-          warnQuestionsV2FallbackOnce(
-            'malformed-payload',
-            'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
-          );
-          return null;
-        }
-        validated.push(parsed);
-      }
-      return validated;
-    } catch (error) {
-      // Network failure or runtimeFetch throwing → fall back. Never the
-      // provably-pre-V2 404 path (that responds with an error result, not a
-      // throw), so surface it once per kind.
-      warnQuestionsV2FallbackOnce(
-        'network-error',
-        `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
-      );
-      return null;
-    }
+    return listPendingQuestionsViaV2(this.client, directory);
   }
 
   // Configuration

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -71,6 +71,29 @@ type SdkResult<T> = {
 
 type DirectoryAvailability = "available" | "missing" | "unknown";
 
+/**
+ * Runtime guard for one native V2 question item before it crosses into the
+ * shared `QuestionRequest` contract. The SDK types the payload, but the
+ * pending-question UI treats this read as authoritative, so a misbehaving
+ * server must fail over to V1 instead of surfacing malformed items.
+ * Mirrors the minimal per-item checks the V1 merge loop already applies.
+ */
+const parseQuestionV2Item = (value: unknown): QuestionRequest | null => {
+  if (!value || typeof value !== 'object') return null;
+  // SAFETY: shape probe only — each field below is re-validated before it
+  // is copied into the trusted contract.
+  const candidate = value as Partial<QuestionRequest>;
+  if (typeof candidate.id !== 'string' || candidate.id.length === 0) return null;
+  if (typeof candidate.sessionID !== 'string') return null;
+  if (!Array.isArray(candidate.questions)) return null;
+  return {
+    id: candidate.id,
+    sessionID: candidate.sessionID,
+    questions: candidate.questions,
+    tool: candidate.tool,
+  };
+};
+
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
     return error.reason === "not-found" || error.reason === "not-directory";
@@ -1439,6 +1462,13 @@ class OpencodeService {
 
     const fetchForDirectory = async (directory?: string | null): Promise<QuestionRequest[]> => {
       const trimmed = typeof directory === 'string' ? directory.trim() : '';
+      // Native V2 read first; the V1 `question.list` call below stays as the
+      // fallback for pre-1.18 servers and any V2 failure (see
+      // {@link fetchPendingQuestionsV2}).
+      const viaV2 = await this.fetchPendingQuestionsV2(trimmed || undefined);
+      if (viaV2) {
+        return viaV2;
+      }
       const result = await this.client.question.list(trimmed ? { directory: trimmed } : undefined);
       if (result.error) {
         throw new Error(`question.list failed: ${formatSdkError(result.error)}`);
@@ -1477,6 +1507,43 @@ class OpencodeService {
     }
 
     return merged;
+  }
+
+  /**
+   * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
+   * `question.request.list` (unscoped for global pending items, or scoped
+   * via `location.directory`).
+   *
+   * Returns the pending questions on success, or `null` on any failure
+   * (network error, 4xx/5xx response, missing/unexpected payload, or a
+   * pre-1.18 server without the V2 endpoint) so the caller can use the
+   * V1 `question.list` path unchanged. Each item is validated minimally
+   * (string `id`/`sessionID`, array `questions`) before being accepted —
+   * any malformed item fails the whole V2 attempt conservatively.
+   */
+  private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
+    try {
+      const response = await this.client.v2.question.request.list(
+        directory ? { location: { directory } } : undefined,
+      );
+      // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
+      // payload nests the array under its own `data` field.
+      if (response.error !== undefined) return null;
+      const items = response.data?.data;
+      if (!Array.isArray(items)) return null;
+      const validated: QuestionRequest[] = [];
+      for (const item of items) {
+        const parsed = parseQuestionV2Item(item);
+        // Malformed item: reject the whole V2 attempt conservatively — the
+        // caller falls back to V1 instead of returning partial data.
+        if (!parsed) return null;
+        validated.push(parsed);
+      }
+      return validated;
+    } catch {
+      // Network failure, pre-V2 server, or runtimeFetch throwing → fall back.
+      return null;
+    }
   }
 
   // Configuration

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1,6 +1,8 @@
 import type { ContextPartMetadata } from '@/lib/messages/contextParts';
 import { createOpencodeClient, OpencodeClient } from "@opencode-ai/sdk/v2";
 import type { PermissionV2Request, PermissionV2Effect, PermissionV2Source } from "@opencode-ai/sdk/v2/client";
+import type { QuestionV2Request } from "@opencode-ai/sdk/v2/client";
+import { z } from 'zod';
 import type { FilesAPI } from "../api/types";
 import { getDesktopHomeDirectory } from "../desktop";
 import type {
@@ -72,26 +74,58 @@ type SdkResult<T> = {
 type DirectoryAvailability = "available" | "missing" | "unknown";
 
 /**
- * Runtime guard for one native V2 question item before it crosses into the
- * shared `QuestionRequest` contract. The SDK types the payload, but the
+ * Parses one native V2 question item before it crosses into the shared
+ * `QuestionRequest` contract. The SDK types the payload, but the
  * pending-question UI treats this read as authoritative, so a misbehaving
- * server must fail over to V1 instead of surfacing malformed items.
- * Mirrors the minimal per-item checks the V1 merge loop already applies.
+ * server must fail over to V1 instead of surfacing malformed items. The
+ * schema validates every field the UI-consumed shape actually carries
+ * (see `QuestionRequest` consumers) — values are mapped fresh from the
+ * parsed payload, nothing is passed through unvalidated.
  */
-const parseQuestionV2Item = (value: unknown): QuestionRequest | null => {
-  if (!value || typeof value !== 'object') return null;
-  // SAFETY: shape probe only — each field below is re-validated before it
-  // is copied into the trusted contract.
-  const candidate = value as Partial<QuestionRequest>;
-  if (typeof candidate.id !== 'string' || candidate.id.length === 0) return null;
-  if (typeof candidate.sessionID !== 'string') return null;
-  if (!Array.isArray(candidate.questions)) return null;
-  return {
-    id: candidate.id,
-    sessionID: candidate.sessionID,
-    questions: candidate.questions,
-    tool: candidate.tool,
+const questionV2ItemSchema = z.object({
+  id: z.string().min(1),
+  sessionID: z.string(),
+  questions: z.array(
+    z.object({
+      question: z.string(),
+      header: z.string(),
+      options: z.array(
+        z.object({
+          label: z.string(),
+          description: z.string(),
+        }),
+      ),
+      multiple: z.boolean().optional(),
+    }),
+  ),
+  tool: z
+    .object({
+      messageID: z.string(),
+      callID: z.string(),
+    })
+    .optional(),
+});
+
+const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
+  const parsed = questionV2ItemSchema.safeParse(item);
+  if (!parsed.success) return null;
+  const request: QuestionRequest = {
+    id: parsed.data.id,
+    sessionID: parsed.data.sessionID,
+    questions: parsed.data.questions.map((question) => ({
+      question: question.question,
+      header: question.header,
+      multiple: question.multiple,
+      options: question.options.map((option) => ({
+        label: option.label,
+        description: option.description,
+      })),
+    })),
   };
+  if (parsed.data.tool) {
+    request.tool = parsed.data.tool;
+  }
+  return request;
 };
 
 const isMissingDirectoryError = (error: unknown): boolean => {
@@ -1517,9 +1551,9 @@ class OpencodeService {
    * Returns the pending questions on success, or `null` on any failure
    * (network error, 4xx/5xx response, missing/unexpected payload, or a
    * pre-1.18 server without the V2 endpoint) so the caller can use the
-   * V1 `question.list` path unchanged. Each item is validated minimally
-   * (string `id`/`sessionID`, array `questions`) before being accepted —
-   * any malformed item fails the whole V2 attempt conservatively.
+   * V1 `question.list` path unchanged. Each item is schema-validated
+   * before being accepted (see {@link parseQuestionV2Item}) — any
+   * malformed item fails the whole V2 attempt conservatively.
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
     try {

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -128,6 +128,24 @@ const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null =>
   return request;
 };
 
+/**
+ * Warn once per process per failure kind for V2 question-read fallbacks
+ * that are NOT the expected pre-V2 404 compat path, so a same-version
+ * upstream contract break cannot silently degrade question reads to V1
+ * forever (see {@link fetchPendingQuestionsV2} for the transition plan).
+ */
+const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
+const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
+  if (questionsV2WarnedKinds.has(kind)) return;
+  questionsV2WarnedKinds.add(kind);
+  console.warn(`[questions-v2] ${kind}: ${detail}`);
+};
+
+/** Clear the once-per-process V2 fallback warnings between tests. */
+export const resetQuestionsV2FallbackWarningsForTests = (): void => {
+  questionsV2WarnedKinds.clear();
+};
+
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
     return error.reason === "not-found" || error.reason === "not-directory";
@@ -1548,12 +1566,21 @@ class OpencodeService {
    * `question.request.list` (unscoped for global pending items, or scoped
    * via `location.directory`).
    *
-   * Returns the pending questions on success, or `null` on any failure
-   * (network error, 4xx/5xx response, missing/unexpected payload, or a
-   * pre-1.18 server without the V2 endpoint) so the caller can use the
-   * V1 `question.list` path unchanged. Each item is schema-validated
-   * before being accepted (see {@link parseQuestionV2Item}) — any
-   * malformed item fails the whole V2 attempt conservatively.
+   * Returns the pending questions on success, or `null` on failure so the
+   * caller can use the V1 `question.list` path unchanged. Each item is
+   * schema-validated before being accepted (see {@link parseQuestionV2Item})
+   * — any malformed item fails the whole V2 attempt conservatively.
+   *
+   * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
+   * malformed payload with a 200 status) are warned once per process per
+   * failure kind before the silent `null` fallback — read-only fallback is
+   * transitional, not a standing behavior.
+   *
+   * Removal condition: this V1 fallback is transitional. End-state is
+   * capability selection via runtime protocol detection (`openCodeProtocol`
+   * from `/health`, infra tracked in #3007, separate follow-up), or
+   * removal of the V1 path once the supported-runtime policy sets a
+   * minimum OpenCode version. Reference: #3259.
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
     try {
@@ -1562,20 +1589,51 @@ class OpencodeService {
       );
       // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
       // payload nests the array under its own `data` field.
-      if (response.error !== undefined) return null;
+      if (response.error !== undefined) {
+        const status = response.response?.status;
+        // A server-confirmed 404 is the expected pre-V2 route-miss compat
+        // path — silent fallback. Any other failure (5xx, auth/contract
+        // drift) must not degrade to V1 invisibly, so warn (once per kind).
+        if (status === 404) return null;
+        warnQuestionsV2FallbackOnce(
+          status === undefined ? 'network-error' : 'server-error',
+          `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
+        );
+        return null;
+      }
       const items = response.data?.data;
-      if (!Array.isArray(items)) return null;
+      if (!Array.isArray(items)) {
+        // Same-version contract drift: 200 status but a payload the typed
+        // SDK path no longer matches. Warn, then fall back to V1.
+        warnQuestionsV2FallbackOnce(
+          'malformed-payload',
+          'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
+        );
+        return null;
+      }
       const validated: QuestionRequest[] = [];
       for (const item of items) {
         const parsed = parseQuestionV2Item(item);
         // Malformed item: reject the whole V2 attempt conservatively — the
         // caller falls back to V1 instead of returning partial data.
-        if (!parsed) return null;
+        if (!parsed) {
+          warnQuestionsV2FallbackOnce(
+            'malformed-payload',
+            'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
+          );
+          return null;
+        }
         validated.push(parsed);
       }
       return validated;
-    } catch {
-      // Network failure, pre-V2 server, or runtimeFetch throwing → fall back.
+    } catch (error) {
+      // Network failure or runtimeFetch throwing → fall back. Never the
+      // provably-pre-V2 404 path (that responds with an error result, not a
+      // throw), so surface it once per kind.
+      warnQuestionsV2FallbackOnce(
+        'network-error',
+        `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
+      );
       return null;
     }
   }

--- a/packages/ui/src/lib/opencode/questions-v2.ts
+++ b/packages/ui/src/lib/opencode/questions-v2.ts
@@ -1,0 +1,172 @@
+/**
+ * Shared native V2 question-read helper (SDK 1.18.25 `Request2.list`).
+ *
+ * Lives in its own module so callers that receive an SDK client as a
+ * parameter (e.g. the sync/bootstrap layer) can use the V2 read without
+ * importing the `OpencodeService` facade — test files that partially mock
+ * `@/lib/opencode/client` must not break bootstrap's import graph
+ * (see #3259 unit-5 CI finding).
+ *
+ * Owned by #3266 (unit-2-questions-v2-read): the OpencodeService read path
+ * delegates to this helper, and #3288 (unit-5-questions-v2-bootstrap) builds
+ * the directory-bootstrap caller on top of this same module. Any change to
+ * V2 read semantics lands here first.
+ */
+import { z } from 'zod';
+import type { QuestionV2Request, OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { QuestionRequest } from "@/types/question";
+
+/**
+ * Parses one native V2 question item before it crosses into the shared
+ * `QuestionRequest` contract. The SDK types the payload, but the
+ * pending-question UI treats this read as authoritative, so a misbehaving
+ * server must fail over to V1 instead of surfacing malformed items. The
+ * schema validates every field the UI-consumed shape actually carries
+ * (see `QuestionRequest` consumers) — values are mapped fresh from the
+ * parsed payload, nothing is passed through unvalidated.
+ */
+const questionV2ItemSchema = z.object({
+  id: z.string().min(1),
+  sessionID: z.string(),
+  questions: z.array(
+    z.object({
+      question: z.string(),
+      header: z.string(),
+      options: z.array(
+        z.object({
+          label: z.string(),
+          description: z.string(),
+        }),
+      ),
+      multiple: z.boolean().optional(),
+    }),
+  ),
+  tool: z
+    .object({
+      messageID: z.string(),
+      callID: z.string(),
+    })
+    .optional(),
+});
+
+const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
+  const parsed = questionV2ItemSchema.safeParse(item);
+  if (!parsed.success) return null;
+  const request: QuestionRequest = {
+    id: parsed.data.id,
+    sessionID: parsed.data.sessionID,
+    questions: parsed.data.questions.map((question) => ({
+      question: question.question,
+      header: question.header,
+      multiple: question.multiple,
+      options: question.options.map((option) => ({
+        label: option.label,
+        description: option.description,
+      })),
+    })),
+  };
+  if (parsed.data.tool) {
+    request.tool = parsed.data.tool;
+  }
+  return request;
+};
+
+/**
+ * Warn once per process per failure kind for V2 question-read fallbacks
+ * that are NOT the expected pre-V2 404 compat path, so a same-version
+ * upstream contract break cannot silently degrade question reads to V1
+ * forever (see {@link listPendingQuestionsViaV2} for the transition plan).
+ */
+const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
+const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
+  if (questionsV2WarnedKinds.has(kind)) return;
+  questionsV2WarnedKinds.add(kind);
+  console.warn(`[questions-v2] ${kind}: ${detail}`);
+};
+
+/** Clear the once-per-process V2 fallback warnings between tests. */
+export const resetQuestionsV2FallbackWarningsForTests = (): void => {
+  questionsV2WarnedKinds.clear();
+};
+
+/**
+ * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
+ * `question.request.list` (unscoped for global pending items, or scoped
+ * via `location.directory`) on any SDK client instance, so both the
+ * `OpencodeService` read path and the directory bootstrap read path share
+ * one authoritative implementation (see #3259 unit-2 / unit-5).
+ *
+ * Returns the pending questions on success, or `null` on failure so the
+ * caller can use the V1 `question.list` path unchanged. Each item is
+ * schema-validated before being accepted (see {@link parseQuestionV2Item})
+ * — any malformed item fails the whole V2 attempt conservatively.
+ *
+ * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
+ * malformed payload with a 200 status) are warned once per process per
+ * failure kind before the silent `null` fallback — read-only fallback is
+ * transitional, not a standing behavior.
+ *
+ * Removal condition: this V1 fallback is transitional. End-state is
+ * capability selection via runtime protocol detection (`openCodeProtocol`
+ * from `/health`, infra tracked in #3007, separate follow-up), or
+ * removal of the V1 path once the supported-runtime policy sets a
+ * minimum OpenCode version. Reference: #3259.
+ */
+export async function listPendingQuestionsViaV2(
+  sdk: Pick<OpencodeClient, 'v2'>,
+  directory?: string,
+): Promise<QuestionRequest[] | null> {
+  try {
+    const response = await sdk.v2.question.request.list(
+      directory ? { location: { directory } } : undefined,
+    );
+    // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
+    // payload nests the array under its own `data` field.
+    if (response.error !== undefined) {
+      const status = response.response?.status;
+      // A server-confirmed 404 is the expected pre-V2 route-miss compat
+      // path — silent fallback. Any other failure (5xx, auth/contract
+      // drift) must not degrade to V1 invisibly, so warn (once per kind).
+      if (status === 404) return null;
+      warnQuestionsV2FallbackOnce(
+        status === undefined ? 'network-error' : 'server-error',
+        `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
+      );
+      return null;
+    }
+    const items = response.data?.data;
+    if (!Array.isArray(items)) {
+      // Same-version contract drift: 200 status but a payload the typed
+      // SDK path no longer matches. Warn, then fall back to V1.
+      warnQuestionsV2FallbackOnce(
+        'malformed-payload',
+        'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
+      );
+      return null;
+    }
+    const validated: QuestionRequest[] = [];
+    for (const item of items) {
+      const parsed = parseQuestionV2Item(item);
+      // Malformed item: reject the whole V2 attempt conservatively — the
+      // caller falls back to V1 instead of returning partial data.
+      if (!parsed) {
+        warnQuestionsV2FallbackOnce(
+          'malformed-payload',
+          'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
+        );
+        return null;
+      }
+      validated.push(parsed);
+    }
+    return validated;
+  } catch (error) {
+    // Network failure or runtimeFetch throwing → fall back. Never the
+    // provably-pre-V2 404 path (that responds with an error result, not a
+    // throw), so surface it once per kind.
+    warnQuestionsV2FallbackOnce(
+      'network-error',
+      `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Final disposition

Closed as superseded by the #3259 selected-runtime architecture.

The production implementation in this PR belongs to the old mixed-runtime migration model and will not be merged.

Preserved:
- `listPendingQuestions` unscoped + per-directory fan-out, merge, and id-dedupe semantics — ported (rewritten as V1-only tests against current main) into test-only salvage PR **#3439** (`client.questions.test.ts`)
- zod item schema, malformed-item, 200 + non-array payload, contract-drift, failure-classification, and warn-once diagnosability tests — recorded in #3259 `Post-hybrid salvage manifest` (verification items Q1–Q3, Q8) as deferred adapter-seam tests; a failed/malformed authoritative read must not masquerade as empty success

Disposition:
- production path (`questions-v2.ts` helper, direct `client.v2` question read, V2→V1 fallback, warn-and-fallback path): **dropped** — duplicates #3007's `question.list` adapter seam and contradicts selected-runtime authority (no cross-runtime fallback)
- main-independent tests: **ported to #3439** (tests only, CI green)
- adapter-specific tests/evidence: **recorded in #3259 for future user-owned corrective work**
- #3007 remains external/read-only and was not modified

Historical implementation details below are retained as engineering evidence.
## Architecture status

> **PROPOSED / SELECTED FOR #3259 — not maintainer-approved policy.**
>
> This PR was implemented under the superseded capability-by-capability #3259 migration model (V2-first read with a V1 fallback inside one mixed runtime).
>
> Under the current #3259 dual-runtime proposal (Stable/V1 and opt-in Beta/V2 as mutually exclusive selected runtimes, no cross-runtime authority fallback), this production diff is NOT mergeable as-is:
>
> - The V2-then-V1 read fallback contradicts the selected-runtime authority rule: on a V2-selected runtime a failed V2 read must surface as `V2 UNSUPPORTED`/`BLOCKED`, never silently fall back to V1 authority.
> - Current #3007 (`feat/opencode-v2-compat` @ `5a424cf7`) already implements the V2 question-read authority behind the existing OpenChamber `question.list` application contract (`question.list` adapter → `v2.form.request.list` → `normalizeQuestion`), including form→session mapping for replies and `form.created/replied/cancelled` → `question.asked/replied/rejected` event translation. A second direct-V2 read path in shared UI would duplicate that adapter seam.
>
> The branch remains open as engineering evidence while its tests, contract audits, and reusable pieces are reconciled with the selected runtime foundation and the #3007 adapter work. Do not infer maintainer rejection or project-wide architectural approval from this status.

### Overlap with current #3007 (2026-09-03 audit)

Current #3007 provides, behind one adapter seam (`createOpencode2Adapter` wrapping the SDK client):

- `question.list` → `v2.form.request.list` + `normalizeQuestion` (V2-backed read under the V1 contract)
- `question.reply` / `question.reject` → requestID→form session mapping, `v2.form.reply/cancel`, explicit `QuestionNotFoundError` preservation, no cross-runtime resend
- event translation `form.created → question.asked`, `form.replied → question.replied`, `form.cancelled → question.rejected`

If the selected V2 runtime is exposed through that adapter, `OpencodeService.listPendingQuestions` needs no direct-V2 read helper at all — the existing V1-shaped call becomes V2-backed. This PR's `questions-v2.ts` helper is therefore a superseded second path, not a foundation prerequisite.

**Evidence worth salvaging regardless:** the zod item schema, malformed-payload tests, 200-with-non-array contract-drift tests, failure-classification tests, warn-once diagnosability, and the consumer-contract/failure tests in `client.questions.test.ts` — these should eventually validate the one chosen adapter boundary (#3007-style), not a per-capability branch.

---

## Historical implementation record

Everything below this point describes the pre-reconciliation implementation and its then-current HEADs and bases. Where this historical record conflicts with the Architecture status section above, the Architecture status section is authoritative.

## Intent

Migration unit #2 (tracking #3259): adopt the **native OpenCode V2 questions read path** in `listPendingQuestions` while preserving production behavior through a guarded V1 fallback. Native stock V2 — no fabricated semantics, no V1-shaped emulation; pure mapping of an existing V2 contract. (Note: #1982's permission work is precedent for adopting a specific native V2 primitive safely, not for a universal fallback pattern.)

Reads prefer `client.v2.question.request.list` (SDK 1.18.25), mapping `QuestionV2Request` items through a validated schema before they enter the trusted UI `QuestionRequest` contract. V2 read failures fall back to the existing V1 `question.list` path — the fallback is transitional and failure-class aware (see the Architecture correction below): silent only for pre-V2 route-miss 404s; network/5xx/malformed failures emit a one-time warning before falling back. Unscoped + per-directory fan-out, merge, and id-dedupe semantics unchanged.

## Non-goals

- Reply/reject V2 adoption (V2 replies require `sessionID`; call-site semantics differ). Next unit (#3259).
- `EventQuestionV2*` event-reducer handling for live V2 question updates. Next unit (#3259).
- Removal of the `listAgents` `/api/agent` fallback (blocker recorded in #3259: fallback masks a current `app.agents` empty-response behavior on some runtimes; no upstream evidence it is fixed).
- No changes to `bootstrap` signatures, permission paths, or any other capability.

## Affected surfaces

- `packages/ui` shared UI (web, Electron, VS Code, mobile — all import the same `client.ts` wrapper).
- OpenCode API surface used: `GET` via `client.v2.question.request.list` (V2), existing `client.question.list` (V1 fallback, untouched).
- No persisted contracts change; no server routes change; no UI components change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariants | Never let fetch failure masquerade as authoritative empty success | V2 failure → V1 fallback, never fabricated data; empty array is a valid V2 success only when all items validate |
| openchamber-change-discipline skill | Source change in shared UI | Single-file production change in the owning integration boundary (`lib/opencode/client.ts`); focused validation; no unrelated cleanup |
| ui-api-decoupling | Shared UI data access via OpenCode SDK | Uses `client.v2.*` through the existing facade; no new RuntimeAPIs/transport |
| DOCUMENTATION (sync) | Question sync reads flow through this client wrapper | Behavior-preserving wrapper change; no sync-contract change |

## Validation

| Check | Result |
|---|---|
| Focused suites (`client.test.ts`, `client.permission.test.ts`, `client.questions.test.ts` — bun test) | 21 pass / 0 fail at corrective head 751ea6d4e (incl. +1 200-with-non-array-payload test covering the contract-drift branch the helper already handles; +3 failure-classification tests at 09855ea1f; was 17 at pre-corrective head 235adadd3) |
| Shared-helper extraction (commit 751ea6d4e) | `packages/ui/src/lib/opencode/questions-v2.ts` now owns the V2 read semantics (zod schema, parser, failure classifier, warn-once set, `resetQuestionsV2FallbackWarningsForTests`); `client.ts` keeps a thin `fetchPendingQuestionsV2` facade that delegates to `listPendingQuestionsViaV2(this.client, directory)`. Both production callers (`OpencodeService.listPendingQuestions` here, `bootstrapDirectory` in #3288) share one authoritative implementation. |
| Regression sweep (question-recovery, bootstrap, child-store, session-actions, session-switch-resync) | 95 pass / 1 fail — the 1 fail is a pre-existing upstream module-load error in `session-switch-resync.test.ts` (missing `isGlobalSessionRecencyOnlyUpdate` export), byte-identical on a clean `upstream/main` worktree; not caused by this change |
| `bun run type-check` (packages/ui) | 5 errors — all pre-existing codemirror `languageByExtension.ts` duplicates; 0 new |
| `bunx oxlint packages/ui/src/lib/opencode/client.ts` | 159 findings, exactly the pre-existing baseline; 0 in authored code |
| `bun run dead-code` | no new findings |

**Baseline before change:** identical suites green on the effective base (upstream/main `0e3aff884`) before edits; sole failure attributed to upstream via detached-worktree baseline run.

**Not runtime-verified against a live OpenCode V2 server:** the V2 list endpoint is validated by generated SDK contract (1.18.25) and tests; behavior against a live `opencode serve` session was not exercised in CI-style harness. Report from the maintainer's runtime validation if needed.

## Visual evidence

No user-visible change by itself: on a healthy V2 backend the returned question list is identical (same shape, same merge/dedupe); on V2 failure the V1 path returns the same list (pre-V2 404s silently; other failure classes emit a one-time console warning for diagnosability). Rendered UI is unchanged — this PR only swaps the data source for the same list.

## Risks and failure behavior

- Failure mode: 404 route-miss (pre-V2 server) → silent V1 fallback (compatibility path); network/5xx/malformed → one-time-per-process `[questions-v2]` warning, then V1 fallback; never fabricated data. See Architecture correction below.
- Version compatibility: `v2.question.request.list` present in SDK 1.18.25 (verified in installed `dist/v2/gen/sdk.gen.d.ts`); older servers pre-dating the endpoint will 404 → fallback engaged.
- Rollback: revert single commit; no data migration, no contract change.
- Cross-runtime: shared `packages/ui` code path only; runtime-specific adapters untouched.

---

### Architecture correction (corrective review pass)

A corrective review modified this PR before merge: the read fallback is **transitional and now failure-class aware**.

- 404 with a response (pre-V2 route miss) remains the only *silent* fallback (expected compatibility path).
- Network throw, 5xx, and malformed-but-200 payloads each emit a one-time-per-process warning (`[questions-v2] <kind>`) before falling back, so a same-version contract drift can no longer silently degrade to V1 forever.
- **#1982 framing corrected**: #1982 did not establish a universal per-call try-V2→V1-fallback rule. (Later note, 2026-09-03 source audit: #1982's pre-check itself was reclassified in #3259 as COMPETING AUTHORITY on Stable/V1 — the V2 `session.permission.get` it consults is backed by a separate pending map from the V1 permission producer, so it is no longer cited as a safe pattern. See the #1982 section of #3259.)
- **Removal condition** (documented in code): capability selection via runtime protocol detection (`openCodeProtocol`, #3007) or a supported-min-version policy; see #3259.

---

### Migration tracking (#3259)

```text
Tracking: #3259

Depends on:
none (this PR is the prerequisite for #3288)

Effective base:
main @ 85a95bb8ebf509749695bec29feedcf03a893e0a

Required merge order:
#3266 → #3288
```

#3288 is now a true dependent on this PR: rebased onto `751ea6d4e`, its reviewer-visible incremental delta over this PR is **1 commit on `bootstrap.ts` + `bootstrap.test.ts` only** (+128 / -9). The shared V2 read helper (`packages/ui/src/lib/opencode/questions-v2.ts`) lives in exactly one place from this PR forward; no follow-up deduplication commit is required at merge time.

Effective base (for reviewer reference):

```text
main (upstream): 85a95bb8e (current; this PR's reviewed base 0e3aff884 is one commit behind — server-side security fix only, no overlap with changed files in this PR)
SDK: @opencode-ai/sdk 1.18.25
```

Existing overlap:

```text
#3007 @ 5a424cf7 — OVERLAP SUPERSEDED THIS PR (2026-09-03 audit: #3007's adapter already maps `question.list` → `v2.form.request.list` + `normalizeQuestion`, i.e. it owns the V2 question-read authority behind the existing OpenChamber contract; the historical note below claiming UNRELATED-SEMANTICS / no semantic duplication predates that audit and is superseded — see Architecture status above)
#1982 @ 4348642f8f (merged) — pattern reference for V2-primitive adoption; NOT a fallback-precedent (corrected framing per #3259)
#3055, #3195 — unrelated (queue/busy-path domain)
#3288 @ 45c40a54d — DEPENDENT (rebased onto this PR; directory-bootstrap caller is the only incremental delta; uses this PR's `listPendingQuestionsViaV2` export directly; no duplication, no follow-up deduplication commit needed)
```

Reuse strategy: `PATTERN-REUSE` (#1982 template). No foreign commits reused (cherry-pick: none).

### V2 purity statement

- Native stock V2: `client.v2.question.request.list({ location: { directory } })` from generated SDK 1.18.25 (`Request2.list`, `V2QuestionRequestListResponses: { data: QuestionV2Request[] }`).
- Mapping existing semantics only; nothing fabricated; V2 404 (pre-V2) ⇒ silent V1 fallback; other V2 failures ⇒ one-time warn + V1 fallback (transitional, removal condition documented).



