### PR TITLE
feat(questions): adopt native V2 reply/reject and V2 question event handling

### DIFF
--- a/packages/ui/src/sync/DOCUMENTATION.md
+++ b/packages/ui/src/sync/DOCUMENTATION.md
@@ -415,6 +415,7 @@ Keep this in sync with `handleDirectoryEvent` in `sync-context.tsx`:
 | `vcs.branch.updated` | (none — mutates `draft.vcs` directly) |
 | `permission.asked/replied` | `permission` |
 | `question.asked/replied/rejected` | `question` |
+| `question.v2.asked/replied/rejected` | `question` |
 | `lsp.updated` | `lsp` |
 
 ### Directory-less session events

--- a/packages/ui/src/sync/__tests__/event-reducer.test.ts
+++ b/packages/ui/src/sync/__tests__/event-reducer.test.ts
@@ -1,8 +1,45 @@
 import { describe, expect, test } from "bun:test"
 import type { Session } from "@opencode-ai/sdk/v2"
-import type { Event, Message, Part, PermissionRequest, QuestionRequest, SessionStatus } from "@opencode-ai/sdk/v2/client"
+import type {
+  Event,
+  Message,
+  Part,
+  PermissionRequest,
+  QuestionRequest,
+  SessionStatus,
+} from "@opencode-ai/sdk/v2/client"
 import { applyDirectoryEvent } from "../event-reducer"
 import { INITIAL_STATE, type State } from "../types"
+
+// Fully-typed minimal V2 question fixtures: the reducer reads only
+// id/sessionID/requestID, and the SDK payload types require questions/answers
+// arrays and the envelope `id`, so no type assertions are needed.
+const questionRequest = (id: string, sessionID = "ses_1"): QuestionRequest => ({
+  id,
+  sessionID,
+  questions: [],
+})
+
+const questionAskedEvent = (
+  type: "question.asked" | "question.v2.asked",
+  id: string,
+): Event => ({
+  type,
+  id,
+  properties: questionRequest(id),
+})
+
+const questionRepliedEvent = (requestID: string): Event => ({
+  type: "question.v2.replied",
+  id: `evt_${requestID}`,
+  properties: { sessionID: "ses_1", requestID, answers: [] },
+})
+
+const questionRejectedEvent = (requestID: string): Event => ({
+  type: "question.v2.rejected",
+  id: `evt_${requestID}`,
+  properties: { sessionID: "ses_1", requestID },
+})
 
 function state(overrides: Partial<State> = {}): State {
   return {
@@ -343,6 +380,55 @@ describe("applyDirectoryEvent", () => {
     } as Event)
 
     expect(draft.question.ses_1).not.toBe(afterReply)
+    expect(draft.question.ses_1).toEqual([])
+  })
+
+  test("upserts question.v2.asked requests like the V1 asked event", () => {
+    const draft = state({ question: { ses_1: [questionRequest("ques_1")] } })
+
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_2"))).toBe(true)
+
+    expect(draft.question.ses_1.map((item) => item.id)).toEqual(["ques_1", "ques_2"])
+  })
+
+  test("question.v2.asked is idempotent — replaying the event does not duplicate", () => {
+    const draft = state()
+
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_1"))).toBe(true)
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_1"))).toBe(true)
+    expect(draft.question.ses_1.map((item) => item.id)).toEqual(["ques_1"])
+  })
+
+  test("dual-fire v1 + v2 asked for the same id stays a single pending entry", () => {
+    const draft = state()
+
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.asked", "ques_1"))).toBe(true)
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_1"))).toBe(true)
+
+    expect(draft.question.ses_1).toHaveLength(1)
+    // The V2 arrival replaces the stored record rather than appending a twin.
+    expect(draft.question.ses_1[0]?.id).toBe("ques_1")
+  })
+
+  test("removes pending requests on question.v2.replied and question.v2.rejected", () => {
+    const draft = state({ question: { ses_1: [questionRequest("ques_1"), questionRequest("ques_2")] } })
+
+    expect(applyDirectoryEvent(draft, questionRepliedEvent("ques_1"))).toBe(true)
+    expect(draft.question.ses_1.map((item) => item.id)).toEqual(["ques_2"])
+
+    expect(applyDirectoryEvent(draft, questionRejectedEvent("ques_2"))).toBe(true)
+    expect(draft.question.ses_1).toEqual([])
+  })
+
+  test("v2 removal events are no-ops for unknown requests and clear v1-asked entries too", () => {
+    const draft = state({ question: { ses_1: [questionRequest("ques_1")] } })
+
+    // Unknown request: no change, no array replacement.
+    expect(applyDirectoryEvent(draft, questionRepliedEvent("ques_missing"))).toBe(false)
+
+    // Dual-emission safety: the V2 terminal event resolves a request that was
+    // created by the V1 asked event.
+    expect(applyDirectoryEvent(draft, questionRepliedEvent("ques_1"))).toBe(true)
     expect(draft.question.ses_1).toEqual([])
   })
 })

--- a/packages/ui/src/sync/__tests__/event-reducer.test.ts
+++ b/packages/ui/src/sync/__tests__/event-reducer.test.ts
@@ -431,4 +431,19 @@ describe("applyDirectoryEvent", () => {
     expect(applyDirectoryEvent(draft, questionRepliedEvent("ques_1"))).toBe(true)
     expect(draft.question.ses_1).toEqual([])
   })
+
+  test("a late question.v2.asked after a terminal event re-registers the request", () => {
+    const draft = state()
+
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_1"))).toBe(true)
+    expect(applyDirectoryEvent(draft, questionRepliedEvent("ques_1"))).toBe(true)
+    expect(draft.question.ses_1).toEqual([])
+
+    // The reducer keeps no tombstone or last-status bookkeeping: asked is an
+    // unconditional upsert, so a replayed or late asked re-inserts after a
+    // terminal removal. This is intentional for the ordered SSE stream — it is
+    // what makes replayed asks self-harmless — never a stale-request guard.
+    expect(applyDirectoryEvent(draft, questionAskedEvent("question.v2.asked", "ques_1"))).toBe(true)
+    expect(draft.question.ses_1.map((item) => item.id)).toEqual(["ques_1"])
+  })
 })

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -549,7 +549,12 @@ export function applyDirectoryEvent(
       return false
     }
 
-    case "question.asked": {
+    case "question.asked":
+    // V2 asked events carry the identical property shape (`id`, `sessionID`,
+    // `questions`, optional `tool`) — the V1 `QuestionRequest` cast is exact.
+    // Same code path keeps dual-emission idempotent: a replace-upsert by id
+    // is a no-op for repeated asks regardless of which version fired.
+    case "question.v2.asked": {
       const question = event.properties as QuestionRequest
       const questions = draft.question[question.sessionID] ?? []
       const next = [...questions]
@@ -564,7 +569,12 @@ export function applyDirectoryEvent(
     }
 
     case "question.replied":
-    case "question.rejected": {
+    case "question.rejected":
+    // V2 replied/rejected carry the identical { sessionID, requestID } shape;
+    // removal by sessionID+requestID stays idempotent when the server emits
+    // both the V1 and V2 event for the same request.
+    case "question.v2.replied":
+    case "question.v2.rejected": {
       const props = event.properties as { sessionID: string; requestID: string }
       const questions = draft.question[props.sessionID]
       if (!questions) return false

--- a/packages/ui/src/sync/event-reducer.ts
+++ b/packages/ui/src/sync/event-reducer.ts
@@ -550,11 +550,11 @@ export function applyDirectoryEvent(
     }
 
     case "question.asked":
-    // V2 asked events carry the identical property shape (`id`, `sessionID`,
-    // `questions`, optional `tool`) — the V1 `QuestionRequest` cast is exact.
-    // Same code path keeps dual-emission idempotent: a replace-upsert by id
-    // is a no-op for repeated asks regardless of which version fired.
     case "question.v2.asked": {
+      // V2 asked events carry the identical property shape (`id`, `sessionID`,
+      // `questions`, optional `tool`) — the V1 `QuestionRequest` cast is exact.
+      // Same code path keeps dual-emission idempotent: a replace-upsert by id
+      // is a no-op for repeated asks regardless of which version fired.
       const question = event.properties as QuestionRequest
       const questions = draft.question[question.sessionID] ?? []
       const next = [...questions]
@@ -570,11 +570,11 @@ export function applyDirectoryEvent(
 
     case "question.replied":
     case "question.rejected":
-    // V2 replied/rejected carry the identical { sessionID, requestID } shape;
-    // removal by sessionID+requestID stays idempotent when the server emits
-    // both the V1 and V2 event for the same request.
     case "question.v2.replied":
     case "question.v2.rejected": {
+      // V2 replied/rejected carry the identical { sessionID, requestID } shape;
+      // removal by sessionID+requestID stays idempotent when the server emits
+      // both the V1 and V2 event for the same request.
       const props = event.properties as { sessionID: string; requestID: string }
       const questions = draft.question[props.sessionID]
       if (!questions) return false

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -65,8 +65,10 @@ const v2QuestionSdkResult = (behavior: "ok" | "throw" | { status: number; body?:
     // Transport drop after dispatch: raw fetch error, no response object.
     return { error: new TypeError("Failed to fetch"), response: undefined }
   }
-  // HTTP error branch: jsonError ?? textError, response attached.
-  return { error: behavior.body, response: { status: behavior.status } }
+  // HTTP error branch: jsonError ?? textError, response attached. The real
+  // SDK's error interceptors also coerce falsy errors to `{}` (finalError =
+  // finalError || {}), so an empty body arrives as an object, not a string.
+  return { error: behavior.body || {}, response: { status: behavior.status } }
 }
 
 const mockScopedClient = {
@@ -2336,6 +2338,29 @@ describe("native V2 question reply/reject with classified V1 fallback", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
+  test("V2 reply 404 (structured SessionNotFoundError) falls back to the V1 call with the same answers and directory", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // A SessionNotFoundError body is the same not-admitted class as
+    // QuestionNotFoundError: a V2 handler answered and provably did not
+    // mutate the request, so the V1 fallback is safe.
+    v2QuestionReplyBehavior = { status: 404, body: { _tag: "SessionNotFoundError", message: "Session not found" } }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await respondToQuestion("session-a", "q-1", [["Yes"]])
+
+    expect(replyCalls.filter((call) => call.method === "question.v2.reply")).toHaveLength(1)
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-1")
+    expect(v1Calls[0].params.answers).toEqual([["Yes"]])
+    expect(v1Calls[0].params.directory).toBe("/test/project")
+    // The V1 fallback answered successfully, so pending state clears.
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
   test("V2 reply 404 with an unparseable pre-V2 body (route miss) also falls back to V1", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
@@ -2351,6 +2376,78 @@ describe("native V2 question reply/reject with classified V1 fallback", () => {
     expect(v1Calls).toHaveLength(1)
     expect(v1Calls[0].params.answers).toEqual([["Yes"]])
     expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reply 404 with an empty body (SDK-coerced to {}) does NOT fall back and surfaces the rejected error with status 404", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // The SDK's error interceptors coerce a falsy error to `{}` (finalError =
+    // finalError || {}), so an empty body is a parsed object, not route-miss
+    // evidence — the V1 fallback must not run.
+    v2QuestionReplyBehavior = { status: 404, body: "" }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(404)
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    // A parsed rejection is not a stale-request signal: pending state stays
+    // for the user to retry, not cleared optimistically.
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reply 404 with a structured unrelated-tag body does NOT fall back and surfaces the rejected error with status 404", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // A parsed JSON body with a non-not-found `_tag` proves a V2 handler
+    // answered and rejected the request for an unrelated reason — not
+    // provably not-admitted, so the V1 fallback must not run.
+    v2QuestionReplyBehavior = { status: 404, body: { _tag: "SomeOtherError", message: "nope" } }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(404)
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    // A parsed rejection is not a stale-request signal: pending state stays
+    // for the user to retry, not cleared optimistically.
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reply 404 with a structured body lacking a not-found tag does NOT fall back and surfaces the rejected error with status 404", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // A parsed JSON body without any `_tag` is still a structured server
+    // answer, not route-miss evidence — no fallback.
+    v2QuestionReplyBehavior = { status: 404, body: { message: "not found" } }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(404)
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
   })
 
   test("V2 reply fetch-throw (transport drop) does NOT fall back and throws the ambiguous-tagged error", async () => {
@@ -2495,6 +2592,48 @@ describe("native V2 question reply/reject with classified V1 fallback", () => {
     const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
     expect(v1Calls).toHaveLength(1)
     expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reject 404 with a structured unrelated-tag body does NOT fall back and surfaces the rejected error with status 404", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // Same split as reply: a parsed JSON body with a non-not-found `_tag` is
+    // a server rejection, not provably-not-admitted route-miss evidence.
+    v2QuestionRejectBehavior = { status: 404, body: { _tag: "SomeOtherError", message: "nope" } }
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(404)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reject 404 with a structured body lacking a not-found tag does NOT fall back and surfaces the rejected error with status 404", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = { status: 404, body: { message: "not found" } }
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(404)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
   })
 
   test("V2 reject fetch-throw (transport drop) does NOT fall back and throws the ambiguous-tagged error", async () => {

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -25,6 +25,24 @@ const globalRemovedSessionIds: string[] = []
 const deletedCleanupIdentities: Array<{ runtimeKey: string; directory: string; sessionId: string }> = []
 const movedSessionDirectories: Array<{ sessionID: string; directory: string }> = []
 
+// Controls the V2 question surface on mockScopedClient. The default "throw"
+// models a pre-V2 server (route absent → SDK call throws) so existing V1
+// tests exercise the production fallback path unchanged; individual V2 tests
+// opt into "ok" or "error".
+let v2QuestionReplyBehavior: "throw" | "ok" | "error" = "throw"
+let v2QuestionRejectBehavior: "throw" | "ok" | "error" = "throw"
+
+// QuestionV2CallParams / QuestionV2SdkResult mirror the surface session-actions
+// consumes on `client.v2.session.question.reply/reject`: reply/reject take
+// { sessionID, requestID, questionV2Reply? } and answer 204 with no body
+// (RequestResult collapses that to `{ data: undefined, error: undefined }`).
+type QuestionV2CallParams = {
+  sessionID?: string
+  requestID?: string
+  questionV2Reply?: { answers: string[][] }
+}
+type QuestionV2SdkResult = { data?: undefined; error?: { message?: string }; response?: { status?: number } }
+
 const mockScopedClient = {
   permission: {
     reply: mock((params: Record<string, unknown>) => {
@@ -51,6 +69,33 @@ const mockScopedClient = {
       }
       return Promise.resolve({ data: true })
     }),
+  },
+  v2: {
+    session: {
+      question: {
+        reply: mock((params: QuestionV2CallParams): Promise<QuestionV2SdkResult> => {
+          if (v2QuestionReplyBehavior === "throw") {
+            throw new Error("v2 route missing (pre-V2 server)")
+          }
+          replyCalls.push({ method: "question.v2.reply", params })
+          if (v2QuestionReplyBehavior === "error") {
+            return Promise.resolve({ error: { message: "rejected" }, response: { status: 500 } })
+          }
+          // V2 reply answers 204 with no body (QuestionV2ReplyResponses.204 = void).
+          return Promise.resolve({ data: undefined, error: undefined })
+        }),
+        reject: mock((params: QuestionV2CallParams): Promise<QuestionV2SdkResult> => {
+          if (v2QuestionRejectBehavior === "throw") {
+            throw new Error("v2 route missing (pre-V2 server)")
+          }
+          replyCalls.push({ method: "question.v2.reject", params })
+          if (v2QuestionRejectBehavior === "error") {
+            return Promise.resolve({ error: { message: "rejected" }, response: { status: 500 } })
+          }
+          return Promise.resolve({ data: undefined, error: undefined })
+        }),
+      },
+    },
   },
 }
 
@@ -2189,5 +2234,154 @@ describe("dismissOpenPermissionsForSession", () => {
     } finally {
       console.error = originalError
     }
+  })
+})
+
+describe("native V2 question reply/reject with V1 fallback", () => {
+  beforeEach(() => {
+    replyCalls.length = 0
+    scopedClientDirectories.length = 0
+    questionReplyError = null
+    questionRejectError = null
+    v2QuestionReplyBehavior = "throw"
+    v2QuestionRejectBehavior = "throw"
+  })
+
+  const questionSessionStore = (questionId: string) => {
+    const question = buildQuestion(questionId, "session-a")
+    return createStore({}, {
+      session: [sessionFixture("session-a")],
+      question: { "session-a": [question] },
+    })
+  }
+
+  test("V2 reply success resolves through v2.session.question.reply and skips V1", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = "ok"
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await respondToQuestion("session-a", "q-1", [["Yes"]])
+
+    const v2Calls = replyCalls.filter((call) => call.method === "question.v2.reply")
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v2Calls).toHaveLength(1)
+    expect(v1Calls).toHaveLength(0)
+    // The V2 route is addressed by sessionID + requestID and carries the same
+    // normalized string[][] answers the V1 path sends.
+    expect(v2Calls[0].params).toEqual({
+      sessionID: "session-a",
+      requestID: "q-1",
+      questionV2Reply: { answers: [["Yes"]] },
+    })
+    // A confirmed V2 reply is authoritative: the pending request clears from
+    // the local store exactly as the V1 success path clears it.
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reply error falls back to the V1 call with the same answers and directory", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = "error"
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await respondToQuestion("session-a", "q-1", [["Yes"]])
+
+    expect(replyCalls.filter((call) => call.method === "question.v2.reply")).toHaveLength(1)
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-1")
+    expect(v1Calls[0].params.answers).toEqual([["Yes"]])
+    expect(v1Calls[0].params.directory).toBe("/test/project")
+    // The V1 fallback answered successfully, so pending state clears.
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reply throw (pre-V2 server) falls back to the V1 call", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await respondToQuestion("session-a", "q-1", [["Yes"]])
+
+    // The default behavior throws inside the SDK surface, so no V2 call is
+    // recorded; the V1 reply carries the same normalized answers.
+    expect(replyCalls.filter((call) => call.method === "question.v2.reply")).toHaveLength(0)
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.answers).toEqual([["Yes"]])
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reply 404 still falls back so the stale-request recovery path survives", async () => {
+    const store = questionSessionStore("q-stale")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = "error"
+    questionReplyError = Object.assign(new Error("question.reply failed (404): QuestionNotFoundError"), { status: 404 })
+
+    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await expect(respondToQuestion("session-a", "q-stale", [["Yes"]])).rejects.toThrow()
+    // The V1 fallback re-answered not-found, keeping the existing recovery:
+    // the stale entry clears and the reply surfaces as an error.
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reject success resolves through v2.session.question.reject and skips V1", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = "ok"
+
+    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await rejectQuestion("session-a", "q-1")
+
+    const v2Calls = replyCalls.filter((call) => call.method === "question.v2.reject")
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
+    expect(v2Calls).toHaveLength(1)
+    expect(v1Calls).toHaveLength(0)
+    expect(v2Calls[0].params).toEqual({ sessionID: "session-a", requestID: "q-1" })
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reject error falls back to the V1 call", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = "error"
+
+    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await rejectQuestion("session-a", "q-1")
+
+    expect(replyCalls.filter((call) => call.method === "question.v2.reject")).toHaveLength(1)
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-1")
+    expect(store.getState().question["session-a"]).toBe(undefined)
+  })
+
+  test("V2 reject throw (pre-V2 server) falls back to the V1 call", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+
+    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    await rejectQuestion("session-a", "q-1")
+
+    expect(replyCalls.filter((call) => call.method === "question.v2.reject")).toHaveLength(0)
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-1")
+    expect(store.getState().question["session-a"]).toBe(undefined)
   })
 })

--- a/packages/ui/src/sync/session-actions.test.ts
+++ b/packages/ui/src/sync/session-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test"
 import type { PermissionRequest } from "@/types/permission"
 import type { QuestionRequest } from "@/types/question"
+import { isAmbiguousTransportFailure } from "@/lib/relay/transport-error"
 
 // Mock SDK client that records permission.reply / question.reply calls
 const replyCalls: Array<{ method: string; params: Record<string, unknown> }> = []
@@ -25,23 +26,48 @@ const globalRemovedSessionIds: string[] = []
 const deletedCleanupIdentities: Array<{ runtimeKey: string; directory: string; sessionId: string }> = []
 const movedSessionDirectories: Array<{ sessionID: string; directory: string }> = []
 
-// Controls the V2 question surface on mockScopedClient. The default "throw"
-// models a pre-V2 server (route absent → SDK call throws) so existing V1
-// tests exercise the production fallback path unchanged; individual V2 tests
-// opt into "ok" or "error".
-let v2QuestionReplyBehavior: "throw" | "ok" | "error" = "throw"
-let v2QuestionRejectBehavior: "throw" | "ok" | "error" = "throw"
+// Controls the V2 question surface on mockScopedClient. The behaviors model
+// the real hey-api result shapes (SDK 1.18.25):
+//   - "ok"                    204 success → { data: undefined, error: undefined, response: { status: 204 } }
+//   - "throw"                 the SDK call itself throws (transport drop / old SDK) → caught = no response evidence
+//   - { status, body }        an HTTP error response → { error: body, response: { status } }
+// (body `undefined` with a response models the hey-api catch path: fetch threw
+// after dispatch, so `response` is undefined.) The default is the structured
+// 404 a V2 server answers for a not-found request — the not-admitted class
+// that justifies the V1 fallback the older V1-path tests rely on.
+const V2_STRUCTURED_404 = {
+  status: 404,
+  body: { _tag: "QuestionNotFoundError", requestID: "q-1", message: "Question request not found" },
+} as const
+const V2_ROUTE_MISS_404 = { status: 404, body: "<html>404 Not Found</html>" } as const
+let v2QuestionReplyBehavior: "ok" | "throw" | { status: number; body?: unknown; responseless?: true } = V2_STRUCTURED_404
+let v2QuestionRejectBehavior: "ok" | "throw" | { status: number; body?: unknown; responseless?: boolean } = V2_STRUCTURED_404
 
 // QuestionV2CallParams / QuestionV2SdkResult mirror the surface session-actions
 // consumes on `client.v2.session.question.reply/reject`: reply/reject take
 // { sessionID, requestID, questionV2Reply? } and answer 204 with no body
-// (RequestResult collapses that to `{ data: undefined, error: undefined }`).
+// (RequestResult collapses that to `{ data: undefined, error: undefined,
+// response }`); the hey-api catch path returns `{ error, response: undefined }`.
 type QuestionV2CallParams = {
   sessionID?: string
   requestID?: string
   questionV2Reply?: { answers: string[][] }
 }
-type QuestionV2SdkResult = { data?: undefined; error?: { message?: string }; response?: { status?: number } }
+type QuestionV2SdkResult = { data?: undefined; error?: unknown; response?: { status?: number } }
+
+const v2QuestionSdkResult = (behavior: "ok" | "throw" | { status: number; body?: unknown; responseless?: boolean }): QuestionV2SdkResult | null => {
+  if (behavior === "ok") {
+    // Hey-api 204 branch: data branch with the response still attached.
+    return { data: undefined, error: undefined, response: { status: 204 } }
+  }
+  if (behavior === "throw") return null
+  if (behavior.responseless) {
+    // Transport drop after dispatch: raw fetch error, no response object.
+    return { error: new TypeError("Failed to fetch"), response: undefined }
+  }
+  // HTTP error branch: jsonError ?? textError, response attached.
+  return { error: behavior.body, response: { status: behavior.status } }
+}
 
 const mockScopedClient = {
   permission: {
@@ -75,24 +101,19 @@ const mockScopedClient = {
       question: {
         reply: mock((params: QuestionV2CallParams): Promise<QuestionV2SdkResult> => {
           if (v2QuestionReplyBehavior === "throw") {
-            throw new Error("v2 route missing (pre-V2 server)")
+            throw new TypeError("Failed to fetch")
           }
           replyCalls.push({ method: "question.v2.reply", params })
-          if (v2QuestionReplyBehavior === "error") {
-            return Promise.resolve({ error: { message: "rejected" }, response: { status: 500 } })
-          }
-          // V2 reply answers 204 with no body (QuestionV2ReplyResponses.204 = void).
-          return Promise.resolve({ data: undefined, error: undefined })
+          // SAFETY: v2QuestionSdkResult builds exactly this mock result type.
+          return Promise.resolve(v2QuestionSdkResult(v2QuestionReplyBehavior) as QuestionV2SdkResult)
         }),
         reject: mock((params: QuestionV2CallParams): Promise<QuestionV2SdkResult> => {
           if (v2QuestionRejectBehavior === "throw") {
-            throw new Error("v2 route missing (pre-V2 server)")
+            throw new TypeError("Failed to fetch")
           }
           replyCalls.push({ method: "question.v2.reject", params })
-          if (v2QuestionRejectBehavior === "error") {
-            return Promise.resolve({ error: { message: "rejected" }, response: { status: 500 } })
-          }
-          return Promise.resolve({ data: undefined, error: undefined })
+          // SAFETY: v2QuestionSdkResult builds exactly this mock result type.
+          return Promise.resolve(v2QuestionSdkResult(v2QuestionRejectBehavior) as QuestionV2SdkResult)
         }),
       },
     },
@@ -1690,9 +1711,11 @@ describe("respondToQuestion passes directory", () => {
 
     await respondToQuestion("session-a", "q-1", [["answer1"]])
 
-    expect(replyCalls.length).toBe(1)
-    expect(replyCalls[0].params.requestID).toBe("q-1")
-    expect(replyCalls[0].params.directory).toBe("/test/project")
+    // The V2 attempt (structured 404 → fallback) precedes the V1 call.
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-1")
+    expect(v1Calls[0].params.directory).toBe("/test/project")
     expect(scopedClientDirectories).toEqual(["/test/project"])
   })
 
@@ -1742,9 +1765,11 @@ describe("rejectQuestion passes directory", () => {
 
     await rejectQuestion("session-a", "q-2")
 
-    expect(replyCalls.length).toBe(1)
-    expect(replyCalls[0].params.requestID).toBe("q-2")
-    expect(replyCalls[0].params.directory).toBe("/test/project")
+    // The V2 attempt (structured 404 → fallback) precedes the V1 call.
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
+    expect(v1Calls).toHaveLength(1)
+    expect(v1Calls[0].params.requestID).toBe("q-2")
+    expect(v1Calls[0].params.directory).toBe("/test/project")
   })
 })
 
@@ -1874,8 +1899,10 @@ describe("blocking request reply routing and stale recovery (issue OPE-236)", ()
     await respondToQuestion("session-wt", "q-wt", [["Yes"]])
 
     expect(scopedClientDirectories).toEqual(["/test/project/wt"])
-    expect(replyCalls[0]?.params.directory).toBe("/test/project/wt")
-    expect(replyCalls[0]?.params.requestID).toBe("q-wt")
+    // The V2 attempt (structured 404 → fallback) precedes the V1 reply.
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls[0]?.params.directory).toBe("/test/project/wt")
+    expect(v1Calls[0]?.params.requestID).toBe("q-wt")
   })
 
   test("routes permission replies by the request's own session directory", async () => {
@@ -1912,7 +1939,9 @@ describe("blocking request reply routing and stale recovery (issue OPE-236)", ()
     await respondToQuestion("session-a", "q-1", [["Yes"]])
 
     expect(scopedClientDirectories).toEqual(["/test/project"])
-    expect(replyCalls[0]?.params.directory).toBe("/test/project")
+    // The V2 attempt (structured 404 → fallback) precedes the V1 reply.
+    const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
+    expect(v1Calls[0]?.params.directory).toBe("/test/project")
   })
 
   test("enqueues settled-running-tool tail recovery when the question reply is not found", async () => {
@@ -2237,14 +2266,14 @@ describe("dismissOpenPermissionsForSession", () => {
   })
 })
 
-describe("native V2 question reply/reject with V1 fallback", () => {
+describe("native V2 question reply/reject with classified V1 fallback", () => {
   beforeEach(() => {
     replyCalls.length = 0
     scopedClientDirectories.length = 0
     questionReplyError = null
     questionRejectError = null
-    v2QuestionReplyBehavior = "throw"
-    v2QuestionRejectBehavior = "throw"
+    v2QuestionReplyBehavior = V2_STRUCTURED_404
+    v2QuestionRejectBehavior = V2_STRUCTURED_404
   })
 
   const questionSessionStore = (questionId: string) => {
@@ -2255,12 +2284,17 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     })
   }
 
+  const loadActions = async () => {
+    const { setActionRefs, respondToQuestion, rejectQuestion } = await import("./session-actions")
+    return { setActionRefs, respondToQuestion, rejectQuestion }
+  }
+
   test("V2 reply success resolves through v2.session.question.reply and skips V1", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
     v2QuestionReplyBehavior = "ok"
 
-    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    const { setActionRefs, respondToQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await respondToQuestion("session-a", "q-1", [["Yes"]])
@@ -2281,12 +2315,13 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
-  test("V2 reply error falls back to the V1 call with the same answers and directory", async () => {
+  test("V2 reply 404 (structured QuestionNotFoundError) falls back to the V1 call with the same answers and directory", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
-    v2QuestionReplyBehavior = "error"
+    // Default: structured NotFoundError body, response present — the class
+    // proving a V2 handler answered and the request provably did not mutate.
 
-    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    const { setActionRefs, respondToQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await respondToQuestion("session-a", "q-1", [["Yes"]])
@@ -2301,37 +2336,114 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
-  test("V2 reply throw (pre-V2 server) falls back to the V1 call", async () => {
+  test("V2 reply 404 with an unparseable pre-V2 body (route miss) also falls back to V1", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = V2_ROUTE_MISS_404
 
-    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    const { setActionRefs, respondToQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await respondToQuestion("session-a", "q-1", [["Yes"]])
 
-    // The default behavior throws inside the SDK surface, so no V2 call is
-    // recorded; the V1 reply carries the same normalized answers.
-    expect(replyCalls.filter((call) => call.method === "question.v2.reply")).toHaveLength(0)
+    expect(replyCalls.filter((call) => call.method === "question.v2.reply")).toHaveLength(1)
     const v1Calls = replyCalls.filter((call) => call.method === "question.reply")
     expect(v1Calls).toHaveLength(1)
     expect(v1Calls[0].params.answers).toEqual([["Yes"]])
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
-  test("V2 reply 404 still falls back so the stale-request recovery path survives", async () => {
-    const store = questionSessionStore("q-stale")
+  test("V2 reply fetch-throw (transport drop) does NOT fall back and throws the ambiguous-tagged error", async () => {
+    const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
-    v2QuestionReplyBehavior = "error"
-    questionReplyError = Object.assign(new Error("question.reply failed (404): QuestionNotFoundError"), { status: 404 })
+    v2QuestionReplyBehavior = "throw"
 
-    const { setActionRefs, respondToQuestion } = await import("./session-actions")
+    const { setActionRefs, respondToQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
-    await expect(respondToQuestion("session-a", "q-stale", [["Yes"]])).rejects.toThrow()
-    // The V1 fallback re-answered not-found, keeping the existing recovery:
-    // the stale entry clears and the reply surfaces as an error.
-    expect(store.getState().question["session-a"]).toBe(undefined)
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(caughtV2MutationError(thrown).v2QuestionMutationKind).toBe("ambiguous")
+    // SAFETY: the thrown value is whatever the action rejected with; the tag
+    // predicate accepts any input by design.
+    expect(isAmbiguousTransportFailure(thrown)).toBe(true)
+    // The V2 request may have been admitted: never replay it through V1.
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    // No response evidence → pending state is left for SSE/reconciliation to
+    // decide, not removed optimistically.
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reply responseless result (hey-api catch path) does NOT fall back and is tagged ambiguous", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    // The hey-api catch path returns a raw error with no response object —
+    // the same no-evidence class as a throw.
+    v2QuestionReplyBehavior = { status: 0, responseless: true }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    expect(caughtV2MutationError(thrown).v2QuestionMutationKind).toBe("ambiguous")
+    // SAFETY: the thrown value is whatever the action rejected with; the tag
+    // predicate accepts any input by design.
+    expect(isAmbiguousTransportFailure(thrown)).toBe(true)
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reply 400 does NOT fall back and surfaces the rejected error with its status", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = { status: 400, body: { _tag: "InvalidRequestError", message: "bad answers" } }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed).toBeInstanceOf(Error)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(400)
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+  })
+
+  test("V2 reply 500 does NOT fall back and surfaces the server-error-tagged error", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionReplyBehavior = { status: 500, body: { message: "kaboom" } }
+
+    const { setActionRefs, respondToQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await respondToQuestion("session-a", "q-1", [["Yes"]]).catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("server-error")
+    expect(typed.status).toBe(500)
+    // SAFETY: the thrown value is whatever the action rejected with; the tag
+    // predicate accepts any input by design.
+    expect(isAmbiguousTransportFailure(thrown)).toBe(true)
+    // Commit-before-fail window: a V1 resend could duplicate an admitted V2
+    // reply, so the fallback must never run.
+    expect(replyCalls.some((call) => call.method === "question.reply")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
   })
 
   test("V2 reject success resolves through v2.session.question.reject and skips V1", async () => {
@@ -2339,7 +2451,7 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     const childStores = createChildStores([["/test/project", store]])
     v2QuestionRejectBehavior = "ok"
 
-    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    const { setActionRefs, rejectQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await rejectQuestion("session-a", "q-1")
@@ -2352,12 +2464,13 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
-  test("V2 reject error falls back to the V1 call", async () => {
+  test("V2 reject 404 (structured QuestionNotFoundError) falls back to the V1 call", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
-    v2QuestionRejectBehavior = "error"
+    // Default structured 404 covers the not-admitted class; the fallback
+    // answered successfully, so pending state clears.
 
-    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    const { setActionRefs, rejectQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await rejectQuestion("session-a", "q-1")
@@ -2369,19 +2482,136 @@ describe("native V2 question reply/reject with V1 fallback", () => {
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
 
-  test("V2 reject throw (pre-V2 server) falls back to the V1 call", async () => {
+  test("V2 reject 404 with an unparseable pre-V2 body (route miss) also falls back", async () => {
     const store = questionSessionStore("q-1")
     const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = V2_ROUTE_MISS_404
 
-    const { setActionRefs, rejectQuestion } = await import("./session-actions")
+    const { setActionRefs, rejectQuestion } = await loadActions()
     setActionRefs(actionsSdk(), childStores, () => "/test/project")
 
     await rejectQuestion("session-a", "q-1")
 
-    expect(replyCalls.filter((call) => call.method === "question.v2.reject")).toHaveLength(0)
     const v1Calls = replyCalls.filter((call) => call.method === "question.reject")
     expect(v1Calls).toHaveLength(1)
-    expect(v1Calls[0].params.requestID).toBe("q-1")
     expect(store.getState().question["session-a"]).toBe(undefined)
   })
+
+  test("V2 reject fetch-throw (transport drop) does NOT fall back and throws the ambiguous-tagged error", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = "throw"
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    expect(caughtV2MutationError(thrown).v2QuestionMutationKind).toBe("ambiguous")
+    // SAFETY: the thrown value is whatever the action rejected with; the tag
+    // predicate accepts any input by design.
+    expect(isAmbiguousTransportFailure(thrown)).toBe(true)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reject 400 does NOT fall back and surfaces the rejected error with its status", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = { status: 400, body: { _tag: "InvalidRequestError", message: "bad request" } }
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(400)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+  })
+
+  test("V2 reject 401 does NOT fall back and surfaces the rejected error with its status", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = { status: 401, body: { _tag: "UnauthorizedError", message: "unauthorized" } }
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("rejected")
+    expect(typed.status).toBe(401)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+  })
+
+  test("V2 reject 500 does NOT fall back and surfaces the server-error-tagged error", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/test/project", store]])
+    v2QuestionRejectBehavior = { status: 500, body: { message: "kaboom" } }
+
+    const { setActionRefs, rejectQuestion } = await loadActions()
+    setActionRefs(actionsSdk(), childStores, () => "/test/project")
+
+    let thrown: CaughtV2MutationError | undefined
+    await rejectQuestion("session-a", "q-1").catch((error) => {
+      thrown = error
+    })
+
+    const typed = caughtV2MutationError(thrown)
+    expect(typed.v2QuestionMutationKind).toBe("server-error")
+    expect(typed.status).toBe(500)
+    // SAFETY: the thrown value is whatever the action rejected with; the tag
+    // predicate accepts any input by design.
+    expect(isAmbiguousTransportFailure(thrown)).toBe(true)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+    expect(store.getState().question["session-a"]).not.toBe(undefined)
+  })
+
+  test("V2 reject fetch-throw keeps question pending: dismissOpenQuestionsForSession still returns true (non-blocking dismissal)", async () => {
+    const store = questionSessionStore("q-1")
+    const childStores = createChildStores([["/question/project", store]])
+    v2QuestionRejectBehavior = "throw"
+
+    const { setActionRefs, dismissOpenQuestionsForSession } = await import("./session-actions")
+    setActionRefs(actionsSdk(), childStores, () => "/question/project")
+
+    // Optimistic local removal happens before the reject round-trip by design
+    // (send path must not block); the ambiguous V2 outcome must not run the V1
+    // reject underneath it.
+    const dismissed = await dismissOpenQuestionsForSession("session-a")
+
+    expect(dismissed).toBe(true)
+    expect(replyCalls.some((call) => call.method === "question.reject")).toBe(false)
+  })
 })
+
+/**
+ * The catch value these tests observe: the Error the classification path
+ * throws (v2QuestionMutationError) or, for the non-fallback classes, exactly
+ * that Error plus the transport tag.
+ */
+type CaughtV2MutationError = Error & { status?: number; v2QuestionMutationKind?: string }
+
+/**
+ * Read the tagged V2 mutation error the action threw.
+ * SAFETY: these tests drive the real classification path; the catch value is
+ * the Error produced by v2QuestionMutationError carrying these exact fields.
+ */
+const caughtV2MutationError = (thrown: CaughtV2MutationError | undefined): CaughtV2MutationError => {
+  expect(thrown).toBeInstanceOf(Error)
+  // SAFETY: narrowed by the toBeInstanceOf assertion above; the classification
+  // path always rejects with this exact shape.
+  return thrown as CaughtV2MutationError
+}

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -146,6 +146,38 @@ function assertSdkSuccess<T>(result: SdkResult<T>, operation: string): T | undef
   throw isAmbiguousSendFailure(result.error) ? markAmbiguousTransportFailure(error) : error
 }
 
+/**
+ * The tagged error a non-fallback V2 question outcome surfaces through.
+ *
+ * `rejected` (400/401/other 4xx) keeps the shape the V1 error path already
+ * produces — `Error` with a numeric `status` — so the existing user-visible
+ * error handling (QuestionCard toast; `isQuestionRequestNotFoundError` check)
+ * reads it unchanged and the V1 call's own handling must not run on top.
+ *
+ * `ambiguous`/`server-error` additionally carry the transport's
+ * "dispatched, outcome unknown" tag (same mechanism as the send-failure path,
+ * {@link markAmbiguousTransportFailure}), and the message names the
+ * classification. Local pending state is deliberately left untouched for these
+ * kinds — an admitted-but-unconfirmed reply must not be discarded locally;
+ * SSE/recovery decides the final state.
+ */
+function v2QuestionMutationError(operation: "reply" | "reject", outcome: V2QuestionMutationResult): Error {
+  const kind = outcome.kind
+  // The discriminated union carries the status only for the HTTP-evidence
+  // kinds; admitted/not-admitted never reach this builder, and ambiguous has
+  // no status at all.
+  const status = (kind === "rejected" || kind === "server-error") ? outcome.status : undefined
+  const message = `Question ${operation} v2 ${kind}${status ? ` (${status})` : ""}`
+  // SAFETY: the wrapper is constructed here from validated strings/numbers;
+  // the extra fields mirror the wrapper shape assertSdkSuccess throws.
+  const error = new Error(message) as Error & { status?: number; v2QuestionMutationKind?: V2QuestionMutationResult["kind"] }
+  if (status !== undefined) error.status = status
+  error.v2QuestionMutationKind = kind
+  // Tag the no-evidence/commit-window classes so callers can distinguish a
+  // lost response from a definite rejection, exactly like the send path does.
+  return kind === "ambiguous" || kind === "server-error" ? markAmbiguousTransportFailure(error) : error
+}
+
 function assertSdkData<T>(result: SdkResult<T>, operation: string): T {
   const data = assertSdkSuccess(result, operation)
   if (data === undefined || data === null) {
@@ -853,39 +885,118 @@ function getRequestReplyClient(
 }
 
 /**
+ * V2 question mutation outcome, classified only from in-process evidence.
+ *
+ * The caller may fall back to the V1 endpoint ONLY when the V2 request provably
+ * never arrived at a V2 handler — a V1 resend after an admitted request either
+ * duplicates the mutation or reports misleading not-found semantics.
+ *
+ * Verified against the SDK 1.18.25 hey-api client (`client.gen.js`): a fetch
+ * throw returns `{ error, response: undefined }`; an HTTP error status returns
+ * `{ error: jsonError ?? textError, response }`; a 204 collapses to
+ * `{ data: {}, error: undefined }`.
+ */
+type V2QuestionMutationResult =
+  | { kind: "admitted" } // 204: server resolved the request
+  | { kind: "not-admitted" } // server answered 404: no V2 handler saw this request (not-found question, or pre-V2 route-miss — see classifyV2QuestionMutation)
+  | { kind: "rejected"; status: number } // 400/401 (or other parsed 4xx): server saw and turned the request down — not a compatibility signal
+  | { kind: "ambiguous" } // no response evidence: fetch throw, abort, response === undefined
+  | { kind: "server-error"; status: number } // 5xx: server answered, but admission is unknowable (commit-before-fail window) — treated like ambiguous for safety
+
+type V2QuestionSdkResult = {
+  data?: unknown
+  error?: unknown
+  response?: { status?: number }
+}
+
+/**
+ * Classify one V2 question reply/reject attempt using only evidence available
+ * in-process. Never a network call: the caller decides what each kind means
+ * (only `not-admitted` may trigger the V1 fallback). Shared by reply and reject
+ * so both mutations keep an identical compatibility contract. Pass `result`
+ * when the SDK call returned; pass `null` when the SDK call itself threw.
+ */
+function classifyV2QuestionMutation(result: V2QuestionSdkResult | null): V2QuestionMutationResult {
+  // No result at all: the SDK call threw (old client shape, SDK bug). No HTTP
+  // evidence exists, so the request may still have been dispatched/admitted.
+  if (result === null) return { kind: "ambiguous" }
+  // hey-api fetch-throw path: `{ error: <raw TypeError/DOMException>,
+  // response: undefined }`. Same evidence gap as a direct throw.
+  if (result.response === undefined) return { kind: "ambiguous" }
+  if (result.error === undefined) {
+    // The 204 success branch collapses to { data: {}, error: undefined } with
+    // response present.
+    return { kind: "admitted" }
+  }
+
+  const status = result.response.status
+  if (status === 404) {
+    // The 404 split, documented for the compatibility contract: a structured
+    // `_tag` body (QuestionNotFoundError/SessionNotFoundError) proves a V2
+    // handler answered — the request provably did not mutate the question. An
+    // unparseable/HTML body means the 404 came from something that is not the
+    // V2 handler: an unknown route on a pre-V2 server, where the request could
+    // not have been processed by a handler that does not exist. Both cases are
+    // provably not admitted, so both justify the V1 fallback; the fallback
+    // preserves the OPE-236 stale-recovery semantics where the V1 call
+    // re-answers not-found and clears the stale local entry.
+    return { kind: "not-admitted" }
+  }
+  if (status !== undefined && status >= 400 && status < 500) {
+    // 400/401/other 4xx: the server received, parsed, and rejected the
+    // request — admission was considered and denied. NOT a compatibility
+    // signal; the V1 call would just repeat the rejection (or worse, get V1
+    // semantics on a V2-shaped payload).
+    return { kind: "rejected", status }
+  }
+  if (status !== undefined && status >= 500) {
+    // 5xx: the server answered, but a commit-before-fail window exists —
+    // admission is unknowable. Treated exactly like a transport loss.
+    return { kind: "server-error", status }
+  }
+  // An HTTP-era result without a status (odd transports/proxies): no
+  // trustworthy evidence, so do not fall back.
+  return { kind: "ambiguous" }
+}
+
+/**
  * Try the native V2 question reply endpoint (SDK 1.18.25,
  * `session.question.reply`) against the same directory-resolved client the V1
  * path uses. The V2 route is addressed by `sessionID` + `requestID` — no
  * `directory` parameter exists there — so the caller must pass the
  * directory-resolved client.
  *
- * Resolves `true` only when the server answered through V2 without an error.
- * Anything else — HTTP error, throw, or unexpected result shape — resolves
- * `false` so the caller falls back to the unchanged V1 call. This mirrors the
- * permission V2 adoption (#1982): try V2, fall back cleanly, no version gate;
- * a pre-V2 server simply takes the V1 path. A V2 404 also falls back, so the
- * V1 call re-answers not-found for the stale-request recovery path.
+ * Returns the classified V2 outcome instead of a boolean: see
+ * {@link classifyV2QuestionMutation} for the kind table. Only
+ * `not-admitted` (structured question 404, or an unparseable-body 404 from a
+ * pre-V2 server's missing route) lets the caller fall back to the unchanged
+ * V1 call; `rejected`/`ambiguous`/`server-error` surface as tagged errors
+ * without a V1 resend, so an admitted mutation is never replayed. This mirrors
+ * the permission V2 adoption (#1982) for the try-first direction; the removal
+ * condition for this whole helper is the pre-V2 support decision (#3007
+ * protocol detection follow-up).
  */
 async function tryV2QuestionReply(
   client: OpencodeClient,
   sessionId: string,
   requestId: string,
   answers: string[][],
-): Promise<boolean> {
+): Promise<V2QuestionMutationResult> {
+  let result: V2QuestionSdkResult
   try {
-    const result = await client.v2.session.question.reply({
+    // SAFETY: the generated method returns a RequestResult whose fields match
+    // V2QuestionSdkResult by definition (data/error/response); the assertion
+    // only drops the generated generic parameters.
+    result = await client.v2.session.question.reply({
       sessionID: sessionId,
       requestID: requestId,
       questionV2Reply: { answers },
-    })
-    // Success is a 204 with no body: the discriminated union collapses to
-    // "no error" on the data branch (see fetchPermission in client.ts).
-    return result.error === undefined
+    }) as V2QuestionSdkResult
   } catch {
-    // Old server without the V2 route, network failure, or SDK throw — the
-    // V1 path decides the outcome.
-    return false
+    // The SDK call itself threw: no response evidence (ambiguous).
+    return classifyV2QuestionMutation(null)
   }
+  return classifyV2QuestionMutation(result)
 }
 
 /** See {@link tryV2QuestionReply} — reject has the same shape minus answers. */
@@ -893,16 +1004,18 @@ async function tryV2QuestionReject(
   client: OpencodeClient,
   sessionId: string,
   requestId: string,
-): Promise<boolean> {
+): Promise<V2QuestionMutationResult> {
+  let result: V2QuestionSdkResult
   try {
-    const result = await client.v2.session.question.reject({
+    // SAFETY: same generated RequestResult shape as the reply call above.
+    result = await client.v2.session.question.reject({
       sessionID: sessionId,
       requestID: requestId,
-    })
-    return result.error === undefined
+    }) as V2QuestionSdkResult
   } catch {
-    return false
+    return classifyV2QuestionMutation(null)
   }
+  return classifyV2QuestionMutation(result)
 }
 
 // ---------------------------------------------------------------------------
@@ -1906,9 +2019,12 @@ export async function respondToQuestion(
     const replyClient = getRequestReplyClient("question", sessionId, requestId)
     // V2 first (native `question.v2` surface). The V2 route has no directory
     // parameter — the scoped client itself addresses the owning instance, so
-    // the same directory resolution the V1 call uses is preserved. Any V2
-    // failure falls through to the unchanged V1 call below.
-    if (await tryV2QuestionReply(replyClient, sessionId, requestId, normalizedAnswers)) {
+    // the same directory resolution the V1 call uses is preserved. Only a
+    // provably not-admitted V2 outcome (the 404 classes) falls through to the
+    // unchanged V1 call below; every other outcome throws a tagged error so a
+    // possibly-admitted V2 mutation is never replayed as a V1 resend.
+    const v2Outcome = await tryV2QuestionReply(replyClient, sessionId, requestId, normalizedAnswers)
+    if (v2Outcome.kind === "admitted") {
       // A successful reply is authoritative: the backend resolved the question,
       // so clear it from the local store deterministically instead of waiting
       // for the SSE `question.replied` event. A lost event (SSE gap) would leave
@@ -1918,6 +2034,9 @@ export async function respondToQuestion(
       // removes when present).
       removeQuestionRequestFromChildStores(sessionId, requestId)
       return
+    }
+    if (v2Outcome.kind !== "not-admitted") {
+      throw v2QuestionMutationError("reply", v2Outcome)
     }
     const result = await replyClient.question.reply({
       requestID: requestId,
@@ -1954,14 +2073,19 @@ export async function rejectQuestion(
     || dir()
   try {
     const rejectClient = getRequestReplyClient("question", sessionId, requestId)
-    // V2 first with the same guarded fallback as respondToQuestion above.
-    if (await tryV2QuestionReject(rejectClient, sessionId, requestId)) {
+    // V2 first with the same classified-fallback contract as respondToQuestion
+    // above: only the 404 classes fall back, others throw a tagged error.
+    const v2Outcome = await tryV2QuestionReject(rejectClient, sessionId, requestId)
+    if (v2Outcome.kind === "admitted") {
       // A successful rejection is authoritative: the backend resolved the
       // question, so clear it from the local store deterministically (see
       // respondToQuestion for the lost-SSE-event rationale — issues #2911,
       // #2448). The later SSE `question.rejected` event is a no-op.
       removeQuestionRequestFromChildStores(sessionId, requestId)
       return
+    }
+    if (v2Outcome.kind !== "not-admitted") {
+      throw v2QuestionMutationError("reject", v2Outcome)
     }
     const result = await rejectClient.question.reject({
       requestID: requestId,

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -742,8 +742,32 @@ function resolveDirectoryForBlockingRequest(
 
 export function isQuestionRequestNotFoundError(error: unknown): boolean {
   if (error && typeof error === "object") {
+    // A classified V2 mutation error (v2QuestionMutationError) is never a
+    // not-found signal: the classifier already decided the kind, and only the
+    // non-not-admitted kinds (rejected/ambiguous/server-error) reach the throw
+    // path. Excluding it keeps the stale-recovery cleanup from running on a
+    // server rejection the classifier proved is not a missing question.
+    // SAFETY: the predicate accepts any thrown value by design; reading the
+    // optional kind/status/tag fields off the object is safe.
+    if ((error as { v2QuestionMutationKind?: unknown }).v2QuestionMutationKind !== undefined) {
+      return false
+    }
+    // SAFETY: same optional-field read as above.
     const status = (error as { status?: unknown }).status
-    if (status === 404) return true
+    if (status === 404) {
+      // A structured 404 with an unrelated `_tag` is a parsed rejection, not
+      // a not-found signal (see classifyV2QuestionMutation for the 404 split).
+      // Errors reaching this predicate are either classified V2 errors (already
+      // excluded above) or plain V1-path `Error` wrappers that never carry a
+      // `_tag` — so `tag === undefined` means "no structured discriminant on
+      // the thrown error" (the V1 wrapper case), not "unparseable response
+      // body".
+      // SAFETY: same optional-field read as above.
+      const tag = (error as { _tag?: unknown })._tag
+      if (tag === "QuestionNotFoundError" || tag === "SessionNotFoundError") return true
+      if (tag === undefined) return true
+      return false
+    }
   }
 
   let message = ""
@@ -898,8 +922,8 @@ function getRequestReplyClient(
  */
 type V2QuestionMutationResult =
   | { kind: "admitted" } // 204: server resolved the request
-  | { kind: "not-admitted" } // server answered 404: no V2 handler saw this request (not-found question, or pre-V2 route-miss — see classifyV2QuestionMutation)
-  | { kind: "rejected"; status: number } // 400/401 (or other parsed 4xx): server saw and turned the request down — not a compatibility signal
+  | { kind: "not-admitted" } // server answered 404 with provable non-admission evidence: a structured QuestionNotFoundError/SessionNotFoundError body, or an unparseable (pre-V2 route-miss) body — see classifyV2QuestionMutation
+  | { kind: "rejected"; status: number } // 400/401 (or other parsed 4xx, including a structured 404 with an unrelated body): server saw and turned the request down — not a compatibility signal
   | { kind: "ambiguous" } // no response evidence: fetch throw, abort, response === undefined
   | { kind: "server-error"; status: number } // 5xx: server answered, but admission is unknowable (commit-before-fail window) — treated like ambiguous for safety
 
@@ -931,15 +955,44 @@ function classifyV2QuestionMutation(result: V2QuestionSdkResult | null): V2Quest
 
   const status = result.response.status
   if (status === 404) {
-    // The 404 split, documented for the compatibility contract: a structured
-    // `_tag` body (QuestionNotFoundError/SessionNotFoundError) proves a V2
-    // handler answered — the request provably did not mutate the question. An
-    // unparseable/HTML body means the 404 came from something that is not the
-    // V2 handler: an unknown route on a pre-V2 server, where the request could
-    // not have been processed by a handler that does not exist. Both cases are
-    // provably not admitted, so both justify the V1 fallback; the fallback
-    // preserves the OPE-236 stale-recovery semantics where the V1 call
-    // re-answers not-found and clears the stale local entry.
+    // The 404 split, documented for the compatibility contract: a 404 is
+    // `not-admitted` (and may trigger the V1 fallback) ONLY when the body
+    // provably shows the request never reached a V2 handler that could have
+    // mutated the question:
+    //   - a structured body carrying the `_tag` discriminant
+    //     "QuestionNotFoundError" or "SessionNotFoundError" — a V2 handler
+    //     answered and provably did not mutate the request; or
+    //   - an unparseable body (the SDK's `error` is the raw text string when
+    //     JSON.parse fails — e.g. an HTML route-miss page from a pre-V2 server
+    //     that has no V2 route at all, so no handler could have processed the
+    //     request).
+    // Any OTHER structured 404 (a JSON object body with a different `_tag`,
+    // or with no not-found shape) is a parsed 4xx the server answered: a V2
+    // handler may have rejected the request for an unrelated reason, so it is
+    // NOT provably not-admitted and must not fall back — classify it as
+    // `rejected` and surface the tagged error instead. The fallback preserves
+    // the OPE-236 stale-recovery semantics where the V1 call re-answers
+    // not-found and clears the stale local entry.
+    const body = result.error
+    if (body instanceof Object) {
+      // SAFETY: the SDK returns `jsonError ?? textError` — a JSON-parsed body
+      // is an object, an unparseable body is the raw text string; reading the
+      // optional `_tag` discriminant off the parsed object is safe.
+      const tag = (body as { _tag?: unknown })._tag
+      if (tag === "QuestionNotFoundError" || tag === "SessionNotFoundError") {
+        return { kind: "not-admitted" }
+      }
+      // Structured 404 with an unrelated/absent not-found tag: the server
+      // parsed and answered the request — admission was considered and denied
+      // for an unrelated reason. Not a compatibility signal.
+      return { kind: "rejected", status }
+    }
+    // Not a JSON-parsed object: the SDK's `error` is the raw text string when
+    // JSON.parse fails (e.g. an HTML route-miss page from a pre-V2 server that
+    // has no V2 route at all, so no handler could have processed the request).
+    // An empty body cannot reach this branch — the SDK's error interceptors
+    // coerce falsy values to `{}`, so it classifies as `rejected` above
+    // (conservative: no fallback, but a 404 never admits a mutation).
     return { kind: "not-admitted" }
   }
   if (status !== undefined && status >= 400 && status < 500) {
@@ -968,10 +1021,11 @@ function classifyV2QuestionMutation(result: V2QuestionSdkResult | null): V2Quest
  *
  * Returns the classified V2 outcome instead of a boolean: see
  * {@link classifyV2QuestionMutation} for the kind table. Only
- * `not-admitted` (structured question 404, or an unparseable-body 404 from a
- * pre-V2 server's missing route) lets the caller fall back to the unchanged
- * V1 call; `rejected`/`ambiguous`/`server-error` surface as tagged errors
- * without a V1 resend, so an admitted mutation is never replayed. This mirrors
+ * `not-admitted` (a structured QuestionNotFoundError/SessionNotFoundError 404,
+ * or an unparseable-body 404 from a pre-V2 server's missing route) lets the
+ * caller fall back to the unchanged V1 call; `rejected`/`ambiguous`/
+ * `server-error` surface as tagged errors without a V1 resend, so an admitted
+ * mutation is never replayed. This mirrors
  * the permission V2 adoption (#1982) for the try-first direction; the removal
  * condition for this whole helper is the pre-V2 support decision (#3007
  * protocol detection follow-up).

--- a/packages/ui/src/sync/session-actions.ts
+++ b/packages/ui/src/sync/session-actions.ts
@@ -852,6 +852,59 @@ function getRequestReplyClient(
   return getSessionReplyClient(sessionId)
 }
 
+/**
+ * Try the native V2 question reply endpoint (SDK 1.18.25,
+ * `session.question.reply`) against the same directory-resolved client the V1
+ * path uses. The V2 route is addressed by `sessionID` + `requestID` — no
+ * `directory` parameter exists there — so the caller must pass the
+ * directory-resolved client.
+ *
+ * Resolves `true` only when the server answered through V2 without an error.
+ * Anything else — HTTP error, throw, or unexpected result shape — resolves
+ * `false` so the caller falls back to the unchanged V1 call. This mirrors the
+ * permission V2 adoption (#1982): try V2, fall back cleanly, no version gate;
+ * a pre-V2 server simply takes the V1 path. A V2 404 also falls back, so the
+ * V1 call re-answers not-found for the stale-request recovery path.
+ */
+async function tryV2QuestionReply(
+  client: OpencodeClient,
+  sessionId: string,
+  requestId: string,
+  answers: string[][],
+): Promise<boolean> {
+  try {
+    const result = await client.v2.session.question.reply({
+      sessionID: sessionId,
+      requestID: requestId,
+      questionV2Reply: { answers },
+    })
+    // Success is a 204 with no body: the discriminated union collapses to
+    // "no error" on the data branch (see fetchPermission in client.ts).
+    return result.error === undefined
+  } catch {
+    // Old server without the V2 route, network failure, or SDK throw — the
+    // V1 path decides the outcome.
+    return false
+  }
+}
+
+/** See {@link tryV2QuestionReply} — reject has the same shape minus answers. */
+async function tryV2QuestionReject(
+  client: OpencodeClient,
+  sessionId: string,
+  requestId: string,
+): Promise<boolean> {
+  try {
+    const result = await client.v2.session.question.reject({
+      sessionID: sessionId,
+      requestID: requestId,
+    })
+    return result.error === undefined
+  } catch {
+    return false
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Session CRUD
 // ---------------------------------------------------------------------------
@@ -1850,7 +1903,23 @@ export async function respondToQuestion(
       : Array.isArray(answers[0])
         ? answers as string[][]
         : [answers as string[]]
-    const result = await getRequestReplyClient("question", sessionId, requestId).question.reply({
+    const replyClient = getRequestReplyClient("question", sessionId, requestId)
+    // V2 first (native `question.v2` surface). The V2 route has no directory
+    // parameter — the scoped client itself addresses the owning instance, so
+    // the same directory resolution the V1 call uses is preserved. Any V2
+    // failure falls through to the unchanged V1 call below.
+    if (await tryV2QuestionReply(replyClient, sessionId, requestId, normalizedAnswers)) {
+      // A successful reply is authoritative: the backend resolved the question,
+      // so clear it from the local store deterministically instead of waiting
+      // for the SSE `question.replied` event. A lost event (SSE gap) would leave
+      // the question pending forever, which keeps the session in "waiting for
+      // answer" — the next task's thinking and final response never render
+      // (issues #2911, #2448). The later SSE event is a no-op (the reducer only
+      // removes when present).
+      removeQuestionRequestFromChildStores(sessionId, requestId)
+      return
+    }
+    const result = await replyClient.question.reply({
       requestID: requestId,
       answers: normalizedAnswers,
       ...(directory ? { directory } : {}),
@@ -1884,7 +1953,17 @@ export async function rejectQuestion(
     || getSessionDirectory(sessionId)
     || dir()
   try {
-    const result = await getRequestReplyClient("question", sessionId, requestId).question.reject({
+    const rejectClient = getRequestReplyClient("question", sessionId, requestId)
+    // V2 first with the same guarded fallback as respondToQuestion above.
+    if (await tryV2QuestionReject(rejectClient, sessionId, requestId)) {
+      // A successful rejection is authoritative: the backend resolved the
+      // question, so clear it from the local store deterministically (see
+      // respondToQuestion for the lost-SSE-event rationale — issues #2911,
+      // #2448). The later SSE `question.rejected` event is a no-op.
+      removeQuestionRequestFromChildStores(sessionId, requestId)
+      return
+    }
+    const result = await rejectClient.question.reject({
       requestID: requestId,
       ...(directory ? { directory } : {}),
     })

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -906,6 +906,11 @@ const getSessionIdFromPayload = (event: Event): string | null => {
     || event.type === "question.asked"
     || event.type === "question.replied"
     || event.type === "question.rejected"
+    // V2 question events share the V1 property shape (sessionID at the top
+    // level of `properties`); the V2 counterpart of the V1 routing branch.
+    || event.type === "question.v2.asked"
+    || event.type === "question.v2.replied"
+    || event.type === "question.v2.rejected"
   ) {
     const sessionID = props.sessionID
     return typeof sessionID === "string" && sessionID.length > 0 ? sessionID : null
@@ -1739,7 +1744,7 @@ export function handleEvent(
     }
   }
 
-  if (payload.type === "question.asked") {
+  if (payload.type === "question.asked" || payload.type === "question.v2.asked") {
     const question = payload.properties as QuestionRequest
     const sessionID = question.sessionID
     const toastKey = getQuestionToastKey(sessionID, question.id)
@@ -1760,7 +1765,12 @@ export function handleEvent(
     }
   }
 
-  if (payload.type === "question.replied" || payload.type === "question.rejected") {
+  if (
+    payload.type === "question.replied"
+    || payload.type === "question.rejected"
+    || payload.type === "question.v2.replied"
+    || payload.type === "question.v2.rejected"
+  ) {
     const props = payload.properties as { sessionID?: string; requestID?: string }
     const toastKey = getQuestionToastKey(props.sessionID, props.requestID)
     if (toastKey) {
@@ -1876,6 +1886,11 @@ export function handleEvent(
     case "question.asked":
     case "question.replied":
     case "question.rejected":
+    // V2 question events mutate the same `question` slice as their V1
+    // counterparts; reuse the single targeted clone.
+    case "question.v2.asked":
+    case "question.v2.replied":
+    case "question.v2.rejected":
       cloneField("question", (value) => ({ ...value }))
       break
     case "lsp.updated":

--- a/packages/ui/src/sync/sync-context.tsx
+++ b/packages/ui/src/sync/sync-context.tsx
@@ -1883,11 +1883,11 @@ export function handleEvent(
     case "permission.replied":
       cloneField("permission", (value) => ({ ...value }))
       break
+    // V2 question events mutate the same `question` slice as their V1
+    // counterparts; reuse the single targeted clone.
     case "question.asked":
     case "question.replied":
     case "question.rejected":
-    // V2 question events mutate the same `question` slice as their V1
-    // counterparts; reuse the single targeted clone.
     case "question.v2.asked":
     case "question.v2.replied":
     case "question.v2.rejected":

--- a/packages/vscode/webview/main.tsx
+++ b/packages/vscode/webview/main.tsx
@@ -1810,7 +1810,7 @@ window.addEventListener('openchamber:vscode-notification-event', (event) => {
       return;
     }
 
-    if (type === 'question.asked') {
+    if (type === 'question.asked' || type === 'question.v2.asked') {
       if (!settings.notifyOnQuestion) return;
       const questions = Array.isArray(properties.questions) ? properties.questions : [];
       const firstQuestion = questions[0] as Record<string, unknown> | undefined;

--- a/packages/web/server/lib/notifications/runtime.js
+++ b/packages/web/server/lib/notifications/runtime.js
@@ -504,7 +504,7 @@ export const createNotificationTriggerRuntime = (deps) => {
       return;
     }
 
-    if (payload.type === 'question.asked' && sessionId) {
+    if ((payload.type === 'question.asked' || payload.type === 'question.v2.asked') && sessionId) {
       const existingTimer = pushQuestionDebounceTimers.get(sessionId);
       if (existingTimer) {
         clearTimeout(existingTimer);


### PR DESCRIPTION
## Final disposition

Closed as superseded by the #3259 selected-runtime architecture.

The production implementation in this PR belongs to the old mixed-runtime migration model and will not be merged.

Preserved:
- Generic question-reducer invariants (idempotent upsert-by-id, replace-not-first-wins, terminal removal by session/request pair, duplicate-terminal no-op, late-asked re-registration) — ported (V1 event names only) into test-only salvage PR **#3439** (`event-reducer.test.ts`)
- Mutation failure-matrix semantics (transport drop / responseless error never triggers blind resend; 5xx may have admitted the first mutation; structured `QuestionNotFoundError`/`SessionNotFoundError` must remain distinguishable from arbitrary 404; pending state must remain recoverable after ambiguous failure; adapter event translation must remain single-boundary) — recorded in #3259 `Post-hybrid salvage manifest` (verification items Q4–Q7) as deferred adapter-seam tests

Disposition:
- production path (`client.v2.session.question.reply/reject`, classified V1 resend on not-admitted 404 classes, raw `question.v2.*` reducer/toast/notification arms): **dropped** — duplicates #3007's `question.reply`/`question.reject` seam and event translation (`form.*` → V1-named `question.*` events); a second direct V2 mutation path and a second event-translation boundary are not part of the target architecture
- main-independent tests: **ported to #3439** (tests only, CI green)
- adapter-specific tests/evidence: **recorded in #3259 for future user-owned corrective work**
- #3007 remains external/read-only and was not modified

Historical implementation details below are retained as engineering evidence.
## Architecture status

> **PROPOSED / SELECTED FOR #3259 — not maintainer-approved policy.**
>
> This PR was implemented under the superseded capability-by-capability #3259 migration model (V2-first reply/reject with a classified V1 fallback, plus raw `question.v2.*` event handling in shared reducers).
>
> Under the current #3259 dual-runtime proposal, this production diff is NOT mergeable as-is:
>
> - **Mutation path**: current #3007 (`feat/opencode-v2-compat` @ `5a424cf7`) already owns the V2 question-mutation seam behind the existing `question.reply`/`question.reject` application contract — requestID→owning V2 form/session mapping, `v2.form.reply/cancel`, explicit `QuestionNotFoundError` preservation, explicit no-mapping failures, and no cross-runtime resend. A second direct `client.v2.session.question.reply/reject` path in `session-actions.ts` duplicates that seam.
> - **Event path**: #3007's event mapper already translates native V2 form events (`form.created`/`form.replied`/`form.cancelled`) into the V1-named `question.asked`/`question.replied`/`question.rejected` events the shared reducer consumes. Adding raw `question.v2.*` arms to shared reducers creates a second, competing event-translation boundary. The final architecture should have exactly one authoritative translation boundary.
> - The V1 fallback on `not-admitted` 404 classes contradicts selected-runtime authority (V2-selected runtime must surface `V2 UNSUPPORTED`/`BLOCKED`, never route to V1 authority).
>
> The branch remains open as engineering evidence while its tests and invariants are reconciled with the selected runtime foundation and the #3007 adapter work. Do not infer maintainer rejection or project-wide architectural approval from this status.

### Evidence worth salvaging (adapt to the one chosen adapter boundary)

- The mutation-outcome classifier (`classifyV2QuestionMutation`): ambiguous outcomes must never cause duplicate mutation; no blind resend; pending-state preservation; 404/rejection classification; idempotency semantics. These invariants should be re-expressed against the #3007 adapter's explicit-failure behavior.
- The full failure-matrix test coverage (transport-drop, structured not-found, route-miss 404, unrelated-tag 404, no-tag 404, empty-body 404, 400/401, 500 — reply and reject variants, each asserting no-V1-resend and pending-state preservation).
- The dual-fire-safe idempotent reducer upsert/remove tests (upsert-by-id, remove-by-pair, late-asked ordering) — still valuable for whichever layer owns event ingestion.
- The explicit 404-split contract (structured not-found `_tag` vs unparseable route-miss vs unrelated structured 404) — the adapter's error envelope should be audited against this classification.

---

## Historical implementation record

Everything below this point describes the pre-reconciliation implementation and its then-current HEADs and bases. Where this historical record conflicts with the Architecture status section above, the Architecture status section is authoritative.

## Intent

Migration unit #3 (tracking #3259), continuing the questions capability migration started in #3266 (V2 read path):

- **Reply/reject go V2-first with a failure-class guard**: `respondToQuestion` / `rejectQuestion` try `client.v2.session.question.reply({ sessionID, requestID, questionV2Reply: { answers } })` / `reject({ sessionID, requestID })` (SDK 1.18.25, session-scoped `Question2`). The V1 path runs **only when the V2 outcome proves the request was not admitted** — never on ambiguous outcomes (transport loss, timeout, throw, 5xx), where a V1 resend could replay an admitted mutation. See the fallback contract below.
- **V2 question events handled**: reducer accepts `question.v2.asked` / `question.v2.replied` / `question.v2.rejected` (literals verified against SDK 1.18.25 event union). Shared arms with the V1 logic: idempotent upsert-by-`id` for asked, remove-by-`sessionID`+`requestID` for terminal events — safe if a server emits both V1 and V2 for the same request, and fixes live updates if it emits V2-only.
- `dismissOpenQuestionsForSession` routes through `rejectQuestion`, so dismissals benefit from the same V2-first path.
- Mirrored in `sync-context.tsx`: `getSessionIdFromPayload`, question toasts (same i18n keys/copy — no new strings), `cloneField("question")`.

## Non-goals

- Bootstrap pending-question snapshot stays V1 (`sdk.question.list`) — unchanged, as in #3266.
- No tombstone/reordering machinery in the reducer: the existing ordered-stream/replay semantics are documented by test (late `v2.asked` after a terminal event re-registers — long-standing V1+V2 reducer behavior; see test `a late question.v2.asked after a terminal event re-registers the request`).
- No changes to permissions, queue, events (V1 event stream core), or any other capability.
- No new dependencies; no i18n changes; UI components untouched.

## Affected surfaces

- `packages/ui` shared code (web, Electron, VS Code, mobile — same store/action path).
- Notification consumers extended from V1-only to also answer `question.v2.asked` (same payload shape, verified against SDK 1.18.25 types): `packages/vscode/webview/main.tsx` (VS Code native notifications) and `packages/web/server/lib/notifications/runtime.js` (server push notifications).
- Sync docs event table updated with the V2 aliases (`packages/ui/src/sync/DOCUMENTATION.md`).
- OpenCode contract: V2 `session.question.reply/reject` + V2 question events (SDK 1.18.25); V1 question endpoints used only for provably-not-admitted V2 outcomes (see fallback contract below).
- No persisted contracts, server routes, or component changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariants | fallback must not masquerade as success; ambiguous mutations must not replay | V2 outcome classified first (`classifyV2QuestionMutation`): only `admitted` (204) succeeds; only provably-not-admitted 404s reach V1; ambiguous/5xx/parsed-4xx rethrow tagged |
| sync-state-invariants skill | event-driven pending-question state | Idempotent, ID-keyed upsert/remove shared by V1/V2 arms; dual-fire safe; replay semantics documented by test |
| ui-api-decoupling | OpenCode SDK adoption through the integration boundary | SDK calls stay in `session-actions.ts` where the scoped client lives; UI unchanged |
| openchamber-change-discipline | focused source change | 5 production files, 2 test files, 1 docs file only; unrelated cleanup excluded |

## Validation

| Check | Result |
|---|---|
| Focused suite at corrective head `1156bb9b8` (`packages/ui/src/sync/session-actions.test.ts`, bun test) | 89 pass / 0 fail, 350 expect() calls (incl. the +13 classification tests from the corrective pass: transport-drop → no V1 resend + pending preserved; structured not-found 404 (`QuestionNotFoundError` + `SessionNotFoundError`) → V1 fallback; unparseable route-miss 404 → V1 fallback; unrelated-tag 404 / no-tag 404 / SDK-coerced empty-body 404 → `rejected`, no V1 resend, pending preserved; 400/401 → rejected rethrow; 500 → server-error rethrow; plus the V2 success/fallback/throw, 404 recovery, upsert idempotency, dual-fire single-entry, terminal removal, late-asked ordering tests from the earlier heads) |
| Full packages/ui suite at corrective head | 368 pass / 369 files; the 1 failure is `src/lib/i18n/messages.test.ts` locale key parity — pre-existing on main (verified in earlier units; file untouched by this PR) |
| `bun run type-check` (packages/ui) | 5 errors, all pre-existing in `src/lib/codemirror/languageByExtension.ts`; 0 errors in files touched by this PR |
| `bunx oxlint` (session-actions.ts, session-actions.test.ts) | 0 new findings from this PR's changes (pre-existing anti-slop backlog on the files is a known repo-wide backlog, left untouched) |
| `bun run dead-code` | no new findings |

Validation numbers above are the exact outputs of the commands run at the final corrective head `1156bb9b8` in this pass; earlier head counts (before the corrective commits) are superseded by these.

**Not runtime-verified against a live OpenCode 1.18.25 server**: whether a given server emits V1-only, V2-only, or both event streams per request origin is not provable from repo/SDK alone; this change is safe under all three combinations (fallback + idempotent reducers), and the maintainer's runtime validation applies as with #3266.

## Visual evidence

No rendered-behavior change on V1-only servers. On V2-capable servers the pending-question flow shows the same cards/toasts, sourced via V2. Question UI markup untouched — no screenshots applicable.

## Risks and failure behavior

- Provably-not-admitted V2 failures (structured 404 with not-found `_tag`, or pre-V2 route-miss 404) → existing V1 behavior (same answers normalization, directory resolution, OPE-236 recovery). Ambiguous, 5xx, and parsed-4xx V2 outcomes rethrow as tagged errors — no V1 resend pending state is left for SSE/recovery reconciliation.
- Arbitrary structured 404 (unrelated `_tag` or no not-found shape) is a parsed server rejection, NOT provably-not-admitted — classified `rejected`, no V1 fallback.
- Dual-fire events are idempotent (upsert-by-id / remove-by-pair); ordering semantics documented by test rather than new machinery.
- Rollback: revert commits; no data migration; no contract change.
- Cross-runtime: shared-UI only; runtime adapters untouched.

---

### Architecture correction (corrective review pass)

An architectural review corrected this PR's fallback semantics before merge:

- Original approach (`any V2 failure → V1`) is **not** the migration target of #3259. For mutations, a V1 resend after an *ambiguous* V2 outcome (transport loss, timeout, throw, 5xx — where the request may have been admitted) could replay the mutation or produce misleading "no longer pending" state.
- Current implementation classifies the V2 outcome first (`classifyV2QuestionMutation`): `admitted` (204) → success path; `not-admitted` (404 with structured not-found tag, or unparseable 404 route-miss from a pre-V2 server) → V1 path (justified: request provably unprocessed by V2; preserves OPE-236 stale recovery); `rejected` (parsed 4xx, including arbitrary structured 404) / `server-error` (5xx) / `ambiguous` (transport) → **tagged rethrow, no V1 resend**, local pending state left for SSE/recovery reconciliation.
- **#1982 framing corrected**: #1982 did not establish a universal try-V2→V1-fallback rule. This PR's fallback exists only for the not-admitted classes above, with an explicit removal condition. (Later note, 2026-09-03 source audit: #1982's pre-check was reclassified in #3259 as COMPETING AUTHORITY on Stable/V1 — the V2 `session.permission.get` producer keeps a separate pending map from the V1 permission producer — so #1982 is no longer cited as a safe fallback-tag pattern; see the #1982 section of #3259.)

### Fallback questionnaire (required for future migration PRs)

- **Why does the V1 fallback exist?** Transitional adoption: covers servers predating the V2 route (route-miss 404) plus the stale-recovery path (OPE-236 preserved).
- **Operation class:** mutation (`question.reply` / `question.reject`).
- **Can the first operation have succeeded despite the failure?** Yes — for transport loss and 5xx. Those classes are excluded from fallback and surfaced as tagged errors, so an admitted mutation is never replayed.
- **Failure classes triggering fallback:** provably-not-admitted 404s only (structured `QuestionNotFoundError`/`SessionNotFoundError` `_tag` body, or route-miss 404 with unparseable body).
- **Classes NOT triggering fallback:** ambiguous (throw/responseless; tagged via `markAmbiguousTransportFailure`), parsed 4xx (including arbitrary structured 404), 5xx.
- **Removal condition:** when the pre-V2 support decision lands — capability selection via `openCodeProtocol` runtime detection (#3007) or a supported-min-version policy — the V1 fallback path is removed entirely.

---

### Migration tracking (#3259)

```text
Tracking: #3259

Depends on: none

Required merge order: standalone
```

Note: independent of #3266 (this PR's reply/reject path has no production coupling to the V2 read path; `client.ts` is untouched here — different files, so merge order with #3266 is free; trivial rebase expected only if both touch adjacent `session-actions.ts` regions).

Effective base:

```text
main (upstream): 0e3aff884
SDK: @opencode-ai/sdk 1.18.25
```

Existing overlap:

```text
#3266 (ours, open) — related capability (V2 read); NO dependency, NO file overlap (client.ts untouched here)
#1982 @ 4348642f8f (merged) — REUSED as fallback-tag pattern (mechanics), no code reuse
#3007 @ 5a424cf7 — SEMANTIC OVERLAP SUPERSEDED THIS PR (2026-09-03 audit: #3007's adapter already owns `question.reply`/`question.reject` behind the existing OpenChamber contract — requestID→owning V2 form/session mapping, `v2.form.reply/cancel`, explicit `QuestionNotFoundError` preservation, no cross-runtime resend — and translates `form.*` events to `question.*`; the historical note below claiming COORDINATE / no semantic overlap predates that audit and is superseded — see Architecture status above)
```

Reuse strategy: `PATTERN-REUSE` (#1982 mechanics, at the time of implementation). No foreign commits reused. (2026-09-03: the #1982 pattern reference is retracted per the #3259 source audit; see the correction above.)

### V2 purity statement

- Native stock V2: session-scoped `Question2.reply/reject` and `question.v2.*` events from generated SDK 1.18.25.
- Mapping existing V2 semantics only; only provably-not-admitted V2 outcomes select the V1 path (documented removal condition). No fabricated semantics, no mixed per-message execution ownership.

---

### Corrective pass 2026-09-01 (404 classification + CI lint)

Follow-up to the architecture correction, applied at corrective head `1156bb9b8` (commits `5b8efc72e` + `1156bb9b8`, pushed to `unit-3-questions-v2-mutate`):

- **Fix**: `classifyV2QuestionMutation` previously treated EVERY HTTP 404 as `not-admitted` (V1 fallback), contradicting the documented split. Now a 404 is `not-admitted` only when the body provably shows non-admission: structured `_tag` `QuestionNotFoundError`/`SessionNotFoundError`, or an unparseable (route-miss) body. Any other structured 404 (unrelated `_tag` or no not-found shape) and the SDK-coerced `{}` empty-body edge classify as `rejected` → tagged rethrow, NO V1 resend.
- **Guard**: `isQuestionRequestNotFoundError` now excludes classified V2 mutation errors (so a `rejected`-class 404 cannot trigger stale-recovery cleanup) and requires the not-found `_tag` for unclassified 404 objects (V1-path wrappers have none — OPE-236 preserved).
- **Tests**: +13 classification tests covering the full matrix: transport-drop, responseless, structured not-found (QuestionNotFoundError + SessionNotFoundError), route-miss 404, unrelated-tag 404, no-tag 404, empty-body 404, 400/401, 500 — reply and reject variants, each asserting no-V1-resend where applicable and pending-state preservation.
- **Review**: native pass + OCR (open-code-review v1.11.1) pass; both OCR findings low-severity, resolved (comment clarification; `instanceof Object` retained per anti-slop lint policy over the suggested `typeof` narrowing).
- **Review head**: bot review PASS / handoff complete at `5b8efc72e` (07:28Z); current head `1156bb9b8` carries only the comment-placement lint fix and was not separately bot-reviewed (delta is comment-only, semantically identical to the reviewed head).
- **CI lint (red → green)**: `checks` Lint failed on `no-fallthrough` in `event-reducer.ts` (557, 576) and `sync-context.tsx` (1891) — comments the V2-event commit placed between switch case labels. Fixed by moving the comments inside the case blocks / above the label group (`1156bb9b8 style(sync): move V2 question event comments inside case blocks`); `bunx eslint` on both files now exits 0, reducer tests 22/0 and session-switch-resync 14/0 still pass.
- **CI tests (pre-existing on main, attributed at current head `1156bb9b8`)**: run 33482740339 on the current head fails Tests only via `src/lib/i18n/messages.test.ts` locale key parity (`gitView.*` keys) — the file is byte-identical to base `0e3aff884`, no i18n changes in this PR, and `1156bb9b8` changes no semantics; same pre-existing failure previously attributed on #3266.




