### PR TITLE
feat: add project scoped agent option

### DIFF
--- a/packages/ui/src/components/sections/projects/ProjectIdentityFields.tsx
+++ b/packages/ui/src/components/sections/projects/ProjectIdentityFields.tsx
@@ -3,6 +3,8 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/icon/Icon';
 import { ModelSelector } from '@/components/sections/agents/ModelSelector';
+import { AgentSelector } from '@/components/sections/commands/AgentSelector';
+import { isPrimaryMode } from '@/components/chat/mobileControlsUtils';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   SettingsFieldRow,
@@ -49,6 +51,8 @@ export const ProjectIdentityFields: React.FC<ProjectIdentityFieldsProps> = ({ fo
     defaultVariant,
     handleDefaultModelChange,
     handleDefaultVariantChange,
+    defaultAgent,
+    setDefaultAgent,
     isUploadingIcon,
     isRemovingCustomIcon,
     isDiscoveringIcon,
@@ -104,6 +108,18 @@ export const ProjectIdentityFields: React.FC<ProjectIdentityFieldsProps> = ({ fo
         info={t('settings.projects.page.section.chatDefaultsDescription')}
         contentClassName="space-y-0"
       >
+        <SettingsFieldRow
+          settingsItem="projects.default-agent"
+          label={t('settings.projects.page.field.projectAgent')}
+        >
+          <AgentSelector
+            agentName={defaultAgent ?? ''}
+            onChange={setDefaultAgent}
+            filter={(agent) => isPrimaryMode(agent.mode)}
+            className={SETTINGS_CUSTOM_TRIGGER_CLASS}
+          />
+        </SettingsFieldRow>
+
         <SettingsFieldRow
           settingsItem="projects.default-model"
           label={t('settings.projects.page.field.projectModel')}

--- a/packages/ui/src/components/sections/projects/ProjectsPage.tsx
+++ b/packages/ui/src/components/sections/projects/ProjectsPage.tsx
@@ -38,6 +38,7 @@ export const ProjectsPage: React.FC = () => {
       iconBackground: data.iconBackground,
       defaultModel: data.defaultModel ?? null,
       defaultVariant: data.defaultVariant ?? null,
+      defaultAgent: data.defaultAgent ?? null,
     });
   }, [selectedProject, updateProjectMeta]);
 

--- a/packages/ui/src/components/sections/projects/useProjectIdentityAutoSave.ts
+++ b/packages/ui/src/components/sections/projects/useProjectIdentityAutoSave.ts
@@ -20,6 +20,7 @@ export const useProjectIdentityAutoSave = (
     color,
     iconBackground,
     defaultModel,
+    defaultAgent,
     pendingRemoveImageIcon,
     pendingUploadIconFile,
     isUploadingIcon,
@@ -61,6 +62,7 @@ export const useProjectIdentityAutoSave = (
   }, [
     color,
     defaultModel,
+    defaultAgent,
     hasChanges,
     icon,
     iconBackground,

--- a/packages/ui/src/components/sections/projects/useProjectIdentityForm.ts
+++ b/packages/ui/src/components/sections/projects/useProjectIdentityForm.ts
@@ -25,11 +25,12 @@ export type ProjectIdentitySaveData = {
   iconBackground: string | null;
   defaultModel: string | null;
   defaultVariant: string | null;
+  defaultAgent: string | null;
 };
 
 type EditableProject = Pick<
   ProjectEntry,
-  'id' | 'label' | 'icon' | 'color' | 'iconBackground' | 'defaultModel' | 'defaultVariant' | 'iconImage' | 'path'
+  'id' | 'label' | 'icon' | 'color' | 'iconBackground' | 'defaultModel' | 'defaultVariant' | 'defaultAgent' | 'iconImage' | 'path'
 >;
 
 export const useProjectIdentityForm = (project: EditableProject | null) => {
@@ -47,6 +48,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
   const [iconBackground, setIconBackground] = React.useState<string | null>(null);
   const [defaultModel, setDefaultModel] = React.useState<string | undefined>(undefined);
   const [defaultVariant, setDefaultVariant] = React.useState<string | undefined>(undefined);
+  const [defaultAgent, setDefaultAgent] = React.useState<string | undefined>(undefined);
   const [isUploadingIcon, setIsUploadingIcon] = React.useState(false);
   const [isRemovingCustomIcon, setIsRemovingCustomIcon] = React.useState(false);
   const [isDiscoveringIcon, setIsDiscoveringIcon] = React.useState(false);
@@ -76,6 +78,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
       setIconBackground(null);
       setDefaultModel(undefined);
       setDefaultVariant(undefined);
+      setDefaultAgent(undefined);
       return;
     }
     setName(project.label ?? '');
@@ -84,6 +87,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
     setIconBackground(project.iconBackground ?? null);
     setDefaultModel(project.defaultModel);
     setDefaultVariant(project.defaultVariant);
+    setDefaultAgent(project.defaultAgent);
     setPendingRemoveImageIcon(false);
     clearPendingUploadIcon();
     setPreviewImageFailed(false);
@@ -115,6 +119,7 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
     || iconBackground !== (project?.iconBackground ?? null)
     || (defaultModel ?? undefined) !== (project?.defaultModel ?? undefined)
     || (defaultVariant ?? undefined) !== (project?.defaultVariant ?? undefined)
+    || (defaultAgent ?? undefined) !== (project?.defaultAgent ?? undefined)
     || pendingRemoveImageIcon
     || Boolean(pendingUploadIconFile)
   );
@@ -245,12 +250,14 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
       iconBackground: normalizeProjectIconBackground(willRemoveImageIcon ? null : iconBackground),
       defaultModel: defaultModel ?? null,
       defaultVariant: defaultModel ? defaultVariant ?? null : null,
+      defaultAgent: defaultAgent ?? null,
     };
   }, [
     clearPendingUploadIcon,
     color,
     defaultModel,
     defaultVariant,
+    defaultAgent,
     icon,
     iconBackground,
     name,
@@ -280,6 +287,8 @@ export const useProjectIdentityForm = (project: EditableProject | null) => {
     parsedDefaultModel,
     handleDefaultModelChange,
     handleDefaultVariantChange,
+    defaultAgent,
+    setDefaultAgent,
     isUploadingIcon,
     isRemovingCustomIcon,
     isDiscoveringIcon,

--- a/packages/ui/src/components/session/SessionSidebar.tsx
+++ b/packages/ui/src/components/session/SessionSidebar.tsx
@@ -347,6 +347,8 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
     color: string | null;
     iconBackground: string | null;
     defaultModel: string | null;
+    defaultVariant: string | null;
+    defaultAgent: string | null;
   }) => {
     if (!editingProjectDialogId) {
       return;
@@ -357,6 +359,8 @@ const SessionSidebarComponent: React.FC<SessionSidebarProps> = ({
       color: data.color,
       iconBackground: data.iconBackground,
       defaultModel: data.defaultModel ?? null,
+      defaultVariant: data.defaultVariant ?? null,
+      defaultAgent: data.defaultAgent ?? null,
     });
   }, [editingProjectDialogId, updateProjectMeta]);
 

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -658,6 +658,8 @@ export interface ProjectEntry {
   defaultModel?: string;
   /** Variant of `defaultModel`, when that model exposes any. */
   defaultVariant?: string;
+  /** Default agent for new chats in this project. Falls back to the global default agent when unset. */
+  defaultAgent?: string;
   addedAt?: number;
   lastOpenedAt?: number;
   sidebarCollapsed?: boolean;

--- a/packages/ui/src/lib/i18n/messages/de.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/de.settings.ts
@@ -1130,6 +1130,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': 'Projekt-Einstellungen',
   'settings.projects.page.section.worktree': 'Arbeitsbaum',
   'settings.projects.page.field.projectName': 'Projektname',
+  'settings.projects.page.field.projectAgent': 'Projekt-Agent',
   'settings.projects.page.field.projectModel': 'Projektmodell',
   'settings.projects.page.field.projectThinking': 'Projekt-Denkstufe',
   'settings.projects.page.section.chatDefaults': 'Vorgaben für neue Chats',

--- a/packages/ui/src/lib/i18n/messages/en.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/en.settings.ts
@@ -1192,6 +1192,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': 'Project Settings',
   'settings.projects.page.section.worktree': 'Worktree',
   'settings.projects.page.field.projectName': 'Project Name',
+  'settings.projects.page.field.projectAgent': 'Project Agent',
   'settings.projects.page.field.projectModel': 'Project Model',
   'settings.projects.page.field.projectThinking': 'Project Thinking',
   'settings.projects.page.section.chatDefaults': 'Defaults for new chats',

--- a/packages/ui/src/lib/i18n/messages/es.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/es.settings.ts
@@ -1160,6 +1160,7 @@ export const settingsDict = {
   "settings.projects.page.title.default": "Configuración del proyecto",
   "settings.projects.page.section.worktree": "Worktree",
   "settings.projects.page.field.projectName": "Nombre del proyecto",
+  "settings.projects.page.field.projectAgent": "Agente del proyecto",
   "settings.projects.page.field.projectModel": "Modelo del proyecto",
   "settings.projects.page.field.projectThinking": "Razonamiento del proyecto",
   "settings.projects.page.section.chatDefaults": "Valores por defecto para chats nuevos",

--- a/packages/ui/src/lib/i18n/messages/fr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.settings.ts
@@ -1078,6 +1078,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': 'Paramètres du projet',
   'settings.projects.page.section.worktree': 'Worktree',
   'settings.projects.page.field.projectName': 'Nom du projet',
+  'settings.projects.page.field.projectAgent': 'Agent du projet',
   'settings.projects.page.field.projectModel': 'Modèle du projet',
   'settings.projects.page.field.projectThinking': 'Réflexion du projet',
   'settings.projects.page.section.chatDefaults': 'Valeurs par défaut des nouveaux chats',

--- a/packages/ui/src/lib/i18n/messages/ja.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.settings.ts
@@ -1193,6 +1193,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': 'プロジェクト設定',
   'settings.projects.page.section.worktree': 'ワークツリー',
   'settings.projects.page.field.projectName': 'プロジェクト名',
+  'settings.projects.page.field.projectAgent': 'プロジェクトのエージェント',
   'settings.projects.page.field.projectModel': 'プロジェクトのモデル',
   'settings.projects.page.field.projectThinking': 'プロジェクトの思考レベル',
   'settings.projects.page.section.chatDefaults': '新規チャットの既定値',

--- a/packages/ui/src/lib/i18n/messages/ko.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.settings.ts
@@ -1160,6 +1160,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': '프로젝트 설정',
   'settings.projects.page.section.worktree': 'Worktree',
   'settings.projects.page.field.projectName': '프로젝트 이름',
+  'settings.projects.page.field.projectAgent': '프로젝트 에이전트',
   'settings.projects.page.field.projectModel': '프로젝트 모델',
   'settings.projects.page.field.projectThinking': '프로젝트 사고 수준',
   'settings.projects.page.section.chatDefaults': '새 채팅 기본값',

--- a/packages/ui/src/lib/i18n/messages/pl.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.settings.ts
@@ -1397,6 +1397,7 @@ export const settingsDict = {
   'settings.projects.page.field.projectIcon': 'Ikona projektu',
   'settings.projects.page.field.projectIconBackgroundAria': 'Kolor tła ikony projektu',
   'settings.projects.page.field.projectName': 'Nazwa projektu',
+  'settings.projects.page.field.projectAgent': 'Agent projektu',
   'settings.projects.page.field.projectModel': 'Model projektu',
   'settings.projects.page.field.projectThinking': 'Poziom myślenia projektu',
   'settings.projects.page.section.chatDefaults': 'Domyślne ustawienia nowych czatów',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.settings.ts
@@ -1160,6 +1160,7 @@ export const settingsDict = {
   "settings.projects.page.title.default": "Configurações do projeto",
   "settings.projects.page.section.worktree": "Worktree",
   "settings.projects.page.field.projectName": "Nome do projeto",
+  "settings.projects.page.field.projectAgent": "Agente do projeto",
   "settings.projects.page.field.projectModel": "Modelo do projeto",
   "settings.projects.page.field.projectThinking": "Raciocínio do projeto",
   "settings.projects.page.section.chatDefaults": "Padrões para novos chats",

--- a/packages/ui/src/lib/i18n/messages/tr.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/tr.settings.ts
@@ -2142,6 +2142,7 @@ export const settingsDict = {
   'settings.openchamber.appLinks.info': 'Burada listelenen linkler bu cihazda tekrar sormadan açılır. Diğer uygulama linkleri açılmadan önce her zaman sorar.',
   'settings.openchamber.appLinks.empty': 'Bu cihazda güvenilen uygulama linki yok. Bir link açarken "Güven ve aç" seçeneğini seçtiğinizde buraya eklenir.',
   'settings.openchamber.appLinks.removeAria': 'Güvenilen {scheme} linklerini kaldır',
+  'settings.projects.page.field.projectAgent': 'Proje Ajanı',
   'settings.projects.page.field.projectModel': 'Proje Modeli',
   'settings.projects.page.field.projectThinking': 'Proje Thinking\'i',
   'settings.projects.page.section.chatDefaults': 'Yeni sohbetler için varsayılanlar',

--- a/packages/ui/src/lib/i18n/messages/uk.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.settings.ts
@@ -1160,6 +1160,7 @@ export const settingsDict = {
   "settings.projects.page.title.default": "Параметри проєкту",
   "settings.projects.page.section.worktree": "Worktree",
   "settings.projects.page.field.projectName": "Назва проєкту",
+  "settings.projects.page.field.projectAgent": "Агент проєкту",
   "settings.projects.page.field.projectModel": "Модель проєкту",
   "settings.projects.page.field.projectThinking": "Міркування проєкту",
   "settings.projects.page.section.chatDefaults": "Значення за замовчуванням для нових чатів",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.settings.ts
@@ -1160,6 +1160,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': '项目设置',
   'settings.projects.page.section.worktree': '工作树',
   'settings.projects.page.field.projectName': '项目名称',
+  'settings.projects.page.field.projectAgent': '项目代理',
   'settings.projects.page.field.projectModel': '项目模型',
   'settings.projects.page.field.projectThinking': '项目思考级别',
   'settings.projects.page.section.chatDefaults': '新聊天的默认设置',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.settings.ts
@@ -1067,6 +1067,7 @@ export const settingsDict = {
   'settings.projects.page.title.default': '專案設定',
   'settings.projects.page.section.worktree': 'Worktree',
   'settings.projects.page.field.projectName': '專案名稱',
+  'settings.projects.page.field.projectAgent': '專案代理',
   'settings.projects.page.field.projectModel': '專案模型',
   'settings.projects.page.field.projectThinking': '專案思考層級',
   'settings.projects.page.section.chatDefaults': '新聊天的預設設定',

--- a/packages/ui/src/lib/persistence.ts
+++ b/packages/ui/src/lib/persistence.ts
@@ -424,6 +424,16 @@ const sanitizeProjects = (value: unknown): DesktopSettings['projects'] | undefin
     if (typeof candidate.color === 'string' && candidate.color.trim().length > 0) {
       project.color = candidate.color.trim();
     }
+    if (typeof candidate.defaultModel === 'string' && candidate.defaultModel.includes('/')) {
+      project.defaultModel = candidate.defaultModel.trim();
+      // A variant only means something next to the model it belongs to.
+      if (typeof candidate.defaultVariant === 'string' && candidate.defaultVariant.trim().length > 0) {
+        project.defaultVariant = candidate.defaultVariant.trim();
+      }
+    }
+    if (typeof candidate.defaultAgent === 'string' && candidate.defaultAgent.trim().length > 0) {
+      project.defaultAgent = candidate.defaultAgent.trim();
+    }
     if (candidate.iconBackground === null) {
       project.iconBackground = null;
     } else {

--- a/packages/ui/src/lib/settings/search.ts
+++ b/packages/ui/src/lib/settings/search.ts
@@ -572,6 +572,12 @@ const SETTINGS_SEARCH_ITEMS: readonly SettingsSearchItem[] = [
     keywords: ['label', 'display name', 'project metadata'],
   },
   {
+    id: 'projects.default-agent',
+    page: 'projects',
+    titleKey: 'settings.projects.page.field.projectAgent',
+    keywords: ['agent', 'default', 'new chat', 'project metadata'],
+  },
+  {
     id: 'projects.default-model',
     page: 'projects',
     titleKey: 'settings.projects.page.field.projectModel',

--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -828,6 +828,50 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentVariant).toBe('high');
   });
 
+  test('a project default agent wins over the settings default agent', () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [provider('openai', 'gpt-5.5')],
+      agents: [testAgent('build'), testAgent('reviewer')],
+      currentProviderId: '',
+      currentModelId: '',
+      currentAgentName: undefined,
+      settingsDefaultAgent: 'build',
+      settingsDefaultModel: undefined,
+      settingsDefaultVariant: undefined,
+      selectionSource: 'auto',
+      directoryScoped: {},
+    });
+
+    useConfigStore.getState().applyDefaultModelAgentSelection({
+      projectDefaultAgent: 'reviewer',
+    });
+
+    expect(useConfigStore.getState().currentAgentName).toBe('reviewer');
+  });
+
+  test('an unknown project default agent falls back to the settings default agent', () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [provider('openai', 'gpt-5.5')],
+      agents: [testAgent('build'), testAgent('reviewer')],
+      currentProviderId: '',
+      currentModelId: '',
+      currentAgentName: undefined,
+      settingsDefaultAgent: 'build',
+      settingsDefaultModel: undefined,
+      settingsDefaultVariant: undefined,
+      selectionSource: 'auto',
+      directoryScoped: {},
+    });
+
+    useConfigStore.getState().applyDefaultModelAgentSelection({
+      projectDefaultAgent: 'ghost-agent',
+    });
+
+    expect(useConfigStore.getState().currentAgentName).toBe('build');
+  });
+
   test('a fresh session applies the settings thinking level instead of the previous override', () => {
     useConfigStore.setState({
       activeDirectoryKey: DIRECTORY,

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -297,7 +297,7 @@ type DefaultAgentModelSelection = {
 // Shared default-selection cascade used both at startup (loadAgents) and when opening a
 // fresh draft (applyDefaultModelAgentSelection), so the two paths stay identical.
 //
-//   Agent: settings.defaultAgent → opencode default_agent → build → first primary → first
+//   Agent: project.defaultAgent → settings.defaultAgent → opencode default_agent → build → first primary → first
 //   Model: project.defaultModel → settings.defaultModel → resolved agent's pinned model+variant → opencode config.model
 //          → opencode/big-pickle → first
 //
@@ -311,6 +311,7 @@ const resolveDefaultAgentModelSelection = ({
     providers,
     projectDefaultModel,
     projectDefaultVariant,
+    projectDefaultAgent,
     settingsDefaultAgent,
     settingsDefaultModel,
     settingsDefaultVariant,
@@ -321,6 +322,7 @@ const resolveDefaultAgentModelSelection = ({
     providers: ProviderWithModelList[];
     projectDefaultModel?: string;
     projectDefaultVariant?: string;
+    projectDefaultAgent?: string;
     settingsDefaultAgent?: string;
     settingsDefaultModel?: string;
     settingsDefaultVariant?: string;
@@ -347,7 +349,10 @@ const resolveDefaultAgentModelSelection = ({
     const primaryAgents = agents.filter((agent) => isPrimaryMode(agent.mode));
 
     let resolvedAgent: Agent | undefined;
-    if (settingsDefaultAgent) {
+    if (projectDefaultAgent) {
+        resolvedAgent = agents.find((agent) => agent.name === projectDefaultAgent);
+    }
+    if (!resolvedAgent && settingsDefaultAgent) {
         resolvedAgent = agents.find((agent) => agent.name === settingsDefaultAgent);
     }
     if (!resolvedAgent && opencodeDefaultAgent) {
@@ -1133,7 +1138,7 @@ interface ConfigStore {
     cycleCurrentVariant: () => string | undefined;
     getCurrentModelVariants: () => string[];
     setAgent: (agentName: string | undefined) => void;
-    applyDefaultModelAgentSelection: (options?: { projectDefaultModel?: string; projectDefaultVariant?: string }) => void;
+    applyDefaultModelAgentSelection: (options?: { projectDefaultModel?: string; projectDefaultVariant?: string; projectDefaultAgent?: string }) => void;
     applyOpenCodeConfigDefaults: (directory?: string | null, source?: string, config?: Config) => void;
     setSelectedProvider: (providerId: string) => void;
     setSettingsDefaultModel: (model: string | undefined) => void;
@@ -2693,6 +2698,7 @@ export const useConfigStore = create<ConfigStore>()(
                         providers,
                         projectDefaultModel: options?.projectDefaultModel,
                         projectDefaultVariant: options?.projectDefaultVariant,
+                        projectDefaultAgent: options?.projectDefaultAgent,
                         settingsDefaultAgent,
                         settingsDefaultModel,
                         settingsDefaultVariant,

--- a/packages/ui/src/stores/useProjectsStore.test.ts
+++ b/packages/ui/src/stores/useProjectsStore.test.ts
@@ -119,6 +119,37 @@ describe("useProjectsStore default model and thinking level", () => {
     const project = useProjectsStore.getState().projects[0]
     expect(project?.defaultVariant).toBe(undefined)
   })
+
+  test("keeps a default agent", () => {
+    seed({ id: "project-a", path: "/repo" } as ProjectEntry)
+
+    useProjectsStore.getState().updateProjectMeta("project-a", { defaultAgent: "reviewer" })
+
+    const project = useProjectsStore.getState().projects[0]
+    expect(project?.defaultAgent).toBe("reviewer")
+  })
+
+  test("drops the default agent when cleared", () => {
+    seed({
+      id: "project-a",
+      path: "/repo",
+      defaultAgent: "reviewer",
+    } as ProjectEntry)
+
+    useProjectsStore.getState().updateProjectMeta("project-a", { defaultAgent: null })
+
+    const project = useProjectsStore.getState().projects[0]
+    expect(project?.defaultAgent).toBe(undefined)
+  })
+
+  test("ignores an empty default agent", () => {
+    useProjectsStore.getState().synchronizeFromSettings({
+      projects: [{ id: "project-a", path: "/repo", defaultAgent: "   " }],
+    } as DesktopSettings)
+
+    const project = useProjectsStore.getState().projects[0]
+    expect(project?.defaultAgent).toBe(undefined)
+  })
 })
 
 describe("useProjectsStore.addProjects", () => {

--- a/packages/ui/src/stores/useProjectsStore.ts
+++ b/packages/ui/src/stores/useProjectsStore.ts
@@ -63,6 +63,7 @@ interface ProjectsStore {
     iconBackground?: string | null;
     defaultModel?: string | null;
     defaultVariant?: string | null;
+    defaultAgent?: string | null;
   }) => void;
   uploadProjectIcon: (id: string, file: File) => Promise<{ ok: boolean; error?: string }>;
   removeProjectIcon: (id: string) => Promise<{ ok: boolean; error?: string }>;
@@ -137,6 +138,17 @@ const normalizeDefaultModel = (value: unknown): string | undefined => {
   }
   const separatorIndex = trimmed.indexOf('/');
   if (separatorIndex <= 0 || separatorIndex >= trimmed.length - 1) {
+    return undefined;
+  }
+  return trimmed;
+};
+
+const normalizeDefaultAgent = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
     return undefined;
   }
   return trimmed;
@@ -305,6 +317,10 @@ const sanitizeProjects = (value: unknown): ProjectEntry[] => {
       if (typeof candidate.defaultVariant === 'string' && candidate.defaultVariant.trim().length > 0) {
         project.defaultVariant = candidate.defaultVariant.trim();
       }
+    }
+    const defaultAgent = normalizeDefaultAgent(candidate.defaultAgent);
+    if (defaultAgent) {
+      project.defaultAgent = defaultAgent;
     }
     if (candidate.iconBackground === null) {
       project.iconBackground = null;
@@ -539,6 +555,7 @@ const vscodeWorkspaceProjectsEqual = (left: ProjectEntry[], right: ProjectEntry[
       && leftProject.iconBackground === rightProject.iconBackground
       && leftProject.defaultModel === rightProject.defaultModel
       && leftProject.defaultVariant === rightProject.defaultVariant
+      && leftProject.defaultAgent === rightProject.defaultAgent
       && leftProject.addedAt === rightProject.addedAt
       && leftProject.lastOpenedAt === rightProject.lastOpenedAt
       && leftProject.sidebarCollapsed === rightProject.sidebarCollapsed
@@ -822,6 +839,7 @@ export const useProjectsStore = create<ProjectsStore>()(
       iconBackground?: string | null;
       defaultModel?: string | null;
       defaultVariant?: string | null;
+      defaultAgent?: string | null;
     }) => {
       if (isVSCodeProjectsRuntime) {
         return;
@@ -853,6 +871,14 @@ export const useProjectsStore = create<ProjectsStore>()(
             updated.defaultVariant = trimmed;
           } else {
             delete updated.defaultVariant;
+          }
+        }
+        if (meta.defaultAgent !== undefined) {
+          const normalized = normalizeDefaultAgent(meta.defaultAgent);
+          if (normalized) {
+            updated.defaultAgent = normalized;
+          } else {
+            delete updated.defaultAgent;
           }
         }
         // A variant without its model is meaningless, and the model may have

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1200,6 +1200,7 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
       useConfigStore.getState().applyDefaultModelAgentSelection({
         projectDefaultModel: selectedProject?.defaultModel,
         projectDefaultVariant: selectedProject?.defaultVariant,
+        projectDefaultAgent: selectedProject?.defaultAgent,
       })
     })
 

--- a/packages/ui/src/sync/session-ui-store.ts
+++ b/packages/ui/src/sync/session-ui-store.ts
@@ -1196,13 +1196,31 @@ export const useSessionUIStore = create<SessionUIState>()((set, get) => ({
     // the project's config instead so the default cascade matches app startup, then re-apply it
     // (a fresh draft must start from defaults, not inherit the previous session's selection).
     const configDirectory = normalizePath(selectedProject?.path ?? null) ?? directory
-    void activateConfigForDirectory(configDirectory).then(() => {
+    const applyProjectDefaults = () => {
       useConfigStore.getState().applyDefaultModelAgentSelection({
         projectDefaultModel: selectedProject?.defaultModel,
         projectDefaultVariant: selectedProject?.defaultVariant,
         projectDefaultAgent: selectedProject?.defaultAgent,
       })
-    })
+    }
+
+    // When the project's config is already active, apply its defaults before
+    // the draft is shown so the first new-chat opens with the project
+    // agent/model instead of the previous (global) selection. The async
+    // re-apply after activation covers the not-yet-active case (first access
+    // to the project, or coming from a worktree whose config is scoped to the
+    // worktree path).
+    const configState = useConfigStore.getState()
+    if (
+      configDirectory
+      && configState.activeDirectoryKey === configDirectory
+      && configState.agents.length > 0
+      && configState.providers.length > 0
+    ) {
+      applyProjectDefaults()
+    }
+
+    void activateConfigForDirectory(configDirectory).then(applyProjectDefaults)
 
     if (directory && directory !== useDirectoryStore.getState().currentDirectory) {
       useDirectoryStore.getState().setDirectory(directory)

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.js
@@ -156,6 +156,7 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
       const color = typeof candidate.color === 'string' ? candidate.color.trim() : '';
       const defaultModel = typeof candidate.defaultModel === 'string' ? candidate.defaultModel.trim() : '';
       const defaultVariant = typeof candidate.defaultVariant === 'string' ? candidate.defaultVariant.trim() : '';
+      const defaultAgent = typeof candidate.defaultAgent === 'string' ? candidate.defaultAgent.trim() : '';
       const addedAt = Number.isFinite(candidate.addedAt) ? Number(candidate.addedAt) : null;
       const lastOpenedAt = Number.isFinite(candidate.lastOpenedAt)
         ? Number(candidate.lastOpenedAt)
@@ -178,6 +179,7 @@ export const createSettingsNormalizationRuntime = (dependencies) => {
         ...(defaultModel && defaultModel.includes('/') ? { defaultModel } : {}),
         // A variant is meaningless without the model it belongs to.
         ...(defaultModel && defaultModel.includes('/') && defaultVariant ? { defaultVariant } : {}),
+        ...(defaultAgent ? { defaultAgent } : {}),
         ...(Number.isFinite(addedAt) && addedAt >= 0 ? { addedAt } : {}),
         ...(Number.isFinite(lastOpenedAt) && lastOpenedAt >= 0 ? { lastOpenedAt } : {}),
       };

--- a/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-normalization-runtime.test.js
@@ -122,6 +122,22 @@ describe('settings normalization runtime - symlink resolution', () => {
       expect(result[1].defaultVariant).toBe(undefined);
     });
 
+    it('keeps a default agent and drops empty values', () => {
+      const runtime = createTestRuntime({
+        realpathSync: (p) => p,
+        path: { resolve: (p) => p, sep: '/', dirname: (p) => p.split('/').slice(0, -1).join('/') || '/' },
+      });
+
+      const projects = [
+        { id: 'proj1', path: '/a', defaultAgent: 'reviewer' },
+        { id: 'proj2', path: '/b', defaultAgent: '   ' },
+      ];
+
+      const result = runtime.sanitizeProjects(projects);
+      expect(result[0].defaultAgent).toBe('reviewer');
+      expect(result[1].defaultAgent).toBe(undefined);
+    });
+
     it('deduplicates projects that resolve to the same realpath', () => {
       const runtime = createTestRuntime({
         realpathSync: (p) => p.startsWith('/symlink') ? '/real/project' : p,


### PR DESCRIPTION
## Intent

Projects can already pin a default model for new chats (`ProjectEntry.defaultModel`). This PR adds the matching **default agent**: each project can now define which agent new sessions start with, in addition to the model.

The shared default-selection cascade in `useConfigStore.resolveDefaultAgentModelSelection` becomes:

```
Agent:  project.defaultAgent → settings.defaultAgent → opencode default_agent → build → first primary → first
Model:  project.defaultModel → settings.defaultModel → resolved agent's pinned model+variant → opencode config.model → opencode/big-pickle → first
```

The project-level agent is injected at the same single point as the project-level model (`openNewSessionDraft` → `applyDefaultModelAgentSelection`), so every session-creation flow (chat, worktree, GitHub issue, Linear, scheduled tasks) picks it up through the existing `currentAgentName` state.

## Non-goals

- No change to the existing per-project default **model** behavior.
- No change to the existing global `settings.defaultAgent` behavior or its UI.
- No extension of the mobile project-edit surface (`MobileProjectEditSurface`): it already omits the default model, so omitting the default agent keeps it consistent.
- No change to `applyOpenCodeConfigDefaults` (the opencode-config-sync path): it re-applies global defaults and has no project context, matching the existing model behavior.

## Affected surfaces

| Surface | Change |
|---|---|
| `packages/ui` types | `ProjectEntry.defaultAgent?: string` (`lib/api/types.ts`) |
| `packages/ui` stores | `useProjectsStore` (normalize/sanitize/`updateProjectMeta`/VS Code equality), `useConfigStore` (cascade + `applyDefaultModelAgentSelection` options) |
| `packages/ui` sync | `openNewSessionDraft` passes `projectDefaultAgent` (`sync/session-ui-store.ts`) |
| `packages/ui` settings UI | `ProjectIdentityFields` (AgentSelector in "Defaults for new chats"), `useProjectIdentityForm`, `useProjectIdentityAutoSave`, settings search item `projects.default-agent` |
| `packages/ui` i18n | new key `settings.projects.page.field.projectAgent` in all 12 locale dictionaries |
| `packages/ui` persistence | `sanitizeProjects` now preserves `defaultModel`/`defaultVariant`/`defaultAgent` through the settings round-trip (fixes a latent data-loss bug affecting the existing model feature too) |
| `packages/web` server | `settings-normalization-runtime.js` normalizes `defaultAgent` in persisted projects |
| Persisted contract | `settings.json` projects gain an optional `defaultAgent` field. Absent field = current behavior; no migration needed. |
| Runtimes | Web/desktop/VS Code read the field through `ProjectEntry`. VS Code runtime: `updateProjectMeta` is a no-op there, consistent with the existing `defaultModel`. Mobile: edit surface unchanged (see Non-goals). |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` (root) | Mandatory skill loading, CHANGELOG read-only, validation discipline | Loaded `openchamber-change-discipline`, `settings-ui-patterns`, `locale-ui-patterns`, `ui-api-decoupling`, `sync-state-invariants`; CHANGELOG untouched |
| `openchamber-change-discipline` | Persisted contract + shared UI change | Traced every consumer of `ProjectEntry` and the settings round-trip; added round-trip preservation; kept the diff scoped to the feature |
| `settings-ui-patterns` | Settings surface + search registry | Used existing `SettingsFieldRow` primitive and `AgentSelector`; added `projects.default-agent` to the search registry with matching `data-settings-item` anchor |
| `locale-ui-patterns` | User-facing strings | New key added with real translations in all 12 dictionaries (no English placeholders) |
| `ui-api-decoupling` | Shared UI data access | No new API route; the field flows through the existing settings persistence path |
| `sync-state-invariants` | Session draft creation | `openNewSessionDraft` is the single injection point, matching the existing model injection |
| `packages/ui/src/stores/DOCUMENTATION.md`, `packages/ui/src/sync/DOCUMENTATION.md` | Owning module docs | Read before editing; no contract change requiring doc updates |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (workspace) | ✅ pass — ui, web, electron, mobile, root |
| `bun run lint` (workspace) | ✅ pass — all packages |
| `bun run build` (workspace) | ✅ pass — web, electron, vscode, mobile assets |
| `bun run test` (workspace) | ⚠️ 1 failure, **pre-existing**: i18n key-parity `gitView.empty.*` (confirmed on clean tree, unrelated to this diff). All other suites pass: UI 368/369, VS Code 26/26, Electron 18/18, Web 175/175 (1821 tests), root scripts 1/1 |
| New unit tests | ✅ +6: cascade (project agent wins over settings; unknown agent falls back), store (keep/drop/empty), server normalization |
| E2E (Playwright, local server) | ✅ selecting an agent persists across reload; cleanup resets to "Not selected" |
| `bunx oxlint` (changed files) | ⚠️ +4 findings mirroring pre-existing patterns on adjacent lines (`no-runtime-typeof`/`no-conditional-empty-object-spread` on the input-normalization style used throughout `useProjectsStore.ts` and `settings-normalization-runtime.js`); left as consistent backlog per AGENTS.md |

## Visual evidence

All screenshots: **Settings → Projects → select a project → "Defaults for new chats"** (the new **Project Agent** selector sits above Project Model).

Defaults for new chats
<img width="2099" height="1201" alt="image" src="https://github.com/user-attachments/assets/c49a2dcf-edf1-4f25-a6fe-6e727719e94a" />
<img width="2099" height="1201" alt="image" src="https://github.com/user-attachments/assets/74bd9fef-207c-4e01-b976-25cafc07dfde" />
<img width="2099" height="1201" alt="image" src="https://github.com/user-attachments/assets/e5dac4ea-462f-4e95-a119-93339937a4e0" />

## Risks and failure behavior

- **Unknown/removed agent**: the cascade falls back silently to `settings.defaultAgent` → `opencode default_agent` → `build` (unit-tested). No crash, no stale selection.
- **Empty/whitespace agent**: rejected by client sanitize and server normalization (unit-tested).
- **Round-trip data loss**: `sanitizeProjects` in `lib/persistence.ts` previously dropped `defaultModel`/`defaultVariant`/`defaultAgent` when the server echoed settings back; all three are now preserved (this also fixes the latent bug affecting the existing per-project model feature).
- **Compatibility**: `defaultAgent` is optional; existing settings files without it behave exactly as before. No migration, no downgrade hazard.
- **Security**: the agent name is used only as an array lookup against the loaded agent list and rendered through React escaping — no injection surface, no new permissions.
- **Cross-runtime**: VS Code project editing is a no-op for `updateProjectMeta` (unchanged, consistent with `defaultModel`); mobile edit surface intentionally not extended.