### PR TITLE
fix(chat): size markdown table columns by content

### DIFF
--- a/packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx
+++ b/packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx
@@ -12,6 +12,7 @@ type OperationCounts = {
   replaceCalls: number;
   removeCalls: number;
   getBoundingClientRectCalls: number;
+  tableProbeReads: number;
   viewBoxWrites: number;
   resizeObserverCreates: number;
   resizeObserverObserveCalls: number;
@@ -62,6 +63,7 @@ let windowInstance: Window;
 let previousGlobals: Map<string, PropertyDescriptor | undefined>;
 let activeCounts: OperationCounts | null = null;
 let animationFrameQueue: FrameRequestCallback[] = [];
+let tableProbeWidths: Map<string, number> | null = null;
 let notifyResize: ((entries: Array<{ target: Element; contentRect: { width: number; height: number } }>) => void) | null = null;
 let MarkdownRenderer: React.ComponentType<{
   content: string;
@@ -82,6 +84,7 @@ const makeCounts = (): OperationCounts => ({
   replaceCalls: 0,
   removeCalls: 0,
   getBoundingClientRectCalls: 0,
+  tableProbeReads: 0,
   viewBoxWrites: 0,
   resizeObserverCreates: 0,
   resizeObserverObserveCalls: 0,
@@ -239,10 +242,15 @@ const initializePerformanceDom = async (): Promise<void> => {
     return originalRemove.call(this);
   } });
   const originalGetBoundingClientRect = elementPrototype.getBoundingClientRect;
-  Object.defineProperty(elementPrototype, 'getBoundingClientRect', { configurable: true, value: function (): DOMRect {
+  Object.defineProperty(elementPrototype, 'getBoundingClientRect', { configurable: true, value: function (this: Element): DOMRect {
     if (activeCounts) {
       activeCounts.getBoundingClientRectCalls += 1;
       activeCounts.geometrySequence.push('read');
+    }
+    if (this.matches('table') && this.closest('[data-md-table-measure]')) {
+      if (activeCounts) activeCounts.tableProbeReads += 1;
+      const key = (this.textContent ?? '').trim();
+      return new windowInstance.DOMRect(0, 0, tableProbeWidths?.get(key) ?? 0, 20);
     }
     return originalGetBoundingClientRect.call(this);
   } });
@@ -318,6 +326,77 @@ afterAll(() => {
 });
 
 describe('MarkdownRenderer DOM mount performance contract', () => {
+  test('fixes body-sized table columns once the stream settles', async () => {
+    const content = [
+      '| An intentionally oversized header | Another oversized header | A third oversized header |',
+      '| --- | --- | --- |',
+      '| short | medium body value | very long body value |',
+    ].join('\n');
+    tableProbeWidths = new Map([
+      ['short', 48],
+      ['medium body value', 186],
+      ['very long body value', 800],
+    ]);
+    const counts = makeCounts();
+    activeCounts = counts;
+    const host = document.createElement('div');
+    document.body.replaceChildren(host);
+    const root = createRoot(host);
+    const render = (isStreaming: boolean) => root.render(
+      <MarkdownRenderer
+        content={content}
+        messageId="table-width-message"
+        isAnimated={false}
+        isStreaming={isStreaming}
+        enableFileReferences={false}
+      />,
+    );
+
+    try {
+      await act(async () => {
+        render(true);
+        await waitForSettledEffects();
+      });
+      await flushAnimationFrame();
+      expect(host.querySelector('[data-markdown="table"]')?.getAttribute('data-md-table-layout')).toBe('pending');
+      expect(counts.tableProbeReads).toBe(0);
+
+      await act(async () => {
+        render(false);
+        await waitForSettledEffects();
+      });
+      await flushAnimationFrame();
+
+      const table = host.querySelector<HTMLTableElement>('[data-markdown="table"]');
+      const cells = Array.from(table?.querySelectorAll('th, td') ?? []);
+      const columnWidths = Array.from(table?.querySelectorAll<HTMLTableColElement>('colgroup[data-md-table-columns] col') ?? [])
+        .map((column) => column.style.width);
+      const tableProbeReads = counts.tableProbeReads;
+      await flushAnimationFrame();
+
+      expect(table).not.toBeNull();
+      expect(table?.getAttribute('data-md-table-layout')).toBe('fixed');
+      expect(table?.style.tableLayout).toBe('fixed');
+      expect(table?.style.width).toBe('626px');
+      expect(columnWidths).toEqual(['120px', '186px', '320px']);
+      expect(table?.classList.contains('w-max')).toBe(true);
+      expect(table?.classList.contains('min-w-full')).toBe(false);
+      expect(table?.classList.contains('w-full')).toBe(false);
+      expect(table?.parentElement?.classList.contains('overflow-x-auto')).toBe(true);
+      expect(cells.length).toBeGreaterThan(0);
+      expect(cells.every((cell) => cell.classList.contains('min-w-[120px]'))).toBe(true);
+      expect(cells.every((cell) => cell.classList.contains('max-w-[320px]'))).toBe(true);
+      expect(cells.every((cell) => (
+        cell.classList.contains('whitespace-normal')
+        && cell.classList.contains('[overflow-wrap:anywhere]')
+      ))).toBe(true);
+      expect(counts.tableProbeReads).toBe(tableProbeReads);
+    } finally {
+      tableProbeWidths = null;
+      await act(async () => root.unmount());
+    }
+  });
+
   test('builds Markdown sprite controls without parsing SVG markup', async () => {
     const mounted = await mountFixture(1);
 
@@ -517,7 +596,8 @@ describe('MarkdownRenderer DOM mount performance contract', () => {
     expect(metrics.innerHTMLWrites).toBeGreaterThan(0);
     expect(metrics.querySelectorAllCalls).toBeGreaterThan(0);
     expect(metrics.appendCalls).toBeGreaterThan(0);
-    expect(metrics.getBoundingClientRectCalls).toBe(metrics.mermaidRenderedCount);
+    expect(metrics.tableProbeReads).toBe(fixtureWorkload.rendererCount * 2);
+    expect(metrics.getBoundingClientRectCalls).toBe(metrics.mermaidRenderedCount + metrics.tableProbeReads);
     expect(metrics.viewBoxWrites).toBe(metrics.mermaidRenderedCount);
     expect(metrics.resizeObserverCreates).toBe(1);
     expect(metrics.resizeObserverObserveCalls).toBe(metrics.mermaidRenderedCount);

--- a/packages/ui/src/components/chat/MarkdownRendererImpl.test.ts
+++ b/packages/ui/src/components/chat/MarkdownRendererImpl.test.ts
@@ -129,6 +129,7 @@ const installRendererDom = () => {
             setTimeout,
             clearTimeout,
             requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0),
+            cancelAnimationFrame: clearTimeout,
         },
     });
     Object.defineProperty(globalThis, 'MutationObserver', {
@@ -288,6 +289,7 @@ mock.module('./markdown/decorate', () => ({
         );
     },
     getMarkdownCodeText: () => '',
+    stabilizeMarkdownTableWidths: () => undefined,
 }));
 mock.module('./markdown/textPosition', () => ({ findTextPosition: () => null }));
 mock.module('./markdown/mermaidViewer', () => ({

--- a/packages/ui/src/components/chat/MarkdownRendererImpl.tsx
+++ b/packages/ui/src/components/chat/MarkdownRendererImpl.tsx
@@ -33,6 +33,7 @@ import {
   applyMarkdownCodeBlockWrapState,
   decorateMarkdown,
   getMarkdownCodeText,
+  stabilizeMarkdownTableWidths,
   type DecorateContext,
   type DecorateLabels,
   type MermaidControlOptions,
@@ -814,6 +815,7 @@ const useMorphdomMarkdown = ({
   syntaxVars,
   ctx,
   domCacheKey,
+  tableLayoutSettled,
 }: {
   containerRef: React.RefObject<HTMLDivElement | null>;
   text: string;
@@ -822,6 +824,7 @@ const useMorphdomMarkdown = ({
   syntaxVars: Record<string, string>;
   ctx: DecorateContext;
   domCacheKey?: DetachedMarkdownDomKey | null;
+  tableLayoutSettled: boolean;
 }) => {
   React.useEffect(() => {
     ensureMarkdownShikiTheme();
@@ -829,6 +832,7 @@ const useMorphdomMarkdown = ({
 
   const mermaidViewerRef = React.useRef<ReturnType<typeof createMermaidViewerRegistry> | null>(null);
   const renderRevisionRef = React.useRef(0);
+  const tableLayoutFrameRef = React.useRef<number | null>(null);
   // A provisional first paint (blocks not in the settled cache) holds the
   // timeline reveal until the async render lands, so the session opens with
   // final code highlighting instead of a visible restyle.
@@ -859,6 +863,28 @@ const useMorphdomMarkdown = ({
     }
     mermaidViewerRef.current.refresh();
   }, [containerRef]);
+  const scheduleTableLayout = React.useCallback(() => {
+    if (!tableLayoutSettled) return;
+    const previousFrame = tableLayoutFrameRef.current;
+    if (previousFrame !== null) window.cancelAnimationFrame(previousFrame);
+    const renderRevision = renderRevisionRef.current;
+    const frame = window.requestAnimationFrame(() => {
+      if (tableLayoutFrameRef.current !== frame) return;
+      tableLayoutFrameRef.current = null;
+      if (renderRevisionRef.current !== renderRevision) return;
+      const container = containerRef.current;
+      const target = container?.querySelector<HTMLElement>('[data-markdown-content]') ?? container;
+      if (target) stabilizeMarkdownTableWidths(target);
+    });
+    tableLayoutFrameRef.current = frame;
+  }, [containerRef, tableLayoutSettled]);
+
+  React.useEffect(() => () => {
+    const frame = tableLayoutFrameRef.current;
+    if (frame === null) return;
+    window.cancelAnimationFrame(frame);
+    tableLayoutFrameRef.current = null;
+  }, []);
 
   React.useLayoutEffect(() => {
     renderRevisionRef.current += 1;
@@ -984,6 +1010,7 @@ const useMorphdomMarkdown = ({
           ? { key: domCacheKey, copiedLabel: ctx.labels.copied }
           : null;
         streamPerfCount('ui.markdown_renderer.settled_paint.reused');
+        scheduleTableLayout();
         releaseRevealHold();
         return;
       }
@@ -1078,13 +1105,14 @@ const useMorphdomMarkdown = ({
       mountedDomRef.current = domCacheKey
         ? { key: domCacheKey, copiedLabel: ctx.labels.copied }
         : null;
+      scheduleTableLayout();
       releaseRevealHold();
     });
 
     return () => {
       active = false;
     };
-  }, [containerRef, ctx, domCacheKey, imageMode, refreshMermaidViewers, releaseRevealHold, streaming, text]);
+  }, [containerRef, ctx, domCacheKey, imageMode, refreshMermaidViewers, releaseRevealHold, scheduleTableLayout, streaming, text]);
 
   React.useEffect(() => {
     const container = containerRef.current;
@@ -1203,6 +1231,7 @@ const MarkdownRendererImpl: React.FC<MarkdownRendererProps> = ({
     syntaxVars,
     ctx,
     domCacheKey,
+    tableLayoutSettled: !isStreaming,
   });
 
   const markdownContent = (
@@ -1293,6 +1322,7 @@ const SimpleMarkdownRendererImpl: React.FC<{
     streaming: false,
     syntaxVars,
     ctx,
+    tableLayoutSettled: true,
   });
 
   return (

--- a/packages/ui/src/components/chat/markdown/decorate.ts
+++ b/packages/ui/src/components/chat/markdown/decorate.ts
@@ -333,6 +333,10 @@ const buildTableMenu = (action: string, items: Array<{ key: string; label: strin
   return menu;
 };
 
+const TABLE_COLUMN_MIN_WIDTH = 120;
+const TABLE_COLUMN_MAX_WIDTH = 320;
+const TABLE_LAYOUT_ATTR = 'data-md-table-layout';
+
 const decorateTables = (root: HTMLElement, labels: DecorateLabels): void => {
   const tables = root.querySelectorAll<HTMLTableElement>('table');
   for (const table of Array.from(tables)) {
@@ -373,7 +377,8 @@ const decorateTables = (root: HTMLElement, labels: DecorateLabels): void => {
     if (!parent) continue;
     parent.replaceChild(wrapper, table);
     table.setAttribute('data-markdown', 'table');
-    table.classList.add('w-full', 'border-collapse', 'text-sm');
+    table.setAttribute(TABLE_LAYOUT_ATTR, 'pending');
+    table.classList.add('w-max', 'border-collapse', 'text-sm');
 
     for (const tr of Array.from(table.querySelectorAll('tr'))) {
       tr.classList.add('border-b', 'border-border/60');
@@ -382,15 +387,110 @@ const decorateTables = (root: HTMLElement, labels: DecorateLabels): void => {
     lastBodyRow?.classList.remove('border-b');
     lastBodyRow?.classList.add('border-0');
     for (const th of Array.from(table.querySelectorAll('th'))) {
-      th.classList.add('border-r', 'border-border/60', 'px-4', 'py-2.5', 'text-left', 'align-middle', 'font-semibold', 'text-foreground', 'last:border-r-0');
+      th.classList.add('min-w-[120px]', 'max-w-[320px]', 'whitespace-normal', '[overflow-wrap:anywhere]', 'border-r', 'border-border/60', 'px-4', 'py-2.5', 'text-left', 'align-middle', 'font-semibold', 'text-foreground', 'last:border-r-0');
     }
     for (const td of Array.from(table.querySelectorAll('td'))) {
-      td.classList.add('border-r', 'border-border/60', 'px-4', 'py-2.5', 'align-middle', 'text-foreground/90', 'last:border-r-0');
+      td.classList.add('min-w-[120px]', 'max-w-[320px]', 'whitespace-normal', '[overflow-wrap:anywhere]', 'border-r', 'border-border/60', 'px-4', 'py-2.5', 'align-middle', 'text-foreground/90', 'last:border-r-0');
     }
 
     scroll.appendChild(table);
     wrapper.appendChild(toolbar);
     wrapper.appendChild(scroll);
+  }
+};
+
+export const stabilizeMarkdownTableWidths = (root: HTMLElement): void => {
+  const tables = Array.from(root.querySelectorAll<HTMLTableElement>(
+    `table[data-markdown="table"]:not([${TABLE_LAYOUT_ATTR}="fixed"])`,
+  ));
+  if (tables.length === 0 || !root.isConnected) return;
+
+  const measurementRoot = root.ownerDocument.createElement('div');
+  measurementRoot.setAttribute('aria-hidden', 'true');
+  measurementRoot.setAttribute('data-md-table-measure', '');
+  measurementRoot.style.position = 'fixed';
+  measurementRoot.style.left = '-100000px';
+  measurementRoot.style.top = '0';
+  measurementRoot.style.visibility = 'hidden';
+  measurementRoot.style.pointerEvents = 'none';
+  measurementRoot.style.width = 'max-content';
+
+  const probes = tables.map((table) => {
+    const getRowCells = (row: HTMLTableRowElement): HTMLTableCellElement[] => (
+      Array.from(row.children).filter((child): child is HTMLTableCellElement => (
+        child.tagName === 'TH' || child.tagName === 'TD'
+      ))
+    );
+    const bodyRows = Array.from(table.querySelectorAll<HTMLTableRowElement>('tbody tr'));
+    const sourceRows = bodyRows.some((row) => getRowCells(row).length > 0)
+      ? bodyRows
+      : Array.from(table.querySelectorAll<HTMLTableRowElement>('thead tr'));
+    const columnCount = Math.max(
+      0,
+      ...Array.from(table.querySelectorAll<HTMLTableRowElement>('tr')).map((row) => getRowCells(row).length),
+    );
+    const columnProbes: HTMLTableElement[] = [];
+
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      const probeTable = root.ownerDocument.createElement('table');
+      probeTable.className = table.className;
+      probeTable.style.tableLayout = 'auto';
+      probeTable.style.width = 'max-content';
+      const probeBody = root.ownerDocument.createElement('tbody');
+
+      for (const row of sourceRows) {
+        const sourceCell = getRowCells(row)[columnIndex];
+        if (!sourceCell) continue;
+        const probeRow = root.ownerDocument.createElement('tr');
+        const probeCell = sourceCell.cloneNode(true);
+        if (!(probeCell instanceof HTMLElement)) continue;
+        probeCell.style.width = 'auto';
+        probeCell.style.minWidth = '0';
+        probeCell.style.maxWidth = 'none';
+        probeCell.style.whiteSpace = 'nowrap';
+        probeCell.style.overflowWrap = 'normal';
+        probeRow.appendChild(probeCell);
+        probeBody.appendChild(probeRow);
+      }
+
+      probeTable.appendChild(probeBody);
+      measurementRoot.appendChild(probeTable);
+      columnProbes.push(probeTable);
+    }
+
+    return { table, columnProbes };
+  });
+
+  root.appendChild(measurementRoot);
+  const plans = probes.map(({ table, columnProbes }) => ({
+    table,
+    widths: columnProbes.map((probe) => Math.min(
+      TABLE_COLUMN_MAX_WIDTH,
+      Math.max(TABLE_COLUMN_MIN_WIDTH, Math.ceil(probe.getBoundingClientRect().width)),
+    )),
+  }));
+  measurementRoot.remove();
+
+  for (const { table, widths } of plans) {
+    const existingColumns = Array.from(table.children).find((child) => (
+      child.matches('colgroup[data-md-table-columns]')
+    ));
+    existingColumns?.remove();
+
+    const colgroup = root.ownerDocument.createElement('colgroup');
+    colgroup.setAttribute('data-md-table-columns', '');
+    for (const width of widths) {
+      const column = root.ownerDocument.createElement('col');
+      column.style.width = `${width}px`;
+      colgroup.appendChild(column);
+    }
+    const firstSection = Array.from(table.children).find((child) => (
+      child.tagName === 'THEAD' || child.tagName === 'TBODY' || child.tagName === 'TFOOT'
+    )) ?? null;
+    table.insertBefore(colgroup, firstSection);
+    table.style.tableLayout = 'fixed';
+    table.style.width = `${widths.reduce((total, width) => total + width, 0)}px`;
+    table.setAttribute(TABLE_LAYOUT_ATTR, 'fixed');
   }
 };
 


### PR DESCRIPTION
## Intent

Wide Markdown tables currently force every cell through a narrow maximum width, causing long values to wrap into nearly vertical text and making rows difficult to compare. Size each column from settled table-body content, clamp the result to 120-320 px, and preserve horizontal scrolling so dense tables remain readable on wide and narrow viewports.

## Non-goals

- Changing Markdown parsing, sanitization, or table content.
- Recomputing widths while an assistant response is streaming.
- Redesigning non-Markdown tables or replacing narrow-screen horizontal scrolling.
- Adding runtime-specific table behavior.

## Affected surfaces

- `packages/ui` Markdown rendering and its focused tests.
- Settled assistant Markdown tables, including body-backed tables and header-only fallback tables.
- Web, Desktop, VS Code, hosted mobile, and Capacitor mobile consume this shared renderer; no runtime bridge or API behavior changes.
- Desktop and narrow/mobile table geometry changes visibly. Persisted data, external contracts, authentication, and transport behavior are unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and base-branch `CONTRIBUTING.md` | The change modifies shared UI source and user-visible rendering. | Kept ownership in `packages/ui`, changed four focused files, used package-scoped validation, documented unverified surfaces, and attached current before/after evidence. |
| `openchamber-change-discipline` | This is an executable source change with test and validation requirements. | Added no dependency, export, entrypoint, generated asset, compatibility shim, or unrelated refactor; the implementation and regression tests remain local to the Markdown renderer. |
| `performance-engineering` | Measuring table geometry can become repeated render-path work for streamed or large tables. | Geometry work is deferred to one animation frame after settlement, stale callbacks are cancelled, streaming renders do not measure, and focused tests assert the scheduling/measurement counts. |
| `theme-system` | The diff changes table layout classes and rendered visual geometry. | Reused existing semantic table/theme classes, introduced no colors, icons, primitives, or theme-specific branches, and preserved the existing overflow surface. |
| `communication-style` | The PR body is reviewer-facing documentation. | Describes the mechanism, evidence, limitations, and rollback directly without speculative claims. |
| Documentation discovery | The repository requires the nearest package README and module `DOCUMENTATION.md` when present. | No `packages/ui/README.md` or chat/Markdown-renderer owner `DOCUMENTATION.md` exists; nearby store, sync, composer, work-status, and message-part documents do not own this renderer, so local implementation and test precedent were used. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx` | Passed: 8 tests, 58 assertions. Covers body-driven sizing, 120 px minimum, 320 px maximum, no streaming measurement, and one settled measurement. |
| `bun test packages/ui/src/components/chat/MarkdownRendererImpl.test.ts` | Passed: 19 tests, 47 assertions. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bun run dead-code` | Completed; it reported only the repository's existing backlog and no newly dead source/export from this change. |
| `bunx oxlint packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx packages/ui/src/components/chat/MarkdownRendererImpl.test.ts packages/ui/src/components/chat/MarkdownRendererImpl.tsx packages/ui/src/components/chat/markdown/decorate.ts` | Did not pass: 16 existing anti-slop findings were reported outside the changed lines; no finding points to newly authored lines. No rule was disabled or weakened. |
| Manual Web HMR comparison at desktop `1536x960` and `/mobile.html` at `390x844`, dark theme | Passed for the demonstrated long-content table. The released `1.9.1` desktop baseline had no `colgroup` and rendered at about `718x1663` px. The mobile baseline from parent commit `0e3aff884` rendered at about `611x1403` px with no `colgroup`. The PR tree renders content-sized fixed columns with horizontal overflow instead of character-stacked cells; the measured mobile table was about `2157x223` px with widths `237, 320, 320, 320, 320, 320, 320` px. |
| `gh api --method HEAD` for each raw Gist image | Passed: all four original PNG URLs return `200 OK` with `Content-Type: image/png`. |
| Workspace-wide and platform-specific validation | Not run: `bun run type-check`, `bun run lint`, `bun run test`, `bun run build`, Electron, VS Code, and native-mobile builds were not executed. Manual runtime validation covered Web HMR only. |

## Visual evidence

| Scenario | Before | After |
|---|---|---|
| Web, desktop `1536x960`, dark theme | <img src="https://gist.githubusercontent.com/ChangeHow/62f718f1c2152915d3a0e38b5b772f9b/raw/5cef0a372369bb0384727b6e1884c8872d49f6c7/ego-table-before-desktop.png" width="700" alt="Released OpenChamber 1.9.1 desktop Markdown table with narrow columns and heavily wrapped text"> | <img src="https://gist.githubusercontent.com/ChangeHow/62f718f1c2152915d3a0e38b5b772f9b/raw/9abdd7275a659ca1772a80e7bdf6c10f5971c598/ego-table-after-desktop.png" width="700" alt="Pull request desktop Markdown table with content-sized columns and horizontal overflow"> |
| Web `/mobile.html`, `390x844`, dark theme | <img src="https://gist.githubusercontent.com/ChangeHow/62f718f1c2152915d3a0e38b5b772f9b/raw/fb3218d737f0d591a3888ceb917586065cebdaaa/ego-table-before-mobile.png" width="340" alt="Parent commit mobile entry Markdown table with narrow columns and heavily wrapped text"> | <img src="https://gist.githubusercontent.com/ChangeHow/62f718f1c2152915d3a0e38b5b772f9b/raw/33af2e7e7de6a19f8261ccc75f43ccbe8719d535/ego-table-after-mobile.png" width="340" alt="Pull request mobile entry Markdown table with content-sized columns and horizontal overflow"> |

## Risks and failure behavior

- Width measurement performs DOM geometry work once after a response settles. Cost grows with the cells in that table; it was protected with operation-count tests but not benchmarked or profiled on production-scale histories.
- Streaming tables retain browser auto-layout until settlement, then may adjust once on the next animation frame. Revision changes and unmounts cancel stale scheduled work.
- Body content intentionally controls widths when rows exist, so unusually long headers may wrap within a body-sized column. Header cells are used only when the body has no rows.
- Fixed pixel columns intentionally overflow narrow viewports; the existing scroll container remains the containment path rather than shrinking text back into character-stacked columns.
- The shared renderer reaches every UI runtime, but only Web HMR was exercised manually. Runtime-specific shells were not built or launched.
- No persisted state, network boundary, credential, or security behavior changes. Rollback is a single commit revert and requires no data cleanup.
