### PR TITLE
fix(session-goal): harden lifecycle races, recovery, and continuation admission

### DIFF
--- a/packages/web/server/index.js
+++ b/packages/web/server/index.js
@@ -402,7 +402,33 @@ const readSettingsFromDiskMigrated = (...args) => settingsRuntime.readSettingsFr
 const readSettingsFromDisk = (...args) => settingsRuntime.readSettingsFromDisk(...args);
 const readSettingsFromDiskStrict = (...args) => settingsRuntime.readSettingsFromDiskStrict(...args);
 const writeSettingsToDisk = (...args) => settingsRuntime.writeSettingsToDisk(...args);
-const persistSettings = (...args) => settingsRuntime.persistSettings(...args);
+const persistSettings = async (...args) => {
+  const changes = args[0];
+  const updated = await settingsRuntime.persistSettings(...args);
+  if (changes?.sessionGoalEnabled === true || changes?.sessionGoalEnabled === false) {
+    sessionGoalRuntime?.onSettingsChanged?.();
+  }
+  return updated;
+};
+
+// Known project directories, MRU first (lastDirectory, then projects by
+// lastOpenedAt). The session-goal restart scan uses the strict settings reader
+// so a read failure remains a retryable failure instead of an empty scan.
+const collectKnownDirectories = async (readSettings = readSettingsFromDiskStrict) => {
+  const settings = await readSettings();
+  const directories = [];
+  if (typeof settings.lastDirectory === 'string' && settings.lastDirectory) {
+    directories.push(settings.lastDirectory);
+  }
+  const projects = Array.isArray(settings.projects) ? [...settings.projects] : [];
+  projects.sort((a, b) => (b?.lastOpenedAt ?? 0) - (a?.lastOpenedAt ?? 0));
+  for (const project of projects) {
+    if (typeof project?.path === 'string' && project.path) {
+      directories.push(project.path);
+    }
+  }
+  return [...new Set(directories)];
+};
 
 const requestSecurityRuntime = createRequestSecurityRuntime({
   readSettingsFromDiskMigrated,
@@ -1239,6 +1265,12 @@ const openCodeLifecycleRuntime = createOpenCodeLifecycleRuntime({
       console.warn('Failed to reconcile sessions after OpenCode restart:', error?.message ?? error);
     }
   },
+  onOpenCodeReady: () => sessionGoalRuntime.start({
+    listDirectories: collectKnownDirectories,
+    resetRetryWindow: true,
+  }).catch((error) => {
+    console.warn('[session-goal] readiness recovery failed:', error?.message ?? error);
+  }),
   getManagedOpenCodeEnv: async () => {
     const settings = await readSettingsFromDiskMigrated().catch(() => null);
     // Each capability is its own tool and its own switch; the plugin is only
@@ -2038,6 +2070,19 @@ async function main(options = {}) {
   } catch (error) {
     console.warn('[ScheduledTasks] Failed to start runtime:', error?.message || error);
   }
+
+  // Deterministic restart recovery for persisted active goals: an already-idle
+  // session usually emits no SSE event after a restart, so a one-shot scan
+  // over all known directories re-arms the loop (see runtime start). Recovery
+  // is logically complete but resource-bounded via scan concurrency, and it
+  // runs fire-and-forget so a slow OpenCode never stalls server startup; the
+  // onOpenCodeReady edge below remains the authoritative recovery trigger
+  // with a fresh bounded retry window. There is no permanent polling.
+  sessionGoalRuntime.start({
+    listDirectories: collectKnownDirectories,
+  }).catch((error) => {
+    console.warn('[session-goal] restart recovery failed:', error?.message ?? error);
+  });
 
   // Only opens a relay control socket when the user opted in (config enabled).
   // Reconcile the relay lifecycle from demand on startup: run it if any relay

--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -119,7 +119,7 @@ This module provides OpenCode server integration utilities for the web server ru
 The runtime maintains active-session count incrementally from idempotent activity phase transitions. Upstream stall-timeout and lifecycle health checks read it in O(1); the hourly cleanup removes activity phases older than 24 hours without broadcasting synthetic state transitions. Snapshot generation remains reserved for the session-activity API.
 
 ## Public exports (lifecycle.js)
-- `createOpenCodeLifecycleRuntime(dependencies)`: creates lifecycle runtime for managed/external OpenCode process orchestration. The optional `onOpenCodeRestarted` dependency (default `null`) is fired after a successful managed restart. `index.js` rebinds event-stream readers to the possibly-new port (#2638), then calls `interruptBusySessionsAfterRestart()` and broadcasts one `opencode-restart-interrupted` UI notification when interrupted turns exist (#2943).
+- `createOpenCodeLifecycleRuntime(dependencies)`: creates lifecycle runtime for managed/external OpenCode process orchestration. The optional `onOpenCodeRestarted` dependency (default `null`) is fired after a successful managed restart. The optional `onOpenCodeReady` dependency (default `null`) is fired once on each transition from not-ready to confirmed health, including startup and recovery. `index.js` uses that edge to retry bounded session-goal restart recovery after the startup pipeline's fire-and-forget bootstrap. `index.js` also rebinds event-stream readers to the possibly-new port (#2638), then calls `interruptBusySessionsAfterRestart()` and broadcasts one `opencode-restart-interrupted` UI notification when interrupted turns exist (#2943).
 - Returned API:
   - `startOpenCode()`
   - `restartOpenCode()`

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -109,8 +109,26 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     reapManagedOrphanedProcesses = reapOrphanedProcesses,
     getWarmupDirectories = async () => [],
     onOpenCodeRestarted = null,
+    onOpenCodeReady = null,
     now = Date.now,
   } = deps;
+
+  const notifyOpenCodeReady = () => {
+    if (!onOpenCodeReady) return;
+    try {
+      Promise.resolve(onOpenCodeReady()).catch((error) => {
+        console.warn('OpenCode readiness callback failed:', error?.message ?? error);
+      });
+    } catch (error) {
+      console.warn('OpenCode readiness callback failed:', error?.message ?? error);
+    }
+  };
+
+  const markOpenCodeReady = () => {
+    const wasReady = state.isOpenCodeReady === true;
+    state.isOpenCodeReady = true;
+    if (!wasReady) notifyOpenCodeReady();
+  };
 
   const killProcessOnPortWin32 = (port) => {
     try {
@@ -753,7 +771,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
         setOpenCodePort(port);
         setDetectedOpenCodeApiPrefix(prefix);
 
-        state.isOpenCodeReady = true;
+        markOpenCodeReady();
         state.lastOpenCodeError = null;
         state.openCodeNotReadySince = 0;
 
@@ -836,7 +854,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
           console.log(`External OpenCode server on port ${probePort} is healthy`);
           state.openCodeBaseUrl = probeOrigin ?? null;
           setOpenCodePort(probePort);
-          state.isOpenCodeReady = true;
+          markOpenCodeReady();
           state.lastOpenCodeError = null;
           state.openCodeNotReadySince = 0;
           syncToHmrState();
@@ -961,7 +979,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
           continue;
         }
 
-        state.isOpenCodeReady = true;
+        markOpenCodeReady();
         state.lastOpenCodeError = null;
         return;
       } catch (error) {
@@ -1032,7 +1050,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
 
     try {
       await waitForOpenCodeReady();
-      state.isOpenCodeReady = true;
+      markOpenCodeReady();
       state.openCodeNotReadySince = 0;
 
       // Waiting for the agent to appear only makes sense when we actually
@@ -1041,7 +1059,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
         await waitForAgentPresence(agentName);
       }
 
-      state.isOpenCodeReady = true;
+      markOpenCodeReady();
       state.openCodeNotReadySince = 0;
     } catch (error) {
       state.isOpenCodeReady = false;
@@ -1081,7 +1099,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
         console.log(`Using external OpenCode server at ${label} (skip-start mode)`);
         state.openCodeBaseUrl = env.ENV_CONFIGURED_OPENCODE_HOST?.origin ?? null;
         setOpenCodePort(env.ENV_EFFECTIVE_PORT);
-        state.isOpenCodeReady = true;
+        markOpenCodeReady();
         state.isExternalOpenCode = true;
         state.lastOpenCodeError = null;
         state.openCodeNotReadySince = 0;
@@ -1091,7 +1109,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
         console.log(`Auto-detected existing OpenCode server at ${label}`);
         state.openCodeBaseUrl = env.ENV_CONFIGURED_OPENCODE_HOST?.origin ?? null;
         setOpenCodePort(env.ENV_EFFECTIVE_PORT);
-        state.isOpenCodeReady = true;
+        markOpenCodeReady();
         state.isExternalOpenCode = true;
         state.lastOpenCodeError = null;
         state.openCodeNotReadySince = 0;

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -127,11 +127,13 @@ const createRuntime = (overrides = {}, stateOverrides = {}, envOverrides = {}) =
 
 describe('OpenCode lifecycle', () => {
   it('records an authoritative ready terminal event for external startup', async () => {
+    const onOpenCodeReady = vi.fn();
     globalThis.fetch = vi.fn(async () => ({
       ok: true,
       json: async () => ({ healthy: true }),
     }));
     const runtime = createRuntime({
+      onOpenCodeReady,
       env: {
         ENV_CONFIGURED_OPENCODE_PORT: 45678,
         ENV_CONFIGURED_OPENCODE_HOST: null,
@@ -143,6 +145,8 @@ describe('OpenCode lifecycle', () => {
     });
 
     await runtime.bootstrapOpenCodeAtStartup();
+
+    expect(onOpenCodeReady).toHaveBeenCalledOnce();
 
     expect(recordStartupPerformanceMock).toHaveBeenCalledWith('opencode.bootstrap.ready', {
       totalDurationMs: expect.any(Number),

--- a/packages/web/server/lib/opencode/settings-runtime.js
+++ b/packages/web/server/lib/opencode/settings-runtime.js
@@ -13,6 +13,7 @@ import {
   seedPreferencesFrom,
   serializePreferencesDocument,
 } from './settings-files.js';
+import { isPlainObject } from './shared.js';
 
 const DEFAULT_NOTIFICATION_TEMPLATES = {
   completion: { title: '{agent_name} is ready', message: '{model_name} completed the task' },
@@ -589,8 +590,8 @@ export const createSettingsRuntime = (deps) => {
       throw error;
     }
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') {
-      throw new Error('Settings file is malformed (non-object payload)');
+    if (!isPlainObject(parsed)) {
+      throw new Error('Settings file is malformed (expected object payload)');
     }
     return parsed;
   };

--- a/packages/web/server/lib/opencode/settings-runtime.test.js
+++ b/packages/web/server/lib/opencode/settings-runtime.test.js
@@ -89,6 +89,22 @@ describe('settings runtime', () => {
     }
   });
 
+  it('rejects array-shaped strict settings while preserving empty and missing settings', async () => {
+    const { runtime, settingsFilePath, cleanup } = await createRuntime();
+    try {
+      await fsPromises.writeFile(settingsFilePath, '[]', 'utf8');
+      await expect(runtime.readSettingsFromDiskStrict()).rejects.toThrow('expected object payload');
+
+      await fsPromises.writeFile(settingsFilePath, '{}', 'utf8');
+      await expect(runtime.readSettingsFromDiskStrict()).resolves.toEqual({});
+
+      await fsPromises.rm(settingsFilePath);
+      await expect(runtime.readSettingsFromDiskStrict()).resolves.toEqual({});
+    } finally {
+      await cleanup();
+    }
+  });
+
   it.skipIf(process.platform === 'win32')('writes settings with restrictive directory and file permissions', async () => {
     const { runtime, settingsFilePath, tempRoot, cleanup } = await createRuntime();
     try {

--- a/packages/web/server/lib/session-goal/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-goal/DOCUMENTATION.md
@@ -22,7 +22,7 @@ the web server and survives UI disconnects.
   blockedStreak,           // consecutive blocked audit verdicts
   auditFailStreak,         // consecutive failed/unavailable audit calls
   note,                    // latest audit progress note, <= 280 chars
-  statusReason,            // why settled; 'resumed' is a kickoff signal from UI
+  statusReason,            // why settled; 'repeated output truncation' is the bounded truncation breaker; 'resumed' is a kickoff signal from UI
   evaluationProviderID,    // provider used by the latest successful audit
   evaluationModelID,       // model used by the latest successful audit
   lastAccountedMessageID,  // incremental accounting cursor
@@ -40,8 +40,29 @@ content, since "Implement this plan: X" alone gives the audit nothing to
 judge against. The armed send also attaches a synthetic system-reminder
 part telling the agent goal mode is active and that each turn should end
 with a factual done/verified/remaining statement for the independent audit.
-Freshness/stale-write protection is by `id`: every runtime write re-reads the
-session and drops the write when the stored goal id no longer matches.
+Freshness/stale-write protection combines goal `id`, goal metadata identity
+(objective/file flag, status, budget, and creation time), a logical-goal
+identity (objective/file flag, budget, and creation time), expected `status`, a per-session cancellation generation, and a runtime-local serialized
+read/modify/PATCH queue. Busy/retry status events and fresh goal replacements
+advance the generation before clearing ordinary work; only an admitted or
+ambiguous dispatch consumes its reservation, while rejected and still-pending
+dispatches remain available for rollback or reconciliation. Repeated identical
+`session.updated` events do not. A newer runtime write supersedes an older
+queued write. Resume dedup keeps the CAS identity separate from the goal
+lifecycle signal (`goal.updatedAt` plus the session's `time.updated`), so
+repeated delivery is suppressed while a file-backed edit can start a new
+Resume. At the `session.updated` boundary, finite `session.time.updated` is
+the primary monotonic freshness value and finite `goal.updatedAt` is its
+secondary value. Older events are ignored; equal freshness keeps the first
+accepted event. A first event may have no freshness timestamp, but after a
+finite per-session baseline exists, an event with no finite freshness value is
+ignored. Every write and continuation re-checks stopped state, generation,
+goal identity, and active status immediately before its operation. A
+continuation also re-reads the message tail and effective file objective after
+the final admission checks and immediately before `prompt_async`. External UI
+`PATCH` callers cannot participate in that queue or CAS protocol, so they can
+still race a runtime write; these checks are not cross-process atomicity or a
+server-side CAS.
 
 ## File-backed objectives
 
@@ -61,8 +82,16 @@ before touching the filesystem). Rationale: metadata rides every
   patching the goal metadata and falls back to an inline objective when the
   write fails; `clearSessionGoal` deletes the file best-effort.
 - The tick resolves the effective objective fresh on every cycle (the file
-  is live-editable mid-goal) and falls back to the inline `objective` when
-  the file is unreadable — a goal never dies because a file went away.
+  is live-editable mid-goal). A file-read failure is never authoritative empty
+  success: when no inline fallback exists, the runtime uses the normal bounded
+  retry/backoff policy and settles the goal as `blocked` with
+  `statusReason: 'objective file unavailable'` after retry exhaustion.
+  The runtime captures that effective text for the tick and re-reads the file
+  immediately before every terminal write and continuation dispatch; changed content rejects
+  stale in-flight work and starts a fresh bounded tick without changing the
+  metadata identity.
+  Inline fallbacks continue to preserve the ordinary file-backed path when the
+  file is temporarily unreadable.
 - UI display fetches content via the GET route
   (`useGoalObjectiveContent`); in VS Code the route is unavailable, so the
   strip degrades to the audit note (display-only fallback by design).
@@ -73,44 +102,116 @@ before touching the filesystem). Rationale: metadata rides every
 ## Flow
 
 1. `createSessionGoalRuntime` subscribes to the global SSE hub (same pattern
-   as session-assist — it needs the envelope's `directory`).
-2. `session.status: idle` arms a 15s per-session timer; `busy`/`retry` clears
-   it. A `session.updated` carrying a fresh active goal (`turnsUsed === 0` or
+   as session-assist — it needs the envelope's `directory`). It keeps a local
+   directory record for every authoritative active goal it observes. On server
+   startup, `start({ listDirectories })` performs one scan over all known
+   directories (MRU-first) and arms active root goals that emitted no
+    post-restart event. Recovery is logically complete but resource-bounded:
+    at most three per-directory fetches run at once per `start()` invocation,
+    each isolated so one slow or unavailable project cannot block the others.
+    Overlapping `start()` scans are superseded by scan epoch, never duplicated:
+    only the newest scan may arm timers, mutate recovery holds, or schedule
+    startup recovery; stale in-flight fetches keep their timeout budget but
+    their results are ignored. The startup caller
+   launches the scan fire-and-forget so server startup never stalls on a
+   slow OpenCode; the strict settings read distinguishes a missing settings
+   file (successful empty result) from malformed data, including an array
+   payload, and from a read or migration failure. If the directory list or a
+   session-list fetch is unavailable, the scan schedules at most four delayed
+   recovery attempts and never treats the failure as an empty result. The
+   OpenCode lifecycle keeps its separate best-effort warmup fallback, while
+   `start` retains the strict signal for goal recovery. The lifecycle calls
+   `start` again after confirmed readiness with a fresh bounded window, covering
+   the startup race where the initial scan ran before OpenCode was usable.
+   Recovery scans every known directory and has no permanent polling loop.
+2. `session.status: idle` arms a 15s per-session timer; `busy`/`retry` advances
+   the session generation before clearing it. A `session.updated` carrying a fresh active goal (`turnsUsed === 0` or
    `statusReason === 'resumed'`) arms a kickoff timer — 3s for fresh goals,
-   ~250ms for an explicit Resume so the nudge feels immediate — since setting
-   a goal on an idle session emits no status transition.
+    ~250ms for an explicit Resume so the nudge feels immediate — since setting
+    a goal on an idle session emits no status transition. Resume replaces an
+   existing idle timer; if work is in flight, the replacement is armed once
+   that work clears. A shorter pending delay always wins, and a later normal
+   idle event cannot replace an already-earlier Resume timer. Fetch/quiet
+   failures use bounded exponential delays derived from the idle delay (15s,
+   30s, 60s, 120s by default), at most four retries after the initial tick.
+     On fetch retry exhaustion, the runtime re-reads the authoritative goal and
+     settles an active goal as `blocked` even when no dispatch reservation exists.
+     The guarded write uses the current goal revision and generation, with a
+     `statusReason` that identifies the exhausted fetch retry. If the read or
+     blocked PATCH is unavailable, terminalization retries with bounded backoff
+     and then stops until a later authoritative idle event or Resume starts a
+     fresh bounded window. This path never calls `prompt_async`.
+    Authoritative activity and successful audit/continuation progress reset the
+    corresponding retry state; a failed fetch never becomes an empty success.
+    A `message.updated` user event invalidates an armed timer or in-flight tick
+    only when its finite creation timestamp is at or after that work's arm
+    point. Replayed events and events without timestamps do not cancel active
+    work; Clear/no-goal updates and user aborts keep their explicit invalidation
+    behavior.
 3. On fire (`tick`), gated by the `sessionGoalEnabled` setting:
-   - fetch session (skip sub-agent sessions), require an `active` goal;
+    - fetch session (skip sub-agent sessions), require an `active` goal;
+      a response with the requested ID but without `metadata.openchamber.goal`
+      is a valid no-goal response only when this runtime has no known active goal;
+      otherwise it is partial/unknown and follows the bounded fetch-retry policy;
    - authoritative live-activity check after the quiet window: re-read the
      session status map, bail if the parent resumed, then list direct child
      sessions and bail while any child is `busy`/`retry`. A background
-     subagent leaves its parent idle, then injects its result into the parent
-     when done; that parent `busy` → `idle` cycle re-arms the loop without
-     polling. Status/children fetch failure is unknown, not empty, so it skips
-     the audit and retries after another quiet window;
+      subagent leaves its parent idle, then injects its result into the parent
+      when done; that parent `busy` → `idle` cycle re-arms the loop without
+      polling. Status/children/message fetch failure is unknown, not empty, so
+      it skips the audit and re-arms a bounded quiet retry after in-flight work
+       clears. A fetch failure is never represented as an empty successful
+       response.
+       Recent-message and child/status payloads are shape-validated at the
+       runtime boundary. A valid status map omits idle sessions, so the target
+       or a child absent from that map is authoritative idle. Malformed maps,
+       malformed explicit target/child entries, and unknown explicit status
+       types remain retryable unknown state, never an empty success.
+       Unknown status events for a known goal follow the bounded status retry
+       policy instead of clearing timers or treating the session as busy;
+       unknown events for unrelated sessions do not invalidate this goal.
    - quiescence check via the message tail (trailing user message or
      unfinished assistant reply → bail; the next idle transition re-arms);
    - token accounting as a SNAPSHOT of the latest completed assistant turn:
-     `input + cache.read + output`. Earlier turns' inputs and outputs fold
+      `input + reasoning + cache.read + cache.write + output`. Earlier turns' inputs and outputs fold
      into the next turn's cache, so the latest snapshot already carries the
      whole run's paid tokens — no summing across messages. Goal-relative via
-     `tokensBaseline` (the same snapshot of the newest pre-goal turn,
-     captured on the first tick). Compaction (an assistant message with
-     `summary: true`) breaks the snapshot chain, so accounting is segmented:
-     the summary message closes the segment into `tokensCommitted` (the
-     summary turn read the whole context, so its snapshot prices the
-     compaction itself) and the next segment starts with a zero baseline.
-     `tokensUsed = tokensCommitted + current segment`, kept monotonic so
-     unflagged context shrinks never move the budget backwards;
+      `tokensBaseline` (the same snapshot of the newest pre-goal turn,
+      captured on the first tick). Compaction (an assistant message with
+      `summary: true`) breaks the snapshot chain, so accounting is segmented:
+       the summary message closes the segment into `tokensCommitted`; OpenCode
+       zeroes the summary token fields, so the compaction call itself is a
+       known undercount, and the next segment starts with a zero baseline.
+      Messages are ordered by finite `time.created`, while equal timestamps
+      retain authoritative API order. Missing or non-finite timestamps stay in
+      a stable unknown bucket after timestamped messages. The persisted `lastAccountedMessageID`
+      remains compatible; if it is outside the bounded page, the runtime does
+      not replay the page or infer chronology from IDs and preserves prior
+      monotonic totals until a safe cursor is visible. `tokensUsed =
+      tokensCommitted + current segment`, kept monotonic so unflagged context
+      shrinks never move the budget backwards;
+      if the initial full page contains no visible pre-goal assistant baseline,
+      the runtime conservatively leaves the cursor and totals unchanged rather
+      than charging unknown pre-goal context. This can undercount until a safe
+      baseline is visible, but preserves monotonic totals and summary
+      segmentation;
    - a user abort pauses the goal instead of blocking it: the event path in
      `processPayload` pauses immediately on the MessageAbortedError message
-     (before any tick could send a continuation over the user's explicit
-     stop), with a tick-side safety net. Messages sent while paused leave
-     the goal alone; Resume re-arms the loop, and resuming over an aborted
-     tail skips the audit and goes straight to a continuation nudge;
-    - terminal checks, cheapest first: assistant turn error → `blocked`;
-      `tokensUsed >= tokenBudget` → `budgetLimited`;
-      `turnsUsed >= MAX_AUTO_TURNS` (20) → `blocked`;
+      (before any tick could send a continuation over the user's explicit
+      stop), with a tick-side safety net. A per-session cancellation generation
+      prevents stale ticks from writing metadata or dispatching after abort. If
+      busy/retry advances the generation before the pause write completes, the
+      pending abort is rebound to the new generation and the next authoritative
+      idle pauses the goal before audit/dispatch.
+      Messages sent while paused leave the goal alone; Resume re-arms the loop,
+      and resuming over an aborted tail skips the audit and goes straight to a
+      continuation nudge;
+    - terminal checks, cheapest first: genuine assistant turn errors → `blocked`;
+      `finish: "length"` and `MessageOutputLengthError` remain resumable when
+      applicable: the first eligible completed non-summary truncation may
+      recover, while the second consecutive one blocks with
+      `statusReason: 'repeated output truncation'`; summaries and assistants
+      without a finite `time.created` do not contribute to the breaker;
     - error classification is independent of `finish`: `MessageAbortedError`
       keeps the pause/resume behavior; only a `finish: "length"` with no
       error, or `MessageOutputLengthError`, is an in-progress truncation that
@@ -128,6 +229,12 @@ before touching the filesystem). Rationale: metadata rides every
       one new recovery attempt over the same transcript; the continuation
       consumes that permission, so another truncation blocks again. Resume
       does not bypass assistant errors or the token budget;
+     `tokensUsed >= tokenBudget` → `budgetLimited`;
+     `turnsUsed >= MAX_AUTO_TURNS` (20) → `blocked`;
+   - if the latest message is a compaction summary, skip the audit and
+     continue unconditionally — running into the context window mid-work is
+     by definition "in progress, not finished" (the summary is a retelling,
+     not evidence, and must not be judged);
    - otherwise, small-model audit of the objective + the last assistant turn
      only — no conversation history and no continuation prompts
      (`restrictToPreferredProvider`, session's own provider/model preferred):
@@ -141,21 +248,88 @@ before touching the filesystem). Rationale: metadata rides every
      audit unavailable") — resumable, and settling resets the streak so
      Resume gets fresh tolerance. A dead small model can never drive the
      loop blind to the turn cap;
-   - continue: persist accounting + `turnsUsed` first (a crash after the
-     write just waits for the next idle tick; the reverse could double-send),
-     re-check the tail, then `POST /session/:id/prompt_async` with the
-     continuation prompt using the last assistant message's
-     provider/model/agent — the goal spends the session's own subscription.
+    - continue: persist accounting + `turnsUsed` first (a crash after the
+      write is reconciled by the next idle tick or restart scan; the reverse
+      could double-send),
+      re-check the tail, then `POST /session/:id/prompt_async` with the
+      continuation prompt using the last assistant message's
+      provider/model/agent — the goal spends the session's own subscription.
+        A proven pre-admission rejection re-arms after in-flight work clears and
+        retries the existing accounting reservation for that exact tail without
+        incrementing tokens or turns again. The reservation is created before
+        the ambiguous accounting PATCH and is idempotently recognized on the
+        next read, so an accepted PATCH with a lost response cannot double-count.
+        Proven rejection dispatch is attempted at most four times, including the
+         initial attempt. On exhaustion the runtime enters an in-memory
+         `terminalization-pending` state before disabling ordinary retries. An
+         authoritative active goal is settled as blocked and its reservation is
+         released only after the terminal write succeeds. If the final fetch,
+         guarded restore, or blocked PATCH fails, terminalization retries with
+          bounded backoff, at most four times after the first terminal attempt.
+           If any terminal write (`complete`, `budgetLimited`, or ordinary
+           `blocked`) committed before its response was lost, the next
+           authoritative terminal read completes the same settlement, releases
+           the matching reservation, and emits one notification without another
+           PATCH. Exhaustion of that resolution window leaves the
+          reservation protected and waits for a later authoritative idle or
+          Resume to start one new bounded resolution window. While pending or
+          escalated, no path may call `prompt_async`. An ambiguous `prompt_async`
+        response is reconciled against authoritative session, status, and
+        message state. It is never retried as a blind POST. A later status
+        drops the reservation only after an ambiguous dispatch, when activity
+        proves admission. Rejected or still-pending dispatches retain the
+        reservation. A changed tail drops the reservation. If the tail moved
+        before dispatch, guarded cleanup restores the exact
+        before-accounting values; if that restore is no longer safe, the goal is
+        explicitly blocked rather than silently charged. If both the restore
+        and blocked writes fail, the reservation remains as an explicit local
+         pending or escalated state and retries through the bounded policy; a
+          later authoritative idle or Resume starts another bounded resolution
+           window. Pause, replacement/edit, abort, and runtime stop never
+        silently drop an undispatched reservation: an active edit-in-place that
+        retains the reservation identity (`id` + `createdAt`) rebinds it and
+        preserves its accounting, while lifecycle invalidation restores the
+        exact before-state; an identity change either proves the old charge is
+        gone or blocks the current goal explicitly when the charge cannot be
+         separated. Resume adopts its authoritative accounting state. When it
+           resets `turnsUsed` while retaining the accounting cursor, any
+           rejected or terminalization reservation for the previous segment is
+           resolved as superseded, its fence is cleared, and the idle kickoff
+           creates one fresh continuation reservation. A genuinely new logical
+           goal
+          cleans up the old reservation. Accounting-first ordering remains
+          intact.
+        The restart scan uses the persisted cursor and authoritative transcript.
+        If `sessionGoalEnabled` is false, it skips the ambiguity hold and keeps a
+        bounded per-goal retry window. Any active-goal timer that fires while the
+        setting is disabled does no work or dispatch, but its authoritative local
+        session record is retained. Re-enabling the setting clears the bounded
+        retry window and re-arms every known active goal, including goals found by
+        the restart scan, so unchanged idle goals recover without permanent
+        polling.
+       If the cursor already names the current assistant tail and no in-memory
+       reservation survived, the state is ambiguous (the POST may have been
+       accepted); recovery holds that goal rather than charging or dispatching
+       again. A new tail or explicit Resume releases the hold. This is the
+       bounded safest outcome without adding a reservation schema or a
+       cross-process transaction.
 4. Settling (`complete`/`blocked`/`budgetLimited`) fires the injected
    `emitGoalNotification` so the user hears about it even with the UI closed:
+   rollback fallback that confirms `blocked` uses this same settlement path;
+   the reservation is removed only after that terminal write succeeds.
    desktop + UI broadcast + the standard push fanout (web-push with full
    text; APNs with a generic per-type title and the session name as body).
    It obeys the notify-on-completion setting. Conversely, while a goal is
    ACTIVE the notifications runtime suppresses per-turn "ready"
    notifications on every channel — they would only echo the loop's own
    continuations; error/question/permission notifications are untouched.
-   Pausing a goal from the UI also aborts the running turn (and vice versa —
-   an abort pauses the goal), so "stop" means stop on both axes.
+    Pausing a goal from the UI also aborts the running turn (and vice versa —
+    an abort pauses the goal), so "stop" means stop on both axes.
+
+`stop()` clears timers and invalidates all in-flight ticks, metadata writes, and
+continuation dispatches. Late completions cannot write or send. The runtime's
+queue/version/goal/status guards are local to this server process; an external
+UI `PATCH` cannot join them and may still race a runtime write.
 
 ## Continuation prompt
 
@@ -221,6 +395,23 @@ ordering used by create and scheduled goals.
   `session.updated` but does not run the loop.
 - A goal on a session with no assistant reply yet starts after the first
   user exchange completes (no provider/model to continue with before that).
-- `tokensUsed` only counts completed assistant messages seen within the
-  40-message fetch window per tick; extremely long busy stretches between
-  idles undercount (acceptable: budget is a guardrail, not billing).
+ - `tokensUsed` only counts completed assistant messages seen within the
+   40-message fetch window per tick; extremely long busy stretches between
+   idles undercount (acceptable: budget is a guardrail, not billing). Message
+   chronology is `time.created`; missing timestamps remain in stable API order,
+   and IDs never break chronology. The cursor is an opaque message identity,
+   never an ordering key.
+- The runtime-local queue and reservation cannot make an external UI PATCH or
+  another OpenChamber process participate in the same compare-and-swap. Final
+  session/status, transcript-tail, objective-content, generation, and status
+  checks minimize this race; a mutation after those checks and before the POST
+ remains ambiguous. Ambiguous POST responses are reconciled and never retried
+ blindly, so an accepted-but-lost continuation cannot trigger duplicate
+ provider execution. Only a proven non-admission rejection enters the bounded
+ dispatch retry policy. Undispatched accounting is restored to its guarded
+ before-state or explicitly blocks instead of being silently charged.
+- A hard process crash can still occur after the accounting PATCH and before
+  the in-memory reservation is durable. On restart the transcript/cursor hold
+  prevents a second charge or prompt, but it cannot reconstruct the exact
+  pre-PATCH counters without another persisted reservation record; the goal
+  may remain active until a new tail or explicit Resume supplies intent.

--- a/packages/web/server/lib/session-goal/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-goal/DOCUMENTATION.md
@@ -139,8 +139,10 @@ before touching the filesystem). Rationale: metadata rides every
      The guarded write uses the current goal revision and generation, with a
      `statusReason` that identifies the exhausted fetch retry. If the read or
      blocked PATCH is unavailable, terminalization retries with bounded backoff
-     and then stops until a later authoritative idle event or Resume starts a
-     fresh bounded window. This path never calls `prompt_async`.
+     and then stops until a later authoritative idle event, a confirmed
+     readiness edge (`start` with `resetRetryWindow`), an explicit Resume, or a
+     feature re-enable starts a fresh bounded window. This path never calls
+     `prompt_async`.
     Authoritative activity and successful audit/continuation progress reset the
     corresponding retry state; a failed fetch never becomes an empty success.
     A `message.updated` user event invalidates an armed timer or in-flight tick
@@ -202,7 +204,10 @@ before touching the filesystem). Rationale: metadata rides every
       prevents stale ticks from writing metadata or dispatching after abort. If
       busy/retry advances the generation before the pause write completes, the
       pending abort is rebound to the new generation and the next authoritative
-      idle pauses the goal before audit/dispatch.
+      idle pauses the goal before audit/dispatch. The pending abort is bound to
+      the goal revision that was active when it arrived (metadata identity when
+      known, otherwise the abort arrival time), so a newer goal revision is
+      discarded instead of being paused by a stale stop.
       Messages sent while paused leave the goal alone; Resume re-arms the loop,
       and resuming over an aborted tail skips the audit and goes straight to a
       continuation nudge;
@@ -271,11 +276,18 @@ before touching the filesystem). Rationale: metadata rides every
            authoritative terminal read completes the same settlement, releases
            the matching reservation, and emits one notification without another
            PATCH. Exhaustion of that resolution window leaves the
-          reservation protected and waits for a later authoritative idle or
-          Resume to start one new bounded resolution window. While pending or
+          reservation protected and waits for a later authoritative idle,
+          readiness edge, feature re-enable, or Resume to start one new
+          bounded resolution window. While pending or
           escalated, no path may call `prompt_async`. An ambiguous `prompt_async`
         response is reconciled against authoritative session, status, and
-        message state. It is never retried as a blind POST. A later status
+        message state. It is never retried as a blind POST. Only the POST
+        attempt itself classifies admission: a pre-POST read failure follows
+        the ordinary bounded fetch retry and cannot overwrite a proven
+        `rejected`/`ambiguous` dispatch outcome. Before redispatching a
+        rejected reservation the token-budget hard stop is re-applied against
+        the current authoritative goal, so an over-budget goal settles as
+        `budgetLimited` instead of dispatching. A later status
         drops the reservation only after an ambiguous dispatch, when activity
         proves admission. Rejected or still-pending dispatches retain the
         reservation. A changed tail drops the reservation. If the tail moved
@@ -284,7 +296,8 @@ before touching the filesystem). Rationale: metadata rides every
         explicitly blocked rather than silently charged. If both the restore
         and blocked writes fail, the reservation remains as an explicit local
          pending or escalated state and retries through the bounded policy; a
-          later authoritative idle or Resume starts another bounded resolution
+          later authoritative idle, readiness edge, feature re-enable, or
+          Resume starts another bounded resolution
            window. Pause, replacement/edit, abort, and runtime stop never
         silently drop an undispatched reservation: an active edit-in-place that
         retains the reservation identity (`id` + `createdAt`) rebinds it and

--- a/packages/web/server/lib/session-goal/runtime.js
+++ b/packages/web/server/lib/session-goal/runtime.js
@@ -11,8 +11,9 @@
 // has no channel to settle its own goal. When the small model is unavailable
 // the loop still terminates via the budget and the continuation cap.
 //
-// Purely event-driven like session-assist: no polling, no backfill, no session
-// scans. Only sessions that emit events while the server runs ever tick.
+// Event-driven like session-assist during normal operation: no permanent
+// polling or backfill. A bounded startup scan handles active goals whose idle
+// state produced no event while the server was down.
 
 import fs from 'fs';
 import os from 'os';
@@ -54,8 +55,38 @@ const BLOCKED_STREAK_LIMIT = 3;
 // hiccup allows a single unaudited continuation; a dead small model must not
 // drive the loop blind all the way to the turn cap.
 const AUDIT_FAIL_LIMIT = 2;
+// Fetch/quiet failures are retried at most four times after the initial tick.
+// The delay is derived from the idle delay so tests and embedded runtimes can
+// use the same policy without a second clock configuration.
+const MAX_RETRY_ATTEMPTS = 4;
+const MAX_DISPATCH_ATTEMPTS = 4;
+const STARTUP_RECOVERY_MAX_ATTEMPTS = 4;
+const STARTUP_RECOVERY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000];
+// Restart recovery is logically complete over all known directories and
+// resource-bounded via concurrency: at most three per-directory session-list
+// fetches run at once, each with its own FETCH_TIMEOUT_MS budget, so one
+// slow or unavailable project cannot stall recovery in unrelated ones.
+const RESTART_SCAN_CONCURRENCY = 3;
 
 const GOAL_STATUSES = ['active', 'paused', 'blocked', 'budgetLimited', 'complete'];
+const SESSION_STATUS_TYPES = new Set(['busy', 'idle', 'retry', 'error']);
+
+const isString = (value) => Object(value) !== value && value === String(value);
+
+const isCallable = (value) => {
+  try {
+    Function.prototype.toString.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const isNonCallableObject = (value) => value !== null
+  && Object(value) === value
+  && !isCallable(value);
+
+const isPlainObject = (value) => isNonCallableObject(value) && !Array.isArray(value);
 
 const clampText = (value, limit) => String(value ?? '').trim().slice(0, limit);
 
@@ -158,6 +189,14 @@ const extractSessionStatus = (payload) => {
   return { sessionId, type, directory };
 };
 
+const sessionStatusType = (status) => status?.type?.trim?.() || '';
+
+const isValidSessionStatus = (status) => Boolean(
+  status
+  && !Array.isArray(status)
+  && SESSION_STATUS_TYPES.has(sessionStatusType(status)),
+);
+
 // A user abort lands as an assistant message carrying MessageAbortedError.
 const extractAbortedAssistant = (payload) => {
   if (!payload || payload.type !== 'message.updated') return null;
@@ -172,11 +211,38 @@ const extractSessionUpdate = (payload) => {
   if (!payload || payload.type !== 'session.updated') return null;
   const info = payload.properties?.info;
   if (!info || typeof info !== 'object' || typeof info.id !== 'string' || !info.id) return null;
+  const sessionUpdatedAt = Number.isFinite(info.time?.updated) ? info.time.updated : null;
   return {
     sessionId: info.id,
     directory: typeof info.directory === 'string' ? info.directory : '',
     goal: parseGoalMetadata(info),
+    hasGoalNamespace: Boolean(
+      info.metadata
+      && isPlainObject(info.metadata)
+      && info.metadata.openchamber
+      && isPlainObject(info.metadata.openchamber),
+    ),
+    hasGoalKey: Boolean(
+      info.metadata
+      && isPlainObject(info.metadata)
+      && info.metadata.openchamber
+      && isPlainObject(info.metadata.openchamber)
+      && Object.hasOwn(info.metadata.openchamber, 'goal'),
+    ),
     parentID: typeof info.parentID === 'string' ? info.parentID : '',
+    sessionUpdatedAt,
+  };
+};
+
+const extractUserMessage = (payload) => {
+  if (!payload || payload.type !== 'message.updated') return null;
+  const info = payload.properties?.info;
+  if (!isPlainObject(info) || info.role !== 'user') return null;
+  if (!isString(info.sessionID) || !info.sessionID || !isString(info.id) || !info.id) return null;
+  return {
+    sessionId: info.sessionID,
+    messageId: info.id,
+    createdAt: Number.isFinite(info.time?.created) ? info.time.created : null,
   };
 };
 
@@ -228,15 +294,37 @@ const messagePartsToText = (message) => {
 // OpenCode reports tokens per message, and each turn's cache.read carries
 // everything that was already paid for in earlier turns (past inputs and
 // outputs fold into the cache of the next turn). So the accumulated cost of
-// a whole run is simply the LATEST message's input + cache.read + output —
+// a whole run is simply the LATEST message's input + reasoning + cache.read
+// + cache.write + output —
 // a snapshot, not a sum across messages.
 const messageTokenTotal = (info) => {
   const tokens = info?.tokens;
   if (!tokens || typeof tokens !== 'object') return 0;
   const input = Number.isFinite(tokens.input) ? Math.max(0, tokens.input) : 0;
   const output = Number.isFinite(tokens.output) ? Math.max(0, tokens.output) : 0;
+  const reasoning = Number.isFinite(tokens.reasoning) ? Math.max(0, tokens.reasoning) : 0;
   const cachedRead = Number.isFinite(tokens.cache?.read) ? Math.max(0, tokens.cache.read) : 0;
-  return input + cachedRead + output;
+  const cachedWrite = Number.isFinite(tokens.cache?.write) ? Math.max(0, tokens.cache.write) : 0;
+  return input + cachedRead + cachedWrite + output + reasoning;
+};
+
+const messageChronology = (message) => {
+  const created = message?.info?.time?.created;
+  return Number.isFinite(created) ? created : Number.POSITIVE_INFINITY;
+};
+
+const compareMessages = (left, right) => {
+  const leftCreated = messageChronology(left);
+  const rightCreated = messageChronology(right);
+  const leftHasCreated = Number.isFinite(leftCreated);
+  const rightHasCreated = Number.isFinite(rightCreated);
+  if (leftHasCreated && rightHasCreated && leftCreated !== rightCreated) return leftCreated - rightCreated;
+  // Missing timestamps form a stable unknown bucket after messages with an
+  // authoritative creation time. Array#sort is stable in the supported
+  // runtimes, so equal timestamps and equal-unknown messages retain the API's
+  // order. Opaque IDs are identity keys, never chronology keys.
+  if (leftHasCreated !== rightHasCreated) return leftHasCreated ? -1 : 1;
+  return 0;
 };
 
 const getErrorName = (error) => error?.name?.trim?.() ?? '';
@@ -290,19 +378,252 @@ const hasRepeatedLengthTail = (messages, latestAssistant, goalCreatedAt) => {
   );
 };
 
+// Metadata identity must not depend on the resolved objective text. File-backed
+// goals persist an empty inline objective and resolve their effective text from
+// a separate file for prompts and audits.
+const goalMetadataIdentityKey = (goal) => JSON.stringify([
+  goal.id,
+  goal.objectiveFile === true ? '' : goal.objective,
+  goal.objectiveFile,
+  goal.status,
+  goal.tokenBudget,
+  goal.createdAt,
+]);
+
+// Status and statusReason are lifecycle signals, not a new logical goal. A
+// reservation must survive pause/resume, while a changed id/objective/budget
+// still identifies a genuinely new goal and must clean up the old one.
+const goalLogicalIdentityKey = (goal) => JSON.stringify([
+  goal.id,
+  goal.objectiveFile === true ? '' : goal.objective,
+  goal.objectiveFile,
+  goal.tokenBudget,
+  goal.createdAt,
+]);
+
+// UI edits intentionally keep the goal id and creation time while changing
+// objective/budget metadata. Those edits preserve accounting and must be able
+// to rebind an undispatched reservation instead of looking like a replacement.
+const goalReservationIdentityKey = (goal) => JSON.stringify([goal.id, goal.createdAt]);
+
+const buildSettlementFields = ({ note, tokensUsed, tokensBaseline, tokensCommitted, turnsUsed, lastAccountedMessageID, evaluationProviderID, evaluationModelID }) => {
+  const fields = {};
+  if (note !== undefined) fields.note = clampText(note, NOTE_CHAR_LIMIT);
+  if (tokensUsed !== undefined) fields.tokensUsed = tokensUsed;
+  if (tokensBaseline !== undefined) fields.tokensBaseline = tokensBaseline;
+  if (tokensCommitted !== undefined) fields.tokensCommitted = tokensCommitted;
+  if (turnsUsed !== undefined) fields.turnsUsed = turnsUsed;
+  if (lastAccountedMessageID !== undefined) fields.lastAccountedMessageID = lastAccountedMessageID;
+  if (evaluationProviderID) fields.evaluationProviderID = evaluationProviderID;
+  if (evaluationModelID) fields.evaluationModelID = evaluationModelID;
+  return fields;
+};
+
+const settlementExpectedState = ({ goal, status, statusReason, note, tokensUsed, tokensBaseline, tokensCommitted, turnsUsed, lastAccountedMessageID, evaluationProviderID, evaluationModelID }) => {
+  const expected = {
+    status,
+    statusReason: clampText(statusReason, REASON_CHAR_LIMIT),
+    blockedStreak: 0,
+    auditFailStreak: 0,
+    logicalIdentityKey: goalLogicalIdentityKey(goal),
+    ...buildSettlementFields({
+      note,
+      tokensUsed,
+      tokensBaseline,
+      tokensCommitted,
+      turnsUsed,
+      lastAccountedMessageID,
+      evaluationProviderID,
+      evaluationModelID,
+    }),
+  };
+  return expected;
+};
+
+const settlementMarkerMatches = (goal, marker) => {
+  if (!goal || !marker) return false;
+  const { expected } = marker;
+  return goalLogicalIdentityKey(goal) === expected.logicalIdentityKey
+    && Object.entries(expected)
+      .filter(([key]) => key !== 'logicalIdentityKey')
+      .every(([key, value]) => goal[key] === value);
+};
+
+const reservationAccountingState = (goal) => ({
+  tokensUsed: goal.tokensUsed,
+  tokensBaseline: goal.tokensBaseline,
+  tokensCommitted: goal.tokensCommitted,
+  turnsUsed: goal.turnsUsed,
+  lastAccountedMessageID: goal.lastAccountedMessageID,
+});
+
+const reservationSettlementAccounting = (reservation) =>
+  reservation?.settlementAccounting ?? reservation?.after;
+
+const reservationGoalState = (goal) => ({
+  status: goal.status,
+  statusReason: goal.statusReason,
+  note: goal.note,
+  blockedStreak: goal.blockedStreak,
+  auditFailStreak: goal.auditFailStreak,
+  ...reservationAccountingState(goal),
+  evaluationProviderID: goal.evaluationProviderID,
+  evaluationModelID: goal.evaluationModelID,
+});
+
+const reservationStateMatches = (goal, state) => Object.entries(state)
+  .every(([key, value]) => goal[key] === value);
+
+const continuationAdmission = (error) => error?.admission === 'rejected' ? 'rejected' : 'ambiguous';
+
 export const createSessionGoalRuntime = ({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
   getSmallModelService,
   emitGoalNotification,
+  readGoalObjective = readObjective,
   isEnabled = isSessionGoalEnabled,
   idleQuietMs = IDLE_QUIET_MS,
   kickoffQuietMs = KICKOFF_QUIET_MS,
   maxAutoTurns = MAX_AUTO_TURNS,
+  retryDelaysMs = [idleQuietMs, idleQuietMs * 2, idleQuietMs * 4, idleQuietMs * 8],
+  maxRetryAttempts = MAX_RETRY_ATTEMPTS,
+  maxDispatchAttempts = MAX_DISPATCH_ATTEMPTS,
+  startupRecoveryDelaysMs = STARTUP_RECOVERY_DELAYS_MS,
+  maxStartupRecoveryAttempts = STARTUP_RECOVERY_MAX_ATTEMPTS,
 }) => {
   const timers = new Map();
-  const inflight = new Set();
+  const inflight = new Map();
+  const inflightArmPoints = new Map();
+  const pendingArms = new Map();
+  const generations = new Map();
+  const writeQueues = new Map();
+  const writeVersions = new Map();
+  const reservations = new Map();
+  const pendingAborts = new Map();
+  const retryStates = new Map();
+  const goalSnapshots = new Map();
+  const goalMetadataSnapshots = new Map();
+  const goalRevisionSnapshots = new Map();
+  // A session response may legitimately omit optional goal metadata. Keep the
+  // last known lifecycle status so an active goal is not mistaken for a clear.
+  const knownGoalStatuses = new Map();
+  // Explicit clears temporarily authorize an omitted goal response while any
+  // undispatched reservation is being reconciled.
+  const clearedGoalSessions = new Set();
+  const resumeSnapshots = new Map();
+  // A persisted accounting cursor with no in-memory reservation is ambiguous
+  // after a process crash: the prompt may have been accepted before the crash.
+  // Hold only sessions found by the one-shot restart scan until a new tail or
+  // explicit Resume provides authoritative intent.
+  const recoveryHolds = new Set();
+  const recoveryHoldDirectories = new Map();
+  // Keep authoritative active-goal sessions independently of restart recovery.
+  // A timer can fire while the feature is disabled; retaining this record lets
+  // the settings lifecycle re-arm the goal without relying on another event.
+  const activeGoalSessions = new Map();
+  // Dispatch exhaustion is terminal for automatic execution, but the final
+  // authoritative reconciliation can still fail transiently. Keep this
+  // state separate from ordinary work retries so a retry can only reconcile
+  // or settle the protected reservation, never dispatch another prompt.
+  const terminalizationStates = new Map();
+  // A terminal PATCH can commit before its response is lost. Keep the exact
+  // intended terminal mutation until an authoritative read confirms it, so
+  // settlement cleanup and notification remain idempotent without another
+  // PATCH or prompt.
+  const settlementMarkers = new Map();
+  let startupRecoveryTimer = null;
+  let startupRecoveryAttempts = 0;
+  // A disabled restart scan cannot keep an ambiguity hold: the hold would be
+  // consumed by the skipped tick and no transcript event may follow. Retry
+  // only these scanned sessions a bounded number of times so a later setting
+  // enable can recover an unchanged idle goal without global polling.
+  const disabledRecoverySessions = new Set();
+  const disabledRecoveryDirectories = new Map();
+  // session.updated delivery is ordered by the session's authoritative
+  // freshness fields, not by arrival time. Keep the last accepted pair local
+  // to this runtime so a delayed clear/pause/replacement cannot invalidate a
+  // newer generation or reservation.
+  const sessionUpdateFreshness = new Map();
   let stopped = false;
+  // Overlapping start() scans are superseded by epoch: each start() captures
+  // its epoch, and stale scans bail out without side effects once a newer
+  // start() begins. In-flight /session fetches keep their timeout budget,
+  // but their results are ignored.
+  let scanEpoch = 0;
+
+  const rememberActiveGoalSession = (sessionId, directory, goal) => {
+    if (goal?.status !== 'active') {
+      activeGoalSessions.delete(sessionId);
+      return;
+    }
+    const previous = activeGoalSessions.get(sessionId);
+    activeGoalSessions.set(sessionId, directory || previous || '');
+  };
+
+  const getGeneration = (sessionId) => generations.get(sessionId) ?? 0;
+  const advanceGeneration = (sessionId) => {
+    const generation = getGeneration(sessionId) + 1;
+    generations.set(sessionId, generation);
+    const pendingAbort = pendingAborts.get(sessionId);
+    if (pendingAbort) {
+      pendingAborts.set(sessionId, { ...pendingAbort, generation });
+    }
+    return generation;
+  };
+  const isGenerationCurrent = (sessionId, generation) => !stopped && getGeneration(sessionId) === generation;
+  const isInflight = (sessionId) => (inflight.get(sessionId) ?? 0) > 0;
+  const beginInflight = (sessionId) => {
+    inflight.set(sessionId, (inflight.get(sessionId) ?? 0) + 1);
+    if (!inflightArmPoints.has(sessionId)) inflightArmPoints.set(sessionId, Date.now());
+  };
+
+  const finishInflight = (sessionId) => {
+    const count = (inflight.get(sessionId) ?? 1) - 1;
+    if (count > 0) {
+      inflight.set(sessionId, count);
+      return;
+    }
+    inflight.delete(sessionId);
+    inflightArmPoints.delete(sessionId);
+    const pending = pendingArms.get(sessionId);
+    if (!pending || stopped) return;
+    pendingArms.delete(sessionId);
+    armTimer(sessionId, pending.directory, pending.quietMs);
+  };
+
+  const resetRetry = (sessionId, kind = null) => {
+    const current = retryStates.get(sessionId);
+    if (!current || (kind && current.kind !== kind)) return;
+    retryStates.delete(sessionId);
+  };
+
+  const scheduleRetry = (sessionId, directory, generation, kind = 'fetch', { settleOnExhaustion = true } = {}) => {
+    if (!isGenerationCurrent(sessionId, generation)) return false;
+    const previous = retryStates.get(sessionId);
+    const attempts = previous?.kind === kind ? previous.attempts + 1 : 1;
+    if (attempts > maxRetryAttempts) {
+      retryStates.set(sessionId, { kind, attempts, exhausted: true });
+      console.warn(`[session-goal] ${sessionId} ${kind} retry limit reached (${maxRetryAttempts})`);
+      if (settleOnExhaustion && (kind === 'fetch' || reservations.has(sessionId))) {
+        const reservation = reservations.get(sessionId);
+        if (reservation) {
+          reservation.resolutionState = 'terminalization-pending';
+          reservation.resolutionReason = `${kind} retry limit reached before continuation dispatch`;
+        }
+        void beginTerminalization(sessionId, directory, generation, kind).catch((error) => {
+          console.warn(`[session-goal] ${sessionId} retry exhaustion settlement failed: ${error?.message || error}`);
+        });
+      }
+      return false;
+    }
+    retryStates.set(sessionId, { kind, attempts, exhausted: false });
+    const delay = Number.isFinite(retryDelaysMs[attempts - 1])
+      ? Math.max(0, retryDelaysMs[attempts - 1])
+      : Math.max(0, idleQuietMs);
+    armTimer(sessionId, directory, delay);
+    return true;
+  };
 
   const clearTimer = (sessionId) => {
     const existing = timers.get(sessionId);
@@ -312,24 +633,58 @@ export const createSessionGoalRuntime = ({
     }
   };
 
+  const clearPendingArm = (sessionId) => {
+    pendingArms.delete(sessionId);
+  };
+
   const openCodeFetch = async (fetchPath, { directory, method = 'GET', body, query } = {}) => {
     const base = buildOpenCodeUrl(fetchPath, '');
     const params = new URLSearchParams(query || {});
     if (directory) params.set('directory', directory);
     const search = params.toString();
     const url = search ? `${base}?${search}` : base;
-    const response = await fetch(url, {
-      method,
-      headers: {
-        Accept: 'application/json',
-        ...(body ? { 'Content-Type': 'application/json' } : {}),
-        ...getOpenCodeAuthHeaders(),
-      },
-      ...(body ? { body: JSON.stringify(body) } : {}),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
+    let response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...(body ? { 'Content-Type': 'application/json' } : {}),
+          ...getOpenCodeAuthHeaders(),
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      // A transport rejection does not tell us whether OpenCode accepted a
+      // prompt before the connection died. Callers of prompt_async must
+      // reconcile authoritative state rather than retrying this blindly.
+      if (isNonCallableObject(error)) error.admission = 'ambiguous';
+      throw error;
+    }
+    if (!response || (response.ok !== true && response.ok !== false) || !Number.isFinite(response.status)) {
+      const error = new Error(`OpenCode ${method} ${fetchPath} returned an unknown response`);
+      error.admission = 'ambiguous';
+      throw error;
+    }
     if (!response.ok) {
-      throw new Error(`OpenCode ${method} ${fetchPath} failed with ${response.status}`);
+      const status = Number.isFinite(response.status) ? response.status : null;
+      const error = new Error(`OpenCode ${method} ${fetchPath} failed with ${status ?? 'unknown status'}`);
+      error.status = status;
+      error.admission = status !== null && ![408, 429, 500, 502, 503, 504].includes(status)
+        ? 'rejected'
+        : 'ambiguous';
+      throw error;
+    }
+    // prompt_async is a 204 endpoint in OpenCode. Its HTTP status is the
+    // admission result; there is no JSON body to validate (and attempting to
+    // parse one would turn a successful 204 into a false unknown). All other
+    // operations retain their JSON response contract.
+    if (method === 'POST') return null;
+    if (!isCallable(response.json)) {
+      const error = new Error(`OpenCode ${method} ${fetchPath} returned an unknown response`);
+      error.admission = 'ambiguous';
+      throw error;
     }
     return response.json().catch(() => null);
   };
@@ -339,63 +694,225 @@ export const createSessionGoalRuntime = ({
       directory,
       query: { limit: String(MESSAGE_FETCH_LIMIT) },
     }).catch(() => null);
-    return Array.isArray(messages) ? messages : null;
+    if (!Array.isArray(messages)) return null;
+    if (messages.some((message) => {
+      const info = message?.info;
+      if (!isPlainObject(info) || !isString(info.id) || !info.id) return true;
+      if (info.role !== 'user' && info.role !== 'assistant') return true;
+      if (message.parts !== undefined && (!Array.isArray(message.parts)
+        || message.parts.some((part) => !isPlainObject(part) || !isString(part.type)))) return true;
+      return false;
+    })) return null;
+    return messages;
   };
 
-  const fetchSessionStatuses = async (directory) => {
+  const fetchSession = async (sessionId, directory) => {
+    const session = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory });
+    if (
+      !session
+      || Array.isArray(session)
+      || session.id !== sessionId
+      || (session.parentID !== undefined && !isString(session.parentID))
+    ) {
+      const error = new Error(`OpenCode session ${sessionId} response was malformed`);
+      error.retryKind = 'fetch';
+      throw error;
+    }
+    const parsedGoal = parseGoalMetadata(session);
+    const hasKnownActiveGoal = !clearedGoalSessions.has(sessionId)
+      && (knownGoalStatuses.get(sessionId) === 'active'
+        || reservations.get(sessionId)?.goal?.status === 'active');
+    if (hasKnownActiveGoal && parsedGoal === null) {
+      const error = new Error(`OpenCode session ${sessionId} response omitted its known active goal`);
+      error.retryKind = 'fetch';
+      throw error;
+    }
+    if (parsedGoal) {
+      // A response already in flight when Clear was accepted must not
+      // resurrect the local active-goal marker. A newer session.updated event
+      // clears the marker when it authoritatively installs a goal again.
+      if (!clearedGoalSessions.has(sessionId)) {
+        knownGoalStatuses.set(sessionId, parsedGoal.status);
+        rememberActiveGoalSession(sessionId, session.directory || directory, parsedGoal);
+        goalRevisionSnapshots.set(sessionId, parsedGoal.updatedAt);
+      }
+    } else if (clearedGoalSessions.has(sessionId)) {
+      activeGoalSessions.delete(sessionId);
+    }
+    return session;
+  };
+
+  const fetchSessionStatuses = async (sessionId, directory) => {
     const statuses = await openCodeFetch('/session/status', { directory }).catch(() => null);
-    return statuses && typeof statuses === 'object' && !Array.isArray(statuses) ? statuses : null;
+    if (!isPlainObject(statuses)) return null;
+    // OpenCode's authoritative status map contains only non-idle sessions.
+    // A missing target is therefore idle; a present malformed/unknown value is
+    // still unknown and must remain retryable.
+    if (Object.hasOwn(statuses, sessionId) && !isValidSessionStatus(statuses[sessionId])) return null;
+    return statuses;
   };
 
   const fetchSessionChildren = async (sessionId, directory) => {
     const children = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/children`, { directory })
       .catch(() => null);
-    return Array.isArray(children) ? children : null;
+    if (!Array.isArray(children)) return null;
+    const childIds = new Set();
+    if (children.some((child) => {
+      const childId = child?.id;
+      if (!isString(childId) || !childId || childId === sessionId || childIds.has(childId)) return true;
+      if (child.parentID !== undefined && child.parentID !== sessionId) return true;
+      childIds.add(childId);
+      return false;
+    })) return null;
+    return children;
   };
 
-  const isWorkingStatus = (status) => status?.type === 'busy' || status?.type === 'retry';
+  const isWorkingStatus = (status) => sessionStatusType(status) === 'busy' || sessionStatusType(status) === 'retry';
 
-  // Merge-write the goal payload from a FRESH session read so concurrent
-  // metadata writes (assist payloads, dismissals, UI goal edits) survive.
-  // Returns the written goal, or null when the stored goal no longer matches
-  // the expected id (user replaced/cleared it while we worked).
-  const writeGoal = async (sessionId, directory, expectedGoalId, mutate) => {
-    const session = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory });
-    const currentGoal = parseGoalMetadata(session);
-    if (!currentGoal || currentGoal.id !== expectedGoalId) return null;
-    const nextGoal = { ...currentGoal, ...mutate(currentGoal), updatedAt: Date.now() };
-    const currentMetadata = session?.metadata && typeof session.metadata === 'object' ? session.metadata : {};
-    const currentNamespace = currentMetadata.openchamber && typeof currentMetadata.openchamber === 'object'
-      ? currentMetadata.openchamber
-      : {};
-    await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, {
-      directory,
-      method: 'PATCH',
-      body: {
-        metadata: {
-          ...currentMetadata,
-          openchamber: { ...currentNamespace, goal: nextGoal },
+  // Runtime writes are serialized per session. This protects read/modify/PATCH
+  // operations issued by this runtime and drops a queued operation when a
+  // newer runtime write supersedes it. External UI PATCH callers cannot join
+  // this queue or CAS protocol; their writes can still race us.
+  const writeGoal = (sessionId, directory, expectedGoal, mutate, {
+    expectedStatus = 'active',
+    expectedGoalRevision,
+    generation,
+    generationCheck = () => true,
+    finalCheck = async () => true,
+    allowStopped = false,
+  } = {}) => {
+    const version = (writeVersions.get(sessionId) ?? 0) + 1;
+    writeVersions.set(sessionId, version);
+    const previous = writeQueues.get(sessionId) ?? Promise.resolve(null);
+    const operation = previous.catch(() => null).then(async () => {
+      const isCurrentWrite = () => writeVersions.get(sessionId) === version;
+      if ((!allowStopped && stopped) || !isCurrentWrite() || (generation !== undefined && !isGenerationCurrent(sessionId, generation)) || !generationCheck()) return null;
+      const session = await fetchSession(sessionId, directory);
+      if ((!allowStopped && stopped) || !isCurrentWrite() || (generation !== undefined && !isGenerationCurrent(sessionId, generation)) || !generationCheck()) return null;
+      const currentGoal = parseGoalMetadata(session);
+      if (
+        !currentGoal
+        || goalMetadataIdentityKey(currentGoal) !== goalMetadataIdentityKey(expectedGoal)
+        || (expectedStatus && currentGoal.status !== expectedStatus)
+        || (expectedGoalRevision !== undefined && currentGoal.updatedAt !== expectedGoalRevision)
+      ) return null;
+      const mutation = mutate(currentGoal);
+      if (mutation === null) return null;
+      if (mutation === currentGoal) return currentGoal;
+      const nextGoal = { ...currentGoal, ...mutation, updatedAt: Date.now() };
+      const currentMetadata = session?.metadata && typeof session.metadata === 'object' ? session.metadata : {};
+      const currentNamespace = currentMetadata.openchamber && typeof currentMetadata.openchamber === 'object'
+        ? currentMetadata.openchamber
+        : {};
+      if ((!allowStopped && stopped) || !isCurrentWrite() || (generation !== undefined && !isGenerationCurrent(sessionId, generation)) || !generationCheck()) return null;
+      if (!(await finalCheck({ session, currentGoal, nextGoal }))) return null;
+      if ((!allowStopped && stopped) || !isCurrentWrite() || (generation !== undefined && !isGenerationCurrent(sessionId, generation)) || !generationCheck()) return null;
+      await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, {
+        directory,
+        method: 'PATCH',
+        body: {
+          metadata: {
+            ...currentMetadata,
+            openchamber: { ...currentNamespace, goal: nextGoal },
+          },
         },
-      },
+      });
+      knownGoalStatuses.set(sessionId, nextGoal.status);
+      return nextGoal;
     });
-    return nextGoal;
+    const settled = operation.finally(() => {
+      if (writeQueues.get(sessionId) === settled) writeQueues.delete(sessionId);
+    });
+    writeQueues.set(sessionId, settled);
+    return settled;
   };
 
-  const settleGoal = async ({ sessionId, directory, goal, status, statusReason, note, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, evaluationProviderID, evaluationModelID }) => {
-    const written = await writeGoal(sessionId, directory, goal.id, (current) => ({
-      status,
-      statusReason: clampText(statusReason, REASON_CHAR_LIMIT),
-      note: note !== undefined ? clampText(note, NOTE_CHAR_LIMIT) : current.note,
-      blockedStreak: 0,
-      auditFailStreak: 0,
-      ...(tokensUsed !== undefined ? { tokensUsed } : {}),
-      ...(tokensBaseline !== undefined ? { tokensBaseline } : {}),
-      ...(tokensCommitted !== undefined ? { tokensCommitted } : {}),
-      ...(lastAccountedMessageID ? { lastAccountedMessageID } : {}),
-      ...(evaluationProviderID ? { evaluationProviderID } : {}),
-      ...(evaluationModelID ? { evaluationModelID } : {}),
-    }));
-    if (!written) return;
+  const forgetReservationIfSettled = (sessionId, goal) => {
+    const reservation = reservations.get(sessionId);
+    const settlementAccounting = reservationSettlementAccounting(reservation);
+    if (
+      reservation
+      && reservation.goalId === goal.id
+      && settlementAccounting
+      && settlementAccounting.turnsUsed === goal.turnsUsed
+      && settlementAccounting.lastAccountedMessageID === goal.lastAccountedMessageID
+    ) {
+      reservations.delete(sessionId);
+    }
+  };
+
+  const resolveObjective = async (sessionId, goal) => {
+    if (!goal.objectiveFile) return { objective: goal.objective, available: Boolean(goal.objective) };
+    let fileObjective = null;
+    try {
+      fileObjective = await readGoalObjective(sessionId);
+    } catch (error) {
+      console.warn(`[session-goal] objective file read failed: ${error?.message || error}`);
+    }
+    if (isString(fileObjective) && fileObjective) return { objective: fileObjective, available: true };
+    if (goal.objective) return { objective: goal.objective, available: true };
+    return { objective: '', available: false };
+  };
+
+  const settleGoal = async ({ sessionId, directory, goal, status, statusReason, note, tokensUsed, tokensBaseline, tokensCommitted, turnsUsed, lastAccountedMessageID, evaluationProviderID, evaluationModelID, generation, expectedGoalRevision, effectiveObjective }) => {
+    const marker = {
+      directory,
+      expected: settlementExpectedState({
+        goal,
+        status,
+        statusReason,
+        note,
+        tokensUsed,
+        tokensBaseline,
+        tokensCommitted,
+        turnsUsed,
+        lastAccountedMessageID,
+        evaluationProviderID,
+        evaluationModelID,
+      }),
+    };
+    settlementMarkers.set(sessionId, marker);
+    const written = await writeGoal(sessionId, directory, goal, (current) => {
+      const mutation = {
+        status,
+        statusReason: clampText(statusReason, REASON_CHAR_LIMIT),
+        note: current.note,
+        blockedStreak: 0,
+        auditFailStreak: 0,
+        ...buildSettlementFields({
+          note,
+          tokensUsed,
+          tokensBaseline,
+          tokensCommitted,
+          turnsUsed,
+          lastAccountedMessageID,
+          evaluationProviderID,
+          evaluationModelID,
+        }),
+      };
+      return mutation;
+    }, {
+      generation,
+      expectedGoalRevision,
+      finalCheck: () => objectiveSnapshotIsCurrent({ sessionId, goal, effectiveObjective }),
+    });
+    if (!written) {
+      if (settlementMarkers.get(sessionId) === marker) settlementMarkers.delete(sessionId);
+      if (effectiveObjective !== undefined && isGenerationCurrent(sessionId, generation)) {
+        scheduleRetry(sessionId, directory, generation, 'objective');
+      }
+      return;
+    }
+    if (settlementMarkers.get(sessionId) !== marker) return;
+    activeGoalSessions.delete(sessionId);
+    finalizeSettlement({ sessionId, directory, written, status, statusReason });
+  };
+
+  const finalizeSettlement = ({ sessionId, directory, written, status, statusReason }) => {
+    settlementMarkers.delete(sessionId);
+    terminalizationStates.delete(sessionId);
+    forgetReservationIfSettled(sessionId, written);
+    resetRetry(sessionId);
     console.log(`[session-goal] ${sessionId} settled as ${status}${statusReason ? ` (${statusReason})` : ''}`);
     if (typeof emitGoalNotification === 'function') {
       try {
@@ -404,6 +921,481 @@ export const createSessionGoalRuntime = ({
         console.warn('[session-goal] notification failed:', error?.message || error);
       }
     }
+  };
+
+  const reconcileCommittedSettlement = (sessionId, directory, currentGoal) => {
+    const marker = settlementMarkers.get(sessionId);
+    if (!marker) return false;
+    const { expected } = marker;
+    if (!settlementMarkerMatches(currentGoal, marker)) {
+      settlementMarkers.delete(sessionId);
+      return false;
+    }
+    // Delete before notifying so repeated authoritative ticks cannot emit a
+    // second notification even if the notification consumer re-enters.
+    settlementMarkers.delete(sessionId);
+    finalizeSettlement({
+      sessionId,
+      directory: directory || marker.directory,
+      written: currentGoal,
+      status: expected.status,
+      statusReason: currentGoal.statusReason,
+    });
+    return true;
+  };
+
+  const reconcileCommittedTerminalization = async (sessionId, directory, reservation, generation) => {
+    if (reservations.get(sessionId) !== reservation) return false;
+    let session;
+    try {
+      session = await fetchSession(sessionId, directory || reservation.directory);
+    } catch {
+      return false;
+    }
+    if (!isGenerationCurrent(sessionId, generation)) return false;
+    const currentGoal = parseGoalMetadata(session);
+    if (
+      !currentGoal
+      || currentGoal.status !== 'blocked'
+      || goalLogicalIdentityKey(currentGoal) !== goalLogicalIdentityKey(reservation.goal)
+      || !reservationStateMatches(currentGoal, reservationAccountingState(reservationSettlementAccounting(reservation)))
+    ) return false;
+
+    // The terminal PATCH may have committed before its response was lost. The
+    // authoritative blocked goal is now the settlement; do not issue another
+    // PATCH or leave the reservation behind to fence future idle work.
+    reservations.delete(sessionId);
+    terminalizationStates.delete(sessionId);
+    activeGoalSessions.delete(sessionId);
+    resetRetry(sessionId);
+    finalizeSettlement({
+      sessionId,
+      directory: directory || reservation.directory,
+      written: currentGoal,
+      status: 'blocked',
+      statusReason: currentGoal.statusReason || reservation.resolutionReason,
+    });
+    return true;
+  };
+
+  const rebindPendingReservation = (reservation, goal, directory, { resetAccounting = false } = {}) => {
+    if (
+      !reservation
+      || reservation.postAttempts > 0
+      || goalReservationIdentityKey(reservation.goal) !== goalReservationIdentityKey(goal)
+      || !GOAL_STATUSES.includes(goal.status)
+    ) return false;
+    const lifecycle = { status: goal.status, statusReason: goal.statusReason };
+    reservation.directory = directory || reservation.directory;
+    reservation.goal = goal;
+    const accountingReset = resetAccounting
+      && !reservationStateMatches(
+        reservationAccountingState(goal),
+        reservationAccountingState(reservation.after),
+      );
+    if (accountingReset) {
+      const resumedState = reservationGoalState(goal);
+      reservation.before = resumedState;
+      reservation.after = resumedState;
+      reservation.previousTurnsUsed = goal.turnsUsed;
+      reservation.previousLastAccountedMessageID = goal.lastAccountedMessageID;
+      reservation.turnsUsed = goal.turnsUsed;
+      reservation.lastAccountedMessageID = goal.lastAccountedMessageID;
+      reservation.tokensUsed = goal.tokensUsed;
+      reservation.tokensBaseline = goal.tokensBaseline;
+      reservation.tokensCommitted = goal.tokensCommitted;
+    } else {
+      reservation.before = { ...reservation.before, ...lifecycle };
+      reservation.after = { ...reservation.after, ...lifecycle };
+    }
+    return true;
+  };
+
+  const rollbackReservation = async ({ sessionId, directory, reservation, generation, rebindGeneration = false, allowStopped = false, blockedReason = 'continuation reservation rollback unavailable', scheduleResolutionRetry = true, releaseReservation = true }) => {
+    if (reservations.get(sessionId) !== reservation) return false;
+    const resolutionReason = reservation.resolutionReason || blockedReason;
+    reservation.resolutionReason = resolutionReason;
+    const expectedGoal = { ...reservation.goal, ...reservation.after };
+    const generationCheck = rebindGeneration
+      ? () => pendingAborts.get(sessionId)?.generation === getGeneration(sessionId)
+      : undefined;
+    let restored = null;
+    let rollbackResponseLost = false;
+    try {
+      restored = await writeGoal(sessionId, directory, expectedGoal, (current) => {
+        if (!reservationStateMatches(current, reservation.after)) return null;
+        return reservation.before;
+      }, {
+        expectedStatus: expectedGoal.status,
+        generation: rebindGeneration ? undefined : generation,
+        generationCheck,
+        allowStopped,
+      });
+    } catch {
+      // A lost/failed response is followed by the same guarded operation;
+      // neither attempt may overwrite a newer goal mutation.
+      rollbackResponseLost = true;
+    }
+    if (!restored && rollbackResponseLost
+      && ((allowStopped || !stopped)
+        && (generation === undefined || isGenerationCurrent(sessionId, generation))
+        && (generationCheck === undefined || generationCheck()))) {
+      // The rollback PATCH may have committed before its response was lost.
+      // Read the authoritative goal before retrying against the after-state;
+      // the before-state proves that the rollback already succeeded.
+      try {
+        const session = await fetchSession(sessionId, directory);
+        const currentGoal = parseGoalMetadata(session);
+        if (
+          currentGoal
+          && goalReservationIdentityKey(currentGoal) === goalReservationIdentityKey(reservation.goal)
+          && reservationStateMatches(currentGoal, reservation.before)
+        ) {
+          restored = currentGoal;
+        }
+      } catch {
+        // Continue with the guarded rollback/fallback resolution below.
+      }
+    }
+    if (restored) {
+      if (releaseReservation && reservations.get(sessionId) === reservation) reservations.delete(sessionId);
+      resetRetry(sessionId, 'reservation-rollback');
+      return true;
+    }
+
+    // Do not leave an active goal carrying an undispatched charge when a
+    // guarded restore is no longer possible. This write is guarded by the
+    // complete after-state and cannot clobber a newer write.
+    let blocked = null;
+    try {
+      blocked = await writeGoal(sessionId, directory, expectedGoal, (current) => {
+        if (!reservationStateMatches(current, reservation.after)) return null;
+        return { status: 'blocked', statusReason: resolutionReason };
+      }, {
+        expectedStatus: expectedGoal.status,
+        generation: rebindGeneration ? getGeneration(sessionId) : generation,
+        generationCheck,
+        allowStopped,
+      });
+    } catch {
+      // Stopped or superseded work is intentionally not written.
+    }
+    if (blocked) {
+      if (reservations.get(sessionId) === reservation) reservations.delete(sessionId);
+      finalizeSettlement({ sessionId, directory, written: blocked, status: 'blocked', statusReason: resolutionReason });
+      return false;
+    }
+
+    // Keep the reservation as an explicit local pending state. A later bounded
+    // retry must either restore the before-state or confirm the blocked state;
+    // dropping it here would strand the active goal with an undispatched charge.
+    reservation.resolutionState = 'pending';
+    if (!scheduleResolutionRetry) return false;
+    if (!scheduleRetry(sessionId, directory, generation, 'reservation-rollback', { settleOnExhaustion: false })) {
+      reservation.resolutionState = 'escalated';
+      console.warn(`[session-goal] ${sessionId} reservation rollback unresolved after bounded retries`);
+    }
+    return false;
+  };
+
+  const settleRejectedReservation = async ({ sessionId, directory, reservation, generation, statusReason }) => {
+    if (reservations.get(sessionId) !== reservation) return false;
+    const before = reservation.before;
+    // A proven rejection cannot have consumed the prompt. Roll back the
+    // accounting first, then use the normal settlement path so the goal cannot
+    // remain active after the bounded dispatch window closes.
+    if (!reservation.restored) {
+      const restored = await rollbackReservation({
+        sessionId,
+        directory,
+        reservation,
+        generation,
+        blockedReason: `${statusReason} before continuation dispatch`,
+        scheduleResolutionRetry: false,
+        releaseReservation: false,
+      });
+      if (!restored) return reservations.get(sessionId) !== reservation;
+      reservation.restored = true;
+    }
+    reservation.settlementAccounting = reservationAccountingState(before);
+    await settleGoal({
+      sessionId,
+      directory,
+      goal: { ...reservation.goal, ...before },
+      status: 'blocked',
+      statusReason,
+      note: before.note,
+      tokensUsed: before.tokensUsed,
+      tokensBaseline: before.tokensBaseline,
+      tokensCommitted: before.tokensCommitted,
+      turnsUsed: before.turnsUsed,
+      lastAccountedMessageID: before.lastAccountedMessageID,
+      evaluationProviderID: before.evaluationProviderID,
+      evaluationModelID: before.evaluationModelID,
+      generation,
+    });
+    return reservations.get(sessionId) !== reservation;
+  };
+
+  const discardReservation = async ({ sessionId, directory, reservation, generation, rebindGeneration = false, rollback = true, blockedReason, scheduleResolutionRetry = true }) => {
+    if (reservations.get(sessionId) !== reservation) return;
+    // After prompt_async was attempted, the server may have accepted it even
+    // when the response was lost. Preserve that accounting and drop only the
+    // retry marker in that case.
+    if (!rollback || (reservation.postAttempts > 0 && reservation.dispatchOutcome !== 'rejected')) {
+      reservations.delete(sessionId);
+      return;
+    }
+    await rollbackReservation({ sessionId, directory, reservation, generation, rebindGeneration, blockedReason, scheduleResolutionRetry });
+  };
+
+  const reconcileDroppedReservation = async ({ sessionId, directory, reservation, generation, preserveAccounting = false }) => {
+    if (reservations.get(sessionId) !== reservation) return;
+    reservation.resolutionState = 'pending';
+
+    let session;
+    try {
+      session = await fetchSession(sessionId, directory || reservation.directory);
+    } catch {
+      reservation.resolutionState = 'pending';
+      scheduleRetry(sessionId, directory || reservation.directory, getGeneration(sessionId), 'reservation-rollback', { settleOnExhaustion: false });
+      return;
+    }
+    // The invalidating event may advance the generation while this read is in
+    // flight. Re-read once so an older lifecycle snapshot cannot overwrite a
+    // newer pause/resume or edit before applying the guarded cleanup.
+    let reconciliationGeneration = getGeneration(sessionId);
+    if (reconciliationGeneration !== generation) {
+      try {
+        session = await fetchSession(sessionId, directory || reservation.directory);
+      } catch {
+        scheduleRetry(sessionId, directory || reservation.directory, reconciliationGeneration, 'reservation-rollback', { settleOnExhaustion: false });
+        return;
+      }
+      reconciliationGeneration = getGeneration(sessionId);
+    }
+    const currentGoal = parseGoalMetadata(session);
+    if (terminalizationStates.has(sessionId)
+      && await reconcileCommittedTerminalization(sessionId, directory || reservation.directory, reservation, reconciliationGeneration)) {
+      return;
+    }
+    if (reservation.postAttempts > 0 && reservation.dispatchOutcome !== 'rejected') {
+      const replacementCarriesCharge = currentGoal
+        && goalLogicalIdentityKey(currentGoal) !== goalLogicalIdentityKey(reservation.goal)
+        && reservationStateMatches(currentGoal, reservation.after);
+      if (currentGoal && !replacementCarriesCharge) {
+        if (!terminalizationStates.has(sessionId)) reservations.delete(sessionId);
+        return;
+      }
+    }
+    if (!currentGoal) {
+      const rawGoal = session?.metadata?.openchamber?.goal;
+      if (rawGoal !== undefined) {
+        // A present-but-malformed goal is unknown, not an authoritative clear.
+        // Keep the reservation for a bounded retry rather than dropping a
+        // charge based on a partial payload.
+        reservation.resolutionState = 'pending';
+        scheduleRetry(sessionId, directory || reservation.directory, reconciliationGeneration, 'reservation-rollback', { settleOnExhaustion: false });
+      } else {
+        // Clear/replacement removed the old metadata, so its charge is no
+        // longer present in the authoritative goal and cannot be replayed.
+        reservations.delete(sessionId);
+      }
+      return;
+    }
+
+    if (goalReservationIdentityKey(currentGoal) === goalReservationIdentityKey(reservation.goal)) {
+      rebindPendingReservation(reservation, currentGoal, directory || reservation.directory);
+      if (reservationStateMatches(currentGoal, reservation.before)) {
+        reservations.delete(sessionId);
+        resetRetry(sessionId, 'reservation-rollback');
+        return;
+      }
+      if (preserveAccounting && currentGoal.status === 'active' && reservationStateMatches(currentGoal, reservation.after)) {
+        // Keep the local marker while persisted accounting is still
+        // undispatched. An edit-in-place may change the objective, status
+        // reason, or freshness, but deleting this marker would make the next
+        // idle tick account the same tail as a new continuation. Rebinding
+        // above is enough; the next guarded dispatch consumes this exact
+        // reservation.
+        reservation.resolutionState = 'rebound';
+        resetRetry(sessionId, 'reservation-rebound');
+        return;
+      }
+      await rollbackReservation({ sessionId, directory: directory || reservation.directory, reservation, generation: reconciliationGeneration });
+      return;
+    }
+
+    if (!reservationStateMatches(currentGoal, reservation.after)) {
+      reservations.delete(sessionId);
+      return;
+    }
+
+    // The current logical goal still contains the old charge, but its
+    // identity no longer permits a rollback to be applied safely. Make the
+    // ambiguity explicit instead of silently leaving a charged active goal.
+    try {
+      const blocked = await writeGoal(sessionId, directory || reservation.directory, currentGoal, () => ({
+        status: 'blocked',
+        statusReason: 'continuation reservation could not be reconciled',
+      }), { expectedStatus: currentGoal.status, generation: reconciliationGeneration });
+      if (blocked) {
+        reservations.delete(sessionId);
+        finalizeSettlement({
+          sessionId,
+          directory: directory || reservation.directory,
+          written: blocked,
+          status: 'blocked',
+          statusReason: 'continuation reservation could not be reconciled',
+        });
+        return;
+      }
+    } catch {
+      // Keep the explicit reservation for a bounded retry if the guarded
+      // terminal write itself is unavailable.
+    }
+    reservation.resolutionState = 'pending';
+    scheduleRetry(sessionId, directory || reservation.directory, generation, 'reservation-rollback', { settleOnExhaustion: false });
+  };
+
+  const ensureObjectiveCurrent = async ({ sessionId, directory, goal, effectiveObjective, generation }) => {
+    if (!goal.objectiveFile) return true;
+    const resolved = await resolveObjective(sessionId, goal);
+    if (!isGenerationCurrent(sessionId, generation)) return false;
+    if (resolved.available && resolved.objective === effectiveObjective) return true;
+    const reason = resolved.available ? 'objective changed during tick' : 'objective file unavailable';
+    console.warn(`[session-goal] ${sessionId} ${reason}; discarding stale work`);
+    if (!scheduleRetry(sessionId, directory, generation, 'objective')) {
+      await settleGoal({ sessionId, directory, goal, status: 'blocked', statusReason: reason, generation });
+    }
+    return false;
+  };
+
+  const objectiveSnapshotIsCurrent = async ({ sessionId, goal, effectiveObjective }) => {
+    if (!goal.objectiveFile || effectiveObjective === undefined) return true;
+    const resolved = await resolveObjective(sessionId, goal);
+    return resolved.available && resolved.objective === effectiveObjective;
+  };
+
+  const settleAfterRetryExhaustion = async (sessionId, directory, generation, kind) => {
+    const reservation = reservations.get(sessionId);
+    if (!reservation) {
+      let session;
+      session = await fetchSession(sessionId, directory);
+      if (!isGenerationCurrent(sessionId, generation)) return;
+      const currentGoal = parseGoalMetadata(session);
+      if (
+        currentGoal
+        && currentGoal.status !== 'active'
+        && reconcileCommittedSettlement(sessionId, directory, currentGoal)
+      ) return;
+      if (!currentGoal || currentGoal.status !== 'active') {
+        terminalizationStates.delete(sessionId);
+        resetRetry(sessionId);
+        return;
+      }
+      const terminalization = terminalizationStates.get(sessionId);
+      if (
+        (terminalization?.expectedGoalIdentity
+          && goalMetadataIdentityKey(currentGoal) !== terminalization.expectedGoalIdentity)
+        || (terminalization?.expectedGoalRevision !== undefined
+          && currentGoal.updatedAt !== terminalization.expectedGoalRevision)
+      ) {
+        terminalizationStates.delete(sessionId);
+        resetRetry(sessionId);
+        return;
+      }
+      await settleGoal({
+        sessionId,
+        directory,
+        goal: currentGoal,
+        status: 'blocked',
+        statusReason: `${kind} retry limit reached`,
+        generation,
+        expectedGoalRevision: currentGoal.updatedAt,
+      });
+      return;
+    }
+    if (await reconcileCommittedTerminalization(sessionId, directory, reservation, generation)) return;
+    const terminalReason = kind === 'dispatch'
+      ? 'continuation dispatch retry limit reached'
+      : `${kind} retry limit reached`;
+    if (reservation.postAttempts > 0 && reservation.dispatchOutcome !== 'rejected') {
+      await settleGoal({
+        sessionId,
+        directory,
+        goal: { ...reservation.goal, ...reservation.after },
+        status: 'blocked',
+        statusReason: terminalReason,
+        generation,
+      });
+    } else if (reservation.postAttempts > 0) {
+      const settled = await settleRejectedReservation({
+        sessionId,
+        directory,
+        reservation,
+        generation,
+        statusReason: terminalReason,
+      });
+      if (!settled) throw new Error(`${kind} terminalization did not settle the rejected reservation`);
+    } else {
+      await discardReservation({
+        sessionId,
+        directory,
+        reservation,
+        generation,
+        blockedReason: `${terminalReason} before continuation dispatch`,
+        scheduleResolutionRetry: false,
+      });
+    }
+    if (reservations.get(sessionId) !== reservation) {
+      terminalizationStates.delete(sessionId);
+      resetRetry(sessionId);
+      return;
+    }
+    throw new Error(`${kind} terminalization did not settle the reservation`);
+  };
+
+  const scheduleTerminalizationRetry = (sessionId, directory, generation, kind) => {
+    if (!isGenerationCurrent(sessionId, generation)) return false;
+    const previous = terminalizationStates.get(sessionId);
+    const attempts = (previous?.kind === kind ? previous.attempts : 0) + 1;
+    if (attempts > maxRetryAttempts) {
+      terminalizationStates.set(sessionId, { ...previous, kind, attempts, exhausted: true });
+      console.warn(`[session-goal] ${sessionId} ${kind} terminalization retry limit reached (${maxRetryAttempts})`);
+      return false;
+    }
+    terminalizationStates.set(sessionId, { ...previous, kind, attempts, exhausted: false });
+    const delay = Number.isFinite(retryDelaysMs[attempts - 1])
+      ? Math.max(0, retryDelaysMs[attempts - 1])
+      : Math.max(0, idleQuietMs);
+    armTimer(sessionId, directory, delay);
+    return true;
+  };
+
+  const beginTerminalization = (sessionId, directory, generation, kind) => {
+    const reservation = reservations.get(sessionId);
+    const terminalReason = kind === 'dispatch'
+      ? 'continuation dispatch retry limit reached'
+      : `${kind} retry limit reached`;
+    if (reservation) {
+      reservation.resolutionState = 'terminalization-pending';
+      reservation.resolutionReason = `${terminalReason} before continuation dispatch`;
+    }
+    terminalizationStates.set(sessionId, {
+      kind,
+      attempts: 0,
+      exhausted: false,
+      expectedGoalIdentity: goalMetadataSnapshots.get(sessionId),
+      expectedGoalRevision: goalRevisionSnapshots.get(sessionId),
+    });
+    return settleAfterRetryExhaustion(sessionId, directory, generation, kind)
+      .catch((error) => {
+        if (isGenerationCurrent(sessionId, generation) && reservations.get(sessionId) === reservation) {
+          scheduleTerminalizationRetry(sessionId, directory, generation, kind);
+        }
+        console.warn(`[session-goal] ${sessionId} terminalization failed: ${error?.message || error}`);
+      });
   };
 
   const runAudit = async ({ goal, assistantText, directory, lastAssistantInfo }) => {
@@ -469,55 +1461,243 @@ export const createSessionGoalRuntime = ({
     }
   };
 
-  const sendContinuation = async ({ sessionId, directory, goal, lastAssistantInfo }) => {
+  const sendContinuation = async ({ sessionId, directory, goal, effectiveObjective, expectedTailID, lastAssistantInfo, generation, onDispatchAttempt }) => {
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    let authoritativeSession;
+    try {
+      authoritativeSession = await fetchSession(sessionId, directory);
+    } catch (error) {
+      const retryableError = error instanceof Error ? error : new Error(String(error));
+      retryableError.retryKind = 'fetch';
+      throw retryableError;
+    }
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    const authoritativeGoal = parseGoalMetadata(authoritativeSession);
+    if (
+      !authoritativeGoal
+      || authoritativeGoal.status !== 'active'
+      || authoritativeGoal.id !== goal.id
+      || goalMetadataIdentityKey(authoritativeGoal) !== goalMetadataIdentityKey(goal)
+    ) return { sent: false, stale: true };
+    const statuses = await fetchSessionStatuses(sessionId, directory);
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    if (!statuses) {
+      const error = new Error('continuation status unavailable');
+      error.retryKind = 'fetch';
+      throw error;
+    }
+    if (isWorkingStatus(statuses[sessionId])) return { sent: false, busy: true };
+
+    // The first session/status pair admits the operation; this second pair is
+    // the final local admission barrier. It closes the common window where a
+    // pause/clear/complete or a new user turn lands after accounting but just
+    // before prompt_async. An external PATCH can still race the final POST;
+    // that unavoidable cross-process case remains explicitly ambiguous.
+    const finalSession = await fetchSession(sessionId, directory);
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    const finalGoal = parseGoalMetadata(finalSession);
+    if (
+      !finalGoal
+      || finalGoal.status !== 'active'
+      || goalMetadataIdentityKey(finalGoal) !== goalMetadataIdentityKey(goal)
+    ) return { sent: false, stale: true };
+    const finalMessages = await fetchRecentMessages(sessionId, directory);
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    if (!finalMessages) {
+      const error = new Error('continuation final message state unavailable');
+      error.retryKind = 'fetch';
+      throw error;
+    }
+    const finalOrderedMessages = [...finalMessages].sort(compareMessages);
+    const finalLastInfo = finalOrderedMessages.length > 0
+      ? finalOrderedMessages[finalOrderedMessages.length - 1]?.info
+      : null;
+    if (!finalLastInfo || finalLastInfo.id !== expectedTailID) return { sent: false, stale: true };
+    if (!(await objectiveSnapshotIsCurrent({ sessionId, goal: finalGoal, effectiveObjective }))) {
+      return { sent: false, stale: true };
+    }
+    const finalStatuses = await fetchSessionStatuses(sessionId, directory);
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    if (!finalStatuses) {
+      const error = new Error('continuation final status unavailable');
+      error.retryKind = 'fetch';
+      throw error;
+    }
+    if (isWorkingStatus(finalStatuses[sessionId])) return { sent: false, busy: true };
     const providerID = typeof lastAssistantInfo?.providerID === 'string' ? lastAssistantInfo.providerID : '';
     const modelID = typeof lastAssistantInfo?.modelID === 'string' ? lastAssistantInfo.modelID : '';
+    // Configuration failure is not a POST, but it is still a bounded dispatch
+    // attempt: otherwise a malformed assistant record can retry forever.
     if (!providerID || !modelID) {
-      throw new Error('cannot continue goal: last assistant message has no provider/model');
+      const error = new Error('cannot continue goal: last assistant message has no provider/model');
+      error.retryKind = 'dispatch-config';
+      error.admission = 'rejected';
+      if (isCallable(onDispatchAttempt)) onDispatchAttempt({ postAttempted: false });
+      throw error;
     }
-    const agent = typeof lastAssistantInfo?.agent === 'string' && lastAssistantInfo.agent
+    if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
+    const agent = isString(lastAssistantInfo?.agent) && lastAssistantInfo.agent
       ? lastAssistantInfo.agent
-      : (typeof lastAssistantInfo?.mode === 'string' ? lastAssistantInfo.mode : '');
-    const variant = typeof lastAssistantInfo?.variant === 'string' ? lastAssistantInfo.variant : '';
+      : (isString(lastAssistantInfo?.mode) ? lastAssistantInfo.mode : '');
+    const variant = isString(lastAssistantInfo?.variant) ? lastAssistantInfo.variant : '';
+    if (isCallable(onDispatchAttempt)) onDispatchAttempt({ postAttempted: true });
+    const continuationBody = {
+      model: { providerID, modelID },
+    };
+    if (agent) continuationBody.agent = agent;
+    if (variant) continuationBody.variant = variant;
+    continuationBody.parts = [{ type: 'text', text: buildContinuationPrompt({ ...goal, objective: effectiveObjective }) }];
     await openCodeFetch(`/session/${encodeURIComponent(sessionId)}/prompt_async`, {
       directory,
       method: 'POST',
-      body: {
-        model: { providerID, modelID },
-        ...(agent ? { agent } : {}),
-        ...(variant ? { variant } : {}),
-        parts: [{ type: 'text', text: buildContinuationPrompt(goal) }],
-      },
+      body: continuationBody,
     });
+    return (generation === undefined || isGenerationCurrent(sessionId, generation))
+      ? { sent: true }
+      : { sent: false, ambiguous: true };
   };
 
-  const tick = async (sessionId, directory) => {
-    if (!isEnabled()) return;
+  const reconcileAmbiguousDispatch = async ({ sessionId, directory, reservation, generation }) => {
+    if (reservations.get(sessionId) !== reservation) return 'stale';
+    let currentSession;
+    try {
+      currentSession = await fetchSession(sessionId, directory);
+    } catch {
+      return 'unknown';
+    }
+    if (!isGenerationCurrent(sessionId, generation)) return 'stale';
+    const currentGoal = parseGoalMetadata(currentSession);
+    if (!currentGoal || currentGoal.status !== 'active'
+      || goalLogicalIdentityKey(currentGoal) !== goalLogicalIdentityKey(reservation.goal)) {
+      // The prompt cannot be resent into a cleared/paused/replaced goal. Its
+      // accounting remains because a POST crossed the transport boundary.
+      reservations.delete(sessionId);
+      return 'settled';
+    }
+    const statuses = await fetchSessionStatuses(sessionId, directory);
+    if (!isGenerationCurrent(sessionId, generation)) return 'stale';
+    if (!statuses) return 'unknown';
+    const messages = await fetchRecentMessages(sessionId, directory);
+    if (!isGenerationCurrent(sessionId, generation)) return 'stale';
+    if (!messages) return 'unknown';
+    const ordered = [...messages].sort(compareMessages);
+    const lastInfo = ordered.length > 0 ? ordered[ordered.length - 1]?.info : null;
+    if (isWorkingStatus(statuses[sessionId]) || lastInfo?.id !== reservation.lastMessageID) {
+      // A busy status or a moved transcript tail is authoritative evidence that
+      // the attempted continuation was consumed (or that the user moved on).
+      // Do not send another provider request for the same reservation.
+      reservations.delete(sessionId);
+      return 'settled';
+    }
 
-    const session = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory })
-      .catch((error) => {
-        console.warn(`[session-goal] session fetch failed: ${error?.message || error}`);
-        return null;
-      });
-    if (!session || typeof session !== 'object') return;
+    // Idle + unchanged tail cannot prove that the request was rejected: an
+    // accepted prompt may not have published its first message yet. Settle
+    // safely instead of converting this ambiguity into a duplicate execution.
+    await settleGoal({
+      sessionId,
+      directory,
+      goal: { ...reservation.goal, ...reservation.after },
+      status: 'blocked',
+      statusReason: 'continuation admission unresolved',
+      generation,
+    });
+    return reservations.get(sessionId) === reservation ? 'unknown' : 'settled';
+  };
+
+  const tick = async (sessionId, directory, expectedGeneration = getGeneration(sessionId)) => {
+    if (stopped) return;
+    const terminalization = terminalizationStates.get(sessionId);
+    if (terminalization) {
+      if (!terminalization.exhausted) {
+        try {
+          await settleAfterRetryExhaustion(sessionId, directory, expectedGeneration, terminalization.kind);
+        } catch (error) {
+          if (isGenerationCurrent(sessionId, expectedGeneration)) {
+            scheduleTerminalizationRetry(sessionId, directory, expectedGeneration, terminalization.kind);
+          }
+          console.warn(`[session-goal] ${sessionId} terminalization failed: ${error?.message || error}`);
+        }
+      }
+      return;
+    }
+    if (!isEnabled()) {
+      if (disabledRecoverySessions.has(sessionId)) {
+        scheduleRetry(sessionId, directory, expectedGeneration, 'enabled', { settleOnExhaustion: false });
+      }
+      return;
+    }
+    if (disabledRecoverySessions.delete(sessionId)) resetRetry(sessionId, 'enabled');
+    disabledRecoveryDirectories.delete(sessionId);
+    const generation = expectedGeneration;
+
+    let session;
+    try {
+      session = await fetchSession(sessionId, directory);
+    } catch (error) {
+      console.warn(`[session-goal] session fetch failed: ${error?.message || error}`);
+      if (isGenerationCurrent(sessionId, generation)) {
+        scheduleRetry(sessionId, directory, generation, error?.retryKind || 'fetch');
+      }
+      return;
+    }
+    if (!isGenerationCurrent(sessionId, generation)) return;
     // Sub-agent/task sessions never carry user goals — skip them.
     if (typeof session.parentID === 'string' && session.parentID) return;
 
     const goal = parseGoalMetadata(session);
-    if (!goal || goal.status !== 'active') return;
+    if (goal) {
+      knownGoalStatuses.set(sessionId, goal.status);
+      goalRevisionSnapshots.set(sessionId, goal.updatedAt);
+    }
+    if (!goal || goal.status !== 'active') {
+      if (goal) reconcileCommittedSettlement(sessionId, directory, goal);
+      return;
+    }
+    const goalSnapshot = goalLogicalIdentityKey(goal);
+    goalSnapshots.set(sessionId, goalSnapshot);
+    goalMetadataSnapshots.set(sessionId, goalMetadataIdentityKey(goal));
+
+    const pendingAbort = pendingAborts.get(sessionId);
+    if (pendingAbort?.generation === generation) {
+      const written = await writeGoal(sessionId, directory, goal, () => ({
+        status: 'paused',
+        statusReason: 'paused after abort',
+      }), { generation });
+      if (written) {
+        pendingAborts.delete(sessionId);
+        activeGoalSessions.delete(sessionId);
+      }
+      return;
+    }
 
     // File-backed objectives: the metadata carries only a flag; the objective
     // TEXT lives under the OpenChamber data dir keyed by session id and is
-    // read fresh on every tick (live-editable). A missing file falls back to
-    // whatever inline objective the metadata still has — the goal must never
-    // die just because a file went away.
-    let effectiveObjective = goal.objective;
+    // read fresh on every tick (live-editable). A missing file is not an empty
+    // objective: retry it with the normal bounded policy, then settle the goal
+    // explicitly if no inline fallback exists.
+    const resolvedObjective = await resolveObjective(sessionId, goal);
+    let effectiveObjective = resolvedObjective.objective;
+    const settleCurrentGoal = async (settlement) => {
+      if (!(await ensureObjectiveCurrent({ sessionId, directory, goal, effectiveObjective, generation }))) return false;
+      await settleGoal({ ...settlement, effectiveObjective });
+      return true;
+    };
     if (goal.objectiveFile) {
-      const fileObjective = await readObjective(sessionId);
-      if (fileObjective) {
-        effectiveObjective = fileObjective;
+      if (!isGenerationCurrent(sessionId, generation)) return;
+      if (resolvedObjective.available) {
+        resetRetry(sessionId, 'objective');
       } else if (!effectiveObjective) {
         console.warn(`[session-goal] ${sessionId} objective file unreadable and no inline fallback`);
+        if (!scheduleRetry(sessionId, directory, generation, 'objective')) {
+          await settleGoal({
+            sessionId,
+            directory,
+            goal,
+            status: 'blocked',
+            statusReason: 'objective file unavailable',
+            generation,
+          });
+        }
         return;
       } else {
         console.warn(`[session-goal] ${sessionId} objective file unreadable, using inline fallback`);
@@ -530,40 +1710,95 @@ export const createSessionGoalRuntime = ({
     // its next idle event will arm a fresh tick. If a child is still working,
     // OpenCode will inject its result into the parent and produce the same
     // busy→idle cycle, so do not poll or audit the interim parent reply.
-    const statuses = await fetchSessionStatuses(directory);
+    const statuses = await fetchSessionStatuses(sessionId, directory);
+    if (!isGenerationCurrent(sessionId, generation)) return;
     if (!statuses) {
-      armTimer(sessionId, directory, idleQuietMs);
+      scheduleRetry(sessionId, directory, generation);
       return;
     }
-    if (isWorkingStatus(statuses[sessionId])) return;
+    if (isWorkingStatus(statuses[sessionId])) {
+      resetRetry(sessionId, 'fetch');
+      return;
+    }
 
     const children = await fetchSessionChildren(sessionId, directory);
+    if (!isGenerationCurrent(sessionId, generation)) return;
     if (!children) {
-      armTimer(sessionId, directory, idleQuietMs);
+      scheduleRetry(sessionId, directory, generation);
       return;
     }
-    if (children.some((child) => typeof child?.id === 'string' && isWorkingStatus(statuses[child.id]))) return;
+    for (const child of children) {
+      const childStatus = statuses[child.id];
+      // The status endpoint omits idle sessions. Only an explicitly present
+      // malformed/unknown child status is retryable unknown.
+      if (Object.hasOwn(statuses, child.id) && !isValidSessionStatus(childStatus)) {
+        scheduleRetry(sessionId, directory, generation);
+        return;
+      }
+      if (isWorkingStatus(childStatus)) {
+        resetRetry(sessionId, 'fetch');
+        return;
+      }
+    }
 
     const messages = await fetchRecentMessages(sessionId, directory);
-    if (!messages) return;
+    if (!isGenerationCurrent(sessionId, generation)) return;
+    if (!messages) {
+      scheduleRetry(sessionId, directory, generation);
+      return;
+    }
+    resetRetry(sessionId, 'fetch');
+
+    const orderedMessages = [...messages].sort(compareMessages);
 
     let lastAssistant = null;
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      if (messages[i]?.info?.role === 'assistant') {
-        lastAssistant = messages[i];
+    for (let i = orderedMessages.length - 1; i >= 0; i -= 1) {
+      if (orderedMessages[i]?.info?.role === 'assistant') {
+        lastAssistant = orderedMessages[i];
         break;
       }
     }
     const lastAssistantInfo = lastAssistant?.info;
-    const lastMessageInfo = messages.length > 0 ? messages[messages.length - 1]?.info : null;
+    const lastMessageInfo = orderedMessages.length > 0 ? orderedMessages[orderedMessages.length - 1]?.info : null;
+
+    if (recoveryHolds.has(sessionId)) {
+      if (goal.lastAccountedMessageID !== lastMessageInfo?.id) {
+        // A newer transcript tail is proof that the old prompt reservation
+        // was consumed (or that new user work arrived), so normal processing
+        // can resume. An unchanged accounted tail remains ambiguous.
+        recoveryHolds.delete(sessionId);
+        recoveryHoldDirectories.delete(sessionId);
+      } else {
+        console.warn(`[session-goal] ${sessionId} holding ambiguous post-restart continuation`);
+        return;
+      }
+    }
+
+    const pendingReservation = reservations.get(sessionId);
+    if ((pendingReservation?.resolutionState === 'pending' || pendingReservation?.resolutionState === 'escalated')
+      && pendingReservation.postAttempts === 0) {
+      if (reservationStateMatches(goal, pendingReservation.before)) {
+        reservations.delete(sessionId);
+        resetRetry(sessionId, 'reservation-rollback');
+      } else {
+        await discardReservation({
+          sessionId,
+          directory,
+          reservation: pendingReservation,
+          generation,
+          blockedReason: pendingReservation.resolutionReason,
+        });
+        return;
+      }
+    }
 
     // Execution source for audits and continuations: the newest NON-summary
     // assistant turn. The compaction summary message carries agent/mode
     // "compaction" and the summarize model — inheriting those would continue
     // the session with the wrong agent/model.
     let executionInfo = null;
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const info = messages[i]?.info;
+    for (let i = orderedMessages.length - 1; i >= 0; i -= 1) {
+      const info = orderedMessages[i]?.info;
       if (info?.role === 'assistant' && info.summary !== true) {
         executionInfo = info;
         break;
@@ -575,12 +1810,176 @@ export const createSessionGoalRuntime = ({
     // user message or an unfinished assistant reply means the session is (or
     // is about to be) busy — the next idle transition re-arms us.
     if (lastMessageInfo?.role === 'user') return;
-    if (lastAssistantInfo && !(lastAssistantInfo.time?.completed > 0) && !lastAssistantInfo.error) return;
+    const lengthLimited = isLengthTruncated(lastAssistantInfo);
+    if (lastAssistantInfo && !(lastAssistantInfo.time?.completed > 0) && !lastAssistantInfo.error
+      && !lengthLimited && lastAssistantInfo.summary !== true) return;
 
     // A goal on a session with no assistant reply yet: there is no message to
     // take provider/model from, so the loop starts after the user's first
     // exchange completes (the idle transition re-arms us).
     if (!lastAssistantInfo?.id) return;
+
+    // A reservation means accounting and turnsUsed were already persisted for
+    // this exact tail, but prompt_async failed (or its tail confirmation did).
+    // Retry the dispatch without auditing or reserving the same turn again.
+    const reservation = reservations.get(sessionId);
+    if (reservation && (
+      reservation.goalId !== goal.id
+      || reservation.turnsUsed !== goal.turnsUsed
+      || reservation.lastAccountedMessageID !== goal.lastAccountedMessageID
+      || reservation.lastMessageID !== lastMessageInfo?.id
+    )) {
+      // A failed accounting PATCH may not have changed the authoritative
+      // goal at all. Drop that uncommitted marker and let this tick retry the
+      // accounting write; only a visible after-state needs guarded cleanup.
+      if (reservationStateMatches(goal, reservation.before)) {
+        reservations.delete(sessionId);
+      } else {
+        await reconcileDroppedReservation({
+          sessionId,
+          directory,
+          reservation,
+          generation,
+        });
+        return;
+      }
+    }
+    if (
+      reservation
+      && reservation.goalId === goal.id
+      && reservation.turnsUsed === goal.turnsUsed
+      && reservation.lastAccountedMessageID === goal.lastAccountedMessageID
+      && reservation.lastMessageID === lastMessageInfo?.id
+    ) {
+      if (reservation.dispatchOutcome === 'ambiguous') {
+        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+        if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
+          await settleGoal({
+            sessionId,
+            directory,
+            goal: { ...reservation.goal, ...reservation.after },
+            status: 'blocked',
+            statusReason: 'continuation admission unresolved',
+            generation,
+          });
+        }
+        return;
+      }
+      const latest = await fetchRecentMessages(sessionId, directory);
+      if (!isGenerationCurrent(sessionId, generation)) return;
+      if (!latest) {
+        scheduleRetry(sessionId, directory, generation);
+        return;
+      }
+      const latestOrdered = [...latest].sort(compareMessages);
+       const latestLastInfo = latestOrdered.length > 0 ? latestOrdered[latestOrdered.length - 1]?.info : null;
+      if (latestLastInfo?.id !== reservation.lastMessageID) {
+        await discardReservation({
+          sessionId,
+          directory,
+          reservation,
+          generation,
+          blockedReason: 'continuation tail changed before dispatch',
+        });
+        return;
+      }
+      try {
+         if (!(await ensureObjectiveCurrent({ sessionId, directory, goal, effectiveObjective, generation }))) {
+           await discardReservation({ sessionId, directory, reservation, generation });
+           return;
+        }
+         if (reservation.dispatchAttempts >= maxDispatchAttempts) {
+           if (reservation.postAttempts === 0) {
+             await discardReservation({
+               sessionId,
+               directory,
+               reservation,
+               generation,
+               blockedReason: 'continuation dispatch rejected before continuation dispatch',
+             });
+             return;
+           }
+            await beginTerminalization(sessionId, directory, generation, 'dispatch');
+          return;
+        }
+        const sent = await sendContinuation({
+          sessionId,
+          directory,
+          goal,
+           effectiveObjective,
+           expectedTailID: reservation.lastMessageID,
+           lastAssistantInfo: executionInfo ?? lastAssistantInfo,
+          generation,
+           onDispatchAttempt: ({ postAttempted }) => {
+             reservation.dispatchAttempts += 1;
+             if (postAttempted) {
+               reservation.postAttempts += 1;
+               reservation.dispatchOutcome = 'pending';
+             }
+           },
+        });
+         if (sent.sent) {
+           reservations.delete(sessionId);
+           resetRetry(sessionId);
+         } else if (sent.ambiguous && isGenerationCurrent(sessionId, generation)) {
+           reservation.dispatchOutcome = 'ambiguous';
+           const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+           if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
+             await settleGoal({
+               sessionId,
+               directory,
+               goal: { ...reservation.goal, ...reservation.after },
+               status: 'blocked',
+               statusReason: 'continuation admission unresolved',
+               generation,
+             });
+           }
+         } else if (sent.stale && isGenerationCurrent(sessionId, generation)) {
+          await reconcileDroppedReservation({ sessionId, directory, reservation, generation });
+        }
+      } catch (error) {
+        console.warn(`[session-goal] continuation dispatch failed: ${error?.message || error}`);
+        const dispatchOutcome = continuationAdmission(error);
+        const currentReservation = reservations.get(sessionId);
+        if (currentReservation?.postAttempts > 0) currentReservation.dispatchOutcome = dispatchOutcome;
+        if (dispatchOutcome === 'ambiguous' && currentReservation?.postAttempts > 0) {
+          currentReservation.dispatchOutcome = 'ambiguous';
+          const reconciled = await reconcileAmbiguousDispatch({
+            sessionId,
+            directory,
+            reservation: currentReservation,
+            generation,
+          });
+          if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
+            await settleGoal({
+              sessionId,
+              directory,
+              goal: { ...currentReservation.goal, ...currentReservation.after },
+              status: 'blocked',
+              statusReason: 'continuation admission unresolved',
+              generation,
+            });
+          }
+        } else if (error?.retryKind === 'fetch') {
+          scheduleRetry(sessionId, directory, generation, 'fetch');
+        } else if (currentReservation?.dispatchAttempts >= maxDispatchAttempts) {
+          if (currentReservation.postAttempts === 0) {
+            await discardReservation({
+              sessionId,
+              directory,
+              reservation: currentReservation,
+              generation,
+              blockedReason: 'continuation dispatch rejected before continuation dispatch',
+            });
+            return;
+          }
+          await beginTerminalization(sessionId, directory, generation, 'dispatch');
+        } else {
+          scheduleRetry(sessionId, directory, generation, 'dispatch');
+        }
+      }
+      return;
+    }
 
     // --- Token accounting: snapshot of the latest completed assistant turn
     // (input + cache.read + output), goal-relative via a baseline captured on
@@ -596,24 +1995,38 @@ export const createSessionGoalRuntime = ({
     // its own snapshot prices the compaction), and the next segment starts
     // with a zero baseline.
     let tokensBaseline = goal.tokensBaseline;
+    let baselineUnknown = false;
     if (!goal.lastAccountedMessageID && !(tokensBaseline > 0)) {
       tokensBaseline = 0;
-      for (const message of messages) {
+      for (const message of orderedMessages) {
         const info = message?.info;
         if (info?.role !== 'assistant') continue;
-        if (!(info.time?.completed > 0) || info.time.completed > goal.createdAt) continue;
+        if (!(info.time?.completed > 0)) continue;
+        const createdAt = info.time?.created;
+        // Completion time is not a chronology fallback. A missing creation
+        // timestamp stays in the unknown/API-order bucket and cannot be
+        // classified as pre-goal history.
+        if (!Number.isFinite(createdAt) || createdAt > goal.createdAt) continue;
         tokensBaseline = Math.max(tokensBaseline, messageTokenTotal(info));
       }
+      baselineUnknown = tokensBaseline === 0 && orderedMessages.length >= MESSAGE_FETCH_LIMIT;
     }
     let tokensCommitted = goal.tokensCommitted;
     let tokensUsed = goal.tokensUsed;
     let lastAccountedMessageID = goal.lastAccountedMessageID;
     let segmentSnapshot = null;
     let sawNewMessages = false;
-    for (const message of messages) {
+    let messagesToAccount = baselineUnknown ? [] : orderedMessages;
+    if (lastAccountedMessageID) {
+      const cursorIndex = orderedMessages.findIndex((message) => message?.info?.id === lastAccountedMessageID);
+      // The cursor is intentionally an opaque compatibility marker. If it is
+      // outside this bounded page, do not replay the page or infer chronology
+      // from IDs; retain the monotonic totals until a safe cursor is visible.
+      messagesToAccount = cursorIndex >= 0 ? orderedMessages.slice(cursorIndex + 1) : [];
+    }
+    for (const message of messagesToAccount) {
       const info = message?.info;
       if (info?.role !== 'assistant' || typeof info.id !== 'string') continue;
-      if (lastAccountedMessageID && info.id <= lastAccountedMessageID) continue;
       if (!(info.time?.completed > 0)) continue;
       sawNewMessages = true;
       const total = messageTokenTotal(info);
@@ -634,9 +2047,7 @@ export const createSessionGoalRuntime = ({
       } else {
         segmentSnapshot = total;
       }
-      if (!lastAccountedMessageID || info.id > lastAccountedMessageID) {
-        lastAccountedMessageID = info.id;
-      }
+      lastAccountedMessageID = info.id;
     }
     if (sawNewMessages) {
       const segmentCurrent = segmentSnapshot !== null ? Math.max(0, segmentSnapshot - tokensBaseline) : 0;
@@ -645,7 +2056,19 @@ export const createSessionGoalRuntime = ({
       tokensUsed = Math.max(goal.tokensUsed, tokensCommitted + segmentCurrent);
     }
 
+    if (baselineUnknown) {
+      // A full page with no visible pre-goal assistant cannot prove that the
+      // segment starts at zero. Keep the cursor and total unchanged rather
+      // than charging pre-goal context; this is conservative undercounting.
+      tokensBaseline = goal.tokensBaseline;
+      tokensCommitted = goal.tokensCommitted;
+      tokensUsed = goal.tokensUsed;
+      lastAccountedMessageID = goal.lastAccountedMessageID;
+    }
+
     const assistantText = messagePartsToText(lastAssistant);
+
+    if (!isGenerationCurrent(sessionId, generation)) return;
 
     // --- Terminal conditions, cheapest first ---
 
@@ -661,14 +2084,15 @@ export const createSessionGoalRuntime = ({
     const abortedTail = errorName === 'MessageAbortedError';
     const lengthTail = isLengthTruncated(lastAssistantInfo, errorName);
     if (abortedTail && goal.statusReason !== 'resumed') {
-      await writeGoal(sessionId, directory, goal.id, () => ({
+      if (!(await ensureObjectiveCurrent({ sessionId, directory, goal, effectiveObjective, generation }))) return;
+      await writeGoal(sessionId, directory, goal, () => ({
         status: 'paused',
         statusReason: 'paused after abort',
         tokensUsed,
         tokensBaseline,
         tokensCommitted,
         lastAccountedMessageID,
-      }));
+      }), { generation });
       console.log(`[session-goal] ${sessionId} paused after user abort`);
       return;
     }
@@ -677,24 +2101,25 @@ export const createSessionGoalRuntime = ({
     // failures). Recognized length cutoffs are in-progress continuations, not
     // hard failures.
     if (!abortedTail && !lengthTail && hasError) {
-      await settleGoal({
-        sessionId, directory, goal, status: 'blocked', statusReason: errorName || 'assistant turn failed', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+      const reason = errorName || 'assistant turn failed';
+      await settleCurrentGoal({
+        sessionId, directory, goal, status: 'blocked', statusReason: reason, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
       });
       return;
     }
 
     // Token budget crossed → budgetLimited.
     if (typeof goal.tokenBudget === 'number' && tokensUsed >= goal.tokenBudget) {
-      await settleGoal({
-        sessionId, directory, goal, status: 'budgetLimited', statusReason: 'token budget reached', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+      await settleCurrentGoal({
+        sessionId, directory, goal, status: 'budgetLimited', statusReason: 'token budget reached', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
       });
       return;
     }
 
     // Auto-continuation safety cap → blocked.
     if (goal.turnsUsed >= maxAutoTurns) {
-      await settleGoal({
-        sessionId, directory, goal, status: 'blocked', statusReason: 'auto-continuation limit reached', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+      await settleCurrentGoal({
+        sessionId, directory, goal, status: 'blocked', statusReason: 'auto-continuation limit reached', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
       });
       return;
     }
@@ -703,8 +2128,17 @@ export const createSessionGoalRuntime = ({
     // bounded recovery failure. Derive this from the loaded transcript rather
     // than persisting another goal counter.
     if (lengthTail && goal.statusReason !== 'resumed' && hasRepeatedLengthTail(messages, lastAssistant, goal.createdAt)) {
-      await settleGoal({
-        sessionId, directory, goal, status: 'blocked', statusReason: 'repeated output truncation', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+      await settleCurrentGoal({
+        sessionId,
+        directory,
+        goal,
+        status: 'blocked',
+        statusReason: 'repeated output truncation',
+        tokensUsed,
+        tokensBaseline,
+        tokensCommitted,
+        lastAccountedMessageID,
+        generation,
       });
       return;
     }
@@ -724,6 +2158,7 @@ export const createSessionGoalRuntime = ({
       blockedStreak = goal.blockedStreak;
     } else {
       audit = await runAudit({ goal: { ...goal, objective: effectiveObjective }, assistantText, directory, lastAssistantInfo: executionInfo ?? lastAssistantInfo });
+      if (!isGenerationCurrent(sessionId, generation)) return;
 
       // Audit unavailable: tolerate one consecutive failure (transient
       // hiccup), then stop the goal instead of continuing blind. Blocked is
@@ -731,8 +2166,8 @@ export const createSessionGoalRuntime = ({
       if (!audit) {
         auditFailStreak += 1;
         if (auditFailStreak >= AUDIT_FAIL_LIMIT) {
-          await settleGoal({
-            sessionId, directory, goal, status: 'blocked', statusReason: 'progress audit unavailable', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+            await settleCurrentGoal({
+              sessionId, directory, goal, status: 'blocked', statusReason: 'progress audit unavailable', tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
           });
           return;
         }
@@ -742,8 +2177,8 @@ export const createSessionGoalRuntime = ({
       }
 
       if (audit?.verdict === 'complete') {
-        await settleGoal({
-          sessionId, directory, goal, status: 'complete', statusReason: 'verified by audit', note: audit.note, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+        await settleCurrentGoal({
+          sessionId, directory, goal, status: 'complete', statusReason: 'verified by audit', note: audit.note, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
           evaluationProviderID: audit.evaluationProviderID, evaluationModelID: audit.evaluationModelID,
         });
         return;
@@ -757,8 +2192,8 @@ export const createSessionGoalRuntime = ({
           blockedStreakLimit: BLOCKED_STREAK_LIMIT,
         });
         if (blockedStreak >= BLOCKED_STREAK_LIMIT) {
-          await settleGoal({
-            sessionId, directory, goal, status: 'blocked', statusReason: audit.note || 'blocked per audit', note: audit.note, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID,
+          await settleCurrentGoal({
+            sessionId, directory, goal, status: 'blocked', statusReason: audit.note || 'blocked per audit', note: audit.note, tokensUsed, tokensBaseline, tokensCommitted, lastAccountedMessageID, generation,
             evaluationProviderID: audit.evaluationProviderID, evaluationModelID: audit.evaluationModelID,
           });
           return;
@@ -769,69 +2204,377 @@ export const createSessionGoalRuntime = ({
     // --- Continue: persist accounting first, then re-prompt ---
     // Order matters: if the write lands and the prompt fails, the goal just
     // waits for the next idle tick; the reverse could double-charge a turn.
-    const written = await writeGoal(sessionId, directory, goal.id, (current) => ({
+    if (!(await ensureObjectiveCurrent({ sessionId, directory, goal, effectiveObjective, generation }))) return;
+    const existingReservation = reservations.get(sessionId);
+    const reservationAfter = {
+      ...reservationGoalState(goal),
       tokensUsed,
       tokensBaseline,
       tokensCommitted,
       lastAccountedMessageID,
-      turnsUsed: current.turnsUsed + 1,
+      turnsUsed: goal.turnsUsed + 1,
       blockedStreak,
       auditFailStreak,
       statusReason: '',
-      ...(audit?.note ? { note: audit.note } : {}),
-      ...(audit?.evaluationProviderID ? { evaluationProviderID: audit.evaluationProviderID } : {}),
-      ...(audit?.evaluationModelID ? { evaluationModelID: audit.evaluationModelID } : {}),
-    }));
+    };
+    if (audit?.note) reservationAfter.note = audit.note;
+    if (audit?.evaluationProviderID) reservationAfter.evaluationProviderID = audit.evaluationProviderID;
+    if (audit?.evaluationModelID) reservationAfter.evaluationModelID = audit.evaluationModelID;
+    const nextReservation = {
+      directory,
+      goal,
+      before: reservationGoalState(goal),
+      after: reservationAfter,
+      goalId: goal.id,
+      previousTurnsUsed: goal.turnsUsed,
+      previousLastAccountedMessageID: goal.lastAccountedMessageID,
+      turnsUsed: goal.turnsUsed + 1,
+      lastAccountedMessageID,
+      lastMessageID: lastMessageInfo.id,
+      tokensUsed,
+      tokensBaseline,
+      tokensCommitted,
+      dispatchAttempts: existingReservation?.goalId === goal.id
+        && existingReservation.lastMessageID === lastMessageInfo.id
+        ? existingReservation.dispatchAttempts
+        : 0,
+      postAttempts: existingReservation?.goalId === goal.id
+        && existingReservation.lastMessageID === lastMessageInfo.id
+        ? existingReservation.postAttempts
+        : 0,
+      dispatchOutcome: existingReservation?.goalId === goal.id
+        && existingReservation.lastMessageID === lastMessageInfo.id
+        ? existingReservation.dispatchOutcome
+        : 'unattempted',
+    };
+    reservations.set(sessionId, nextReservation);
+    const written = await writeGoal(sessionId, directory, goal, (current) => {
+      if (goalMetadataIdentityKey(current) !== goalMetadataIdentityKey(goal)) return null;
+      if (
+        current.turnsUsed === nextReservation.turnsUsed
+        && current.lastAccountedMessageID === nextReservation.lastAccountedMessageID
+        && current.tokensUsed === nextReservation.tokensUsed
+        && current.tokensBaseline === nextReservation.tokensBaseline
+        && current.tokensCommitted === nextReservation.tokensCommitted
+      ) return current;
+      if (
+        current.turnsUsed !== nextReservation.previousTurnsUsed
+        || current.lastAccountedMessageID !== nextReservation.previousLastAccountedMessageID
+      ) return null;
+      const nextState = {
+        tokensUsed,
+        tokensBaseline,
+        tokensCommitted,
+        lastAccountedMessageID,
+        turnsUsed: nextReservation.turnsUsed,
+        blockedStreak,
+        auditFailStreak,
+        statusReason: '',
+      };
+      if (audit?.note) nextState.note = audit.note;
+      if (audit?.evaluationProviderID) nextState.evaluationProviderID = audit.evaluationProviderID;
+      if (audit?.evaluationModelID) nextState.evaluationModelID = audit.evaluationModelID;
+      return nextState;
+    }, {
+      generation,
+      finalCheck: () => objectiveSnapshotIsCurrent({ sessionId, goal, effectiveObjective }),
+    });
     if (!written) {
+      await reconcileDroppedReservation({ sessionId, directory, reservation: nextReservation, generation });
       console.log('[session-goal] goal changed during tick, dropping continuation');
+      return;
+    }
+    if (!isGenerationCurrent(sessionId, generation)) return;
+
+    nextReservation.turnsUsed = written.turnsUsed;
+    nextReservation.lastAccountedMessageID = written.lastAccountedMessageID;
+    nextReservation.after = reservationGoalState(written);
+    nextReservation.goal = written;
+    reservations.set(sessionId, nextReservation);
+
+    if (!(await ensureObjectiveCurrent({ sessionId, directory, goal: written, effectiveObjective, generation }))) {
+      await discardReservation({ sessionId, directory, reservation: nextReservation, generation });
       return;
     }
 
     // The tail may have moved while auditing (user sent a message) — a
     // continuation now would collide with the user's own turn.
     const latest = await fetchRecentMessages(sessionId, directory);
-    const latestLastInfo = latest && latest.length > 0 ? latest[latest.length - 1]?.info : null;
+    if (!isGenerationCurrent(sessionId, generation)) return;
+    if (!latest) {
+      scheduleRetry(sessionId, directory, generation);
+      return;
+    }
+    const latestOrdered = [...latest].sort(compareMessages);
+    const latestLastInfo = latestOrdered.length > 0 ? latestOrdered[latestOrdered.length - 1]?.info : null;
     if (!latestLastInfo || latestLastInfo.id !== lastMessageInfo?.id) {
+      await discardReservation({
+        sessionId,
+        directory,
+        reservation: nextReservation,
+        generation,
+        blockedReason: 'continuation tail changed before dispatch',
+      });
       console.log('[session-goal] tail moved on, dropping continuation');
       return;
     }
 
     console.log(`[session-goal] continuing ${sessionId} (turn ${written.turnsUsed}/${maxAutoTurns}, tokens ${written.tokensUsed}${written.tokenBudget ? `/${written.tokenBudget}` : ''})`);
-    await sendContinuation({ sessionId, directory, goal: { ...written, objective: effectiveObjective }, lastAssistantInfo: executionInfo ?? lastAssistantInfo });
+    try {
+      const reservation = reservations.get(sessionId);
+      if (!reservation) return;
+      if (!(await ensureObjectiveCurrent({ sessionId, directory, goal: written, effectiveObjective, generation }))) {
+        await discardReservation({ sessionId, directory, reservation, generation });
+        return;
+      }
+      const sent = await sendContinuation({
+        sessionId,
+        directory,
+        goal: written,
+         effectiveObjective,
+         expectedTailID: lastMessageInfo.id,
+         lastAssistantInfo: executionInfo ?? lastAssistantInfo,
+        generation,
+        onDispatchAttempt: ({ postAttempted }) => {
+          reservation.dispatchAttempts += 1;
+          if (postAttempted) {
+            reservation.postAttempts += 1;
+            reservation.dispatchOutcome = 'pending';
+          }
+        },
+      });
+      if (sent.sent) {
+        reservations.delete(sessionId);
+        resetRetry(sessionId);
+      } else if (sent.ambiguous && isGenerationCurrent(sessionId, generation)) {
+        reservation.dispatchOutcome = 'ambiguous';
+        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+        if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
+          await settleGoal({
+            sessionId,
+            directory,
+            goal: { ...reservation.goal, ...reservation.after },
+            status: 'blocked',
+            statusReason: 'continuation admission unresolved',
+            generation,
+          });
+        }
+      } else if (sent.stale && isGenerationCurrent(sessionId, generation)) {
+         await reconcileDroppedReservation({ sessionId, directory, reservation, generation });
+       }
+    } catch (error) {
+      console.warn(`[session-goal] continuation dispatch failed: ${error?.message || error}`);
+      const reservation = reservations.get(sessionId);
+      const dispatchOutcome = continuationAdmission(error);
+      if (reservation?.postAttempts > 0) reservation.dispatchOutcome = dispatchOutcome;
+      if (dispatchOutcome === 'ambiguous' && reservation?.postAttempts > 0) {
+        reservation.dispatchOutcome = 'ambiguous';
+        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+        if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
+          await settleGoal({
+            sessionId,
+            directory,
+            goal: { ...reservation.goal, ...reservation.after },
+            status: 'blocked',
+            statusReason: 'continuation admission unresolved',
+            generation,
+          });
+        }
+      } else if (error?.retryKind === 'fetch') {
+        scheduleRetry(sessionId, directory, generation, 'fetch');
+      } else if ((reservation?.dispatchAttempts ?? maxDispatchAttempts) >= maxDispatchAttempts) {
+        if ((reservation?.postAttempts ?? 0) === 0) {
+          await discardReservation({
+            sessionId,
+            directory,
+            reservation,
+            generation,
+            blockedReason: 'continuation dispatch rejected before continuation dispatch',
+          });
+          return;
+        }
+        await beginTerminalization(sessionId, directory, generation, 'dispatch');
+      } else {
+        scheduleRetry(sessionId, directory, generation, 'dispatch');
+      }
+    }
   };
 
   const armTimer = (sessionId, directory, quietMs) => {
+    if (
+      retryStates.get(sessionId)?.exhausted
+      && quietMs !== RESUME_KICKOFF_MS
+      && !reservations.get(sessionId)?.resolutionState
+      && !terminalizationStates.has(sessionId)
+    ) return;
+    if (isInflight(sessionId)) {
+      const pending = pendingArms.get(sessionId);
+      if (!pending || quietMs < pending.quietMs) {
+        pendingArms.set(sessionId, { directory, quietMs });
+      }
+      return;
+    }
+    const now = Date.now();
+    const existing = timers.get(sessionId);
+    const requestedDueAt = now + quietMs;
+    if (existing && existing.dueAt <= requestedDueAt) return;
     clearTimer(sessionId);
     const timer = setTimeout(() => {
       timers.delete(sessionId);
-      if (stopped || inflight.has(sessionId)) return;
-      inflight.add(sessionId);
-      tick(sessionId, directory)
+      if (stopped) return;
+      if (isInflight(sessionId)) {
+        pendingArms.set(sessionId, { directory, quietMs });
+        return;
+      }
+       beginInflight(sessionId);
+      const generation = getGeneration(sessionId);
+      tick(sessionId, directory, generation)
         .catch((error) => {
           console.warn('[session-goal] tick failed:', error?.message || error);
+          scheduleRetry(sessionId, directory, generation, error?.retryKind || 'fetch');
         })
         .finally(() => {
-          inflight.delete(sessionId);
+          finishInflight(sessionId);
         });
     }, quietMs);
     if (typeof timer?.unref === 'function') timer.unref();
-    timers.set(sessionId, { timer, armedAt: Date.now() });
+    timers.set(sessionId, { timer, armedAt: now, dueAt: requestedDueAt });
+  };
+
+  const clearStartupRecoveryTimer = () => {
+    if (!startupRecoveryTimer) return;
+    clearTimeout(startupRecoveryTimer);
+    startupRecoveryTimer = null;
+  };
+
+  const scheduleStartupRecovery = (listDirectories) => {
+    if (stopped || startupRecoveryTimer) return;
+    const attempt = startupRecoveryAttempts + 1;
+    if (attempt > maxStartupRecoveryAttempts) {
+      console.warn(`[session-goal] startup recovery retry limit reached (${maxStartupRecoveryAttempts})`);
+      return;
+    }
+    startupRecoveryAttempts = attempt;
+    const delay = Number.isFinite(startupRecoveryDelaysMs[attempt - 1])
+      ? Math.max(0, startupRecoveryDelaysMs[attempt - 1])
+      : Math.max(0, idleQuietMs);
+    startupRecoveryTimer = setTimeout(() => {
+      startupRecoveryTimer = null;
+      void start({ listDirectories }).catch((error) => {
+        console.warn(`[session-goal] startup recovery failed: ${error?.message || error}`);
+      });
+    }, delay);
+    startupRecoveryTimer.unref?.();
   };
 
   // Immediate event path for a user abort: pause the active goal right away,
   // BEFORE any idle tick could send a continuation over the user's explicit
   // "stop". Messages the user sends afterwards leave the paused goal alone;
   // Resume re-arms the loop (and kicks off immediately on an idle session).
-  const pauseAfterAbort = async (sessionId, directory) => {
-    const session = await openCodeFetch(`/session/${encodeURIComponent(sessionId)}`, { directory })
-      .catch(() => null);
+  const pauseAfterAbort = async (sessionId, directory, generation) => {
+    if (!isGenerationCurrent(sessionId, generation)) return;
+    const session = await fetchSession(sessionId, directory);
+    if (!isGenerationCurrent(sessionId, generation)) return;
     const goal = parseGoalMetadata(session);
-    if (!goal || goal.status !== 'active') return;
-    await writeGoal(sessionId, directory, goal.id, () => ({
+    if (!goal || goal.status !== 'active') {
+      if (isGenerationCurrent(sessionId, generation)) pendingAborts.delete(sessionId);
+      return;
+    }
+    const written = await writeGoal(sessionId, directory, goal, () => ({
       status: 'paused',
       statusReason: 'paused after abort',
-    }));
+    }), { generation });
+    if (!written) return;
+    pendingAborts.delete(sessionId);
+    activeGoalSessions.delete(sessionId);
     console.log(`[session-goal] ${sessionId} paused after user abort`);
+  };
+
+  const invalidateForAuthoritativeUserChange = (sessionId, directory) => {
+    const generation = advanceGeneration(sessionId);
+    clearTimer(sessionId);
+    clearPendingArm(sessionId);
+    resetRetry(sessionId);
+    disabledRecoverySessions.delete(sessionId);
+    terminalizationStates.delete(sessionId);
+    const reservation = reservations.get(sessionId);
+    if (!reservation) return generation;
+    if (reservation.postAttempts > 0 && reservation.dispatchOutcome !== 'rejected') {
+      // A POST crossed the boundary. Preserve its persisted accounting, but
+      // never let this old reservation trigger another provider execution.
+      reservations.delete(sessionId);
+    } else {
+      void reconcileDroppedReservation({ sessionId, directory, reservation, generation });
+    }
+    return generation;
+  };
+
+  const clearGoalTracking = (sessionId) => {
+    clearedGoalSessions.add(sessionId);
+    pendingAborts.delete(sessionId);
+    knownGoalStatuses.delete(sessionId);
+    goalSnapshots.delete(sessionId);
+    goalMetadataSnapshots.delete(sessionId);
+    goalRevisionSnapshots.delete(sessionId);
+    resumeSnapshots.delete(sessionId);
+    recoveryHolds.delete(sessionId);
+    recoveryHoldDirectories.delete(sessionId);
+    disabledRecoverySessions.delete(sessionId);
+    disabledRecoveryDirectories.delete(sessionId);
+    activeGoalSessions.delete(sessionId);
+    terminalizationStates.delete(sessionId);
+    settlementMarkers.delete(sessionId);
+  };
+
+  const acceptSessionUpdate = (update) => {
+    if (update.parentID) return true;
+    const sessionUpdatedAt = update.sessionUpdatedAt;
+    const goalUpdatedAt = update.goal && Number.isFinite(update.goal.updatedAt)
+      ? update.goal.updatedAt
+      : null;
+    const previous = sessionUpdateFreshness.get(update.sessionId);
+    // A timestamp-less event is usable as the first observation, but once a
+    // session has a freshness baseline it cannot prove that a delayed clear or
+    // replacement is newer than the accepted state.
+    if (!Number.isFinite(sessionUpdatedAt) && !Number.isFinite(goalUpdatedAt)) {
+      return !previous;
+    }
+    if (!previous) {
+      sessionUpdateFreshness.set(update.sessionId, { sessionUpdatedAt, goalUpdatedAt });
+      return true;
+    }
+
+    if (Number.isFinite(sessionUpdatedAt) && Number.isFinite(previous.sessionUpdatedAt)) {
+      if (sessionUpdatedAt < previous.sessionUpdatedAt) return false;
+      if (sessionUpdatedAt > previous.sessionUpdatedAt) {
+        sessionUpdateFreshness.set(update.sessionId, { sessionUpdatedAt, goalUpdatedAt });
+        return true;
+      }
+    } else if (Number.isFinite(sessionUpdatedAt) && !Number.isFinite(previous.sessionUpdatedAt)) {
+      sessionUpdateFreshness.set(update.sessionId, { sessionUpdatedAt, goalUpdatedAt });
+      return true;
+    }
+
+    // Some producers update goal metadata more precisely than the enclosing
+    // session timestamp. Use that field only as an equal-session-time
+    // secondary freshness signal. A missing value cannot outrank a known one.
+    if (Number.isFinite(goalUpdatedAt) && Number.isFinite(previous.goalUpdatedAt)) {
+      if (goalUpdatedAt < previous.goalUpdatedAt) return false;
+      if (goalUpdatedAt > previous.goalUpdatedAt) {
+        sessionUpdateFreshness.set(update.sessionId, { sessionUpdatedAt, goalUpdatedAt });
+        return true;
+      }
+    } else if (!Number.isFinite(goalUpdatedAt) && Number.isFinite(previous.goalUpdatedAt)) {
+      return false;
+    } else if (Number.isFinite(goalUpdatedAt) && !Number.isFinite(previous.goalUpdatedAt)) {
+      sessionUpdateFreshness.set(update.sessionId, { sessionUpdatedAt, goalUpdatedAt });
+      return true;
+    }
+
+    // Equal freshness is deterministic: keep the first accepted event. This
+    // makes duplicate delivery a no-op and avoids inventing chronology from an
+    // opaque goal/session ID.
+    return false;
   };
 
   const processPayload = (payload, directoryHint = '') => {
@@ -839,26 +2582,104 @@ export const createSessionGoalRuntime = ({
 
     const aborted = extractAbortedAssistant(payload);
     if (aborted) {
+      const generation = advanceGeneration(aborted.sessionId);
       clearTimer(aborted.sessionId);
-      if (!inflight.has(aborted.sessionId)) {
-        inflight.add(aborted.sessionId);
-        pauseAfterAbort(aborted.sessionId, directoryHint)
-          .catch((error) => {
-            console.warn('[session-goal] pause after abort failed:', error?.message || error);
-          })
-          .finally(() => {
-            inflight.delete(aborted.sessionId);
-          });
-      }
+      clearPendingArm(aborted.sessionId);
+      const reservation = reservations.get(aborted.sessionId);
+      pendingAborts.set(aborted.sessionId, { directory: directoryHint, generation });
+      beginInflight(aborted.sessionId);
+      const cleanup = reservation
+        ? discardReservation({
+          sessionId: aborted.sessionId,
+          directory: directoryHint || reservation.directory,
+          reservation,
+          generation,
+          rebindGeneration: true,
+        })
+        : Promise.resolve();
+      cleanup.then(() => pauseAfterAbort(aborted.sessionId, directoryHint || reservation?.directory, generation))
+        .catch((error) => {
+          console.warn('[session-goal] pause after abort failed:', error?.message || error);
+          if (isGenerationCurrent(aborted.sessionId, generation)) {
+            armTimer(aborted.sessionId, directoryHint, idleQuietMs);
+          }
+        })
+        .finally(() => {
+          finishInflight(aborted.sessionId);
+        });
       return;
     }
 
     const status = extractSessionStatus(payload);
     if (status) {
       if (status.type === 'idle') {
+        const terminalization = terminalizationStates.get(status.sessionId);
+        if (terminalization?.exhausted) {
+          terminalizationStates.set(status.sessionId, {
+            ...terminalization,
+            attempts: 0,
+            exhausted: false,
+          });
+          resetRetry(status.sessionId, 'terminalization');
+        } else if (reservations.get(status.sessionId)?.resolutionState && retryStates.get(status.sessionId)?.exhausted) {
+          // A later authoritative idle starts a fresh bounded resolution
+          // window after an earlier escalation, without a self-sustaining loop.
+          resetRetry(status.sessionId, 'reservation-rollback');
+        }
+        resetRetry(status.sessionId, 'status-event');
         armTimer(status.sessionId, status.directory || directoryHint, idleQuietMs);
-      } else {
+      } else if (SESSION_STATUS_TYPES.has(status.type)) {
+        advanceGeneration(status.sessionId);
+        resetRetry(status.sessionId);
         clearTimer(status.sessionId);
+        clearPendingArm(status.sessionId);
+        disabledRecoverySessions.delete(status.sessionId);
+        disabledRecoveryDirectories.delete(status.sessionId);
+        const reservation = reservations.get(status.sessionId);
+        if (reservation && reservation.postAttempts === 0) {
+          void reconcileDroppedReservation({
+            sessionId: status.sessionId,
+            directory: status.directory || directoryHint || reservation.directory,
+            reservation,
+            generation: getGeneration(status.sessionId),
+          });
+        } else if (reservation?.dispatchOutcome === 'ambiguous') {
+          // Busy/retry is authoritative evidence that an ambiguous prompt was
+          // admitted. Retain persisted accounting, but remove only an
+          // explicitly ambiguous marker so the next idle cannot send it twice.
+          reservations.delete(status.sessionId);
+        } else if (reservation) {
+          // A rejected response proves that no prompt was admitted, while a
+          // pending request has not resolved yet. Keep either reservation for
+          // rollback/reconciliation instead of treating status activity as
+          // admission.
+        }
+      } else {
+        // An event with a status type introduced by a newer OpenCode must not
+        // be treated as definitive activity. Keep the current generation and
+        // use the normal bounded retry policy until a known status arrives.
+        scheduleRetry(
+          status.sessionId,
+          status.directory || directoryHint,
+          getGeneration(status.sessionId),
+          'status-event',
+          { settleOnExhaustion: false },
+        );
+      }
+      return;
+    }
+
+    const userMessage = extractUserMessage(payload);
+    if (userMessage) {
+      const timer = timers.get(userMessage.sessionId);
+      const armedAt = timer?.armedAt ?? inflightArmPoints.get(userMessage.sessionId);
+      // Message IDs are opaque. Only a message with an authoritative creation
+      // timestamp at or after the current timer/tick arm point is new activity;
+      // an old or timestamp-less replay must not cancel active work.
+      if (Number.isFinite(armedAt)
+        && Number.isFinite(userMessage.createdAt)
+        && userMessage.createdAt >= armedAt) {
+        invalidateForAuthoritativeUserChange(userMessage.sessionId, directoryHint);
       }
       return;
     }
@@ -868,27 +2689,374 @@ export const createSessionGoalRuntime = ({
     // transition, only session.updated. Arm a short timer; the tick's
     // quiescence check keeps this safe if the session is actually busy.
     const update = extractSessionUpdate(payload);
+    if (update && !acceptSessionUpdate(update)) return;
+    let freshGoal = false;
+    let newGoalDuringWork = false;
+    if (
+      update
+      && !update.parentID
+      && !update.goal
+      && !update.hasGoalKey
+      && (
+        update.hasGoalNamespace
+        || knownGoalStatuses.get(update.sessionId) === 'active'
+        || reservations.has(update.sessionId)
+        || goalSnapshots.has(update.sessionId)
+      )
+    ) {
+      // Clear removes the goal key from the OpenChamber namespace. The event is
+      // authoritative even though it has no parseable goal or namespace. Only
+      // sessions already tracked as goal-bearing are invalidated, so an
+      // unrelated session.updated without goal metadata remains a no-op.
+      invalidateForAuthoritativeUserChange(update.sessionId, update.directory || directoryHint);
+      clearGoalTracking(update.sessionId);
+      return;
+    }
+    if (update && !update.parentID && update.goal) {
+      const settlementMarker = settlementMarkers.get(update.sessionId);
+      const committedSettlement = settlementMarker
+        && update.goal.status !== 'active'
+        && settlementMarkerMatches(update.goal, settlementMarker)
+        && reconcileCommittedSettlement(
+          update.sessionId,
+          update.directory || directoryHint,
+          update.goal,
+        );
+      if (settlementMarker && !committedSettlement && (
+        update.goal.status === 'active'
+        || !settlementMarkerMatches(update.goal, settlementMarker)
+      )) {
+        settlementMarkers.delete(update.sessionId);
+      }
+      const nextGoalSnapshot = goalLogicalIdentityKey(update.goal);
+      const previousGoalSnapshot = goalSnapshots.get(update.sessionId);
+      freshGoal = previousGoalSnapshot !== undefined && previousGoalSnapshot !== nextGoalSnapshot;
+      newGoalDuringWork = previousGoalSnapshot === undefined
+        && isInflight(update.sessionId)
+        && update.goal.status === 'active';
+      goalSnapshots.set(update.sessionId, nextGoalSnapshot);
+      knownGoalStatuses.set(update.sessionId, update.goal.status);
+      goalRevisionSnapshots.set(update.sessionId, update.goal.updatedAt);
+      rememberActiveGoalSession(update.sessionId, update.directory || directoryHint, update.goal);
+      clearedGoalSessions.delete(update.sessionId);
+      const nextGoalMetadataSnapshot = goalMetadataIdentityKey(update.goal);
+      const previousGoalMetadataSnapshot = goalMetadataSnapshots.get(update.sessionId);
+      const changedGoalMetadata = previousGoalMetadataSnapshot !== undefined
+        && previousGoalMetadataSnapshot !== nextGoalMetadataSnapshot;
+      goalMetadataSnapshots.set(update.sessionId, nextGoalMetadataSnapshot);
+      const lifecycleUpdate = update.goal.status !== 'active'
+        && (previousGoalMetadataSnapshot === undefined || changedGoalMetadata);
+      const resumeUpdate = update.goal.status === 'active'
+        && update.goal.statusReason === 'resumed';
+      const reservation = reservations.get(update.sessionId);
+      const terminalization = terminalizationStates.get(update.sessionId);
+      const isNewReservationIdentity = !reservation
+        || goalReservationIdentityKey(update.goal) !== goalReservationIdentityKey(reservation.goal);
+      if ((freshGoal || newGoalDuringWork)
+        && terminalization
+        && isNewReservationIdentity
+        && (!reservation || goalLogicalIdentityKey(update.goal) !== goalLogicalIdentityKey(reservation.goal))) {
+        // A new logical goal owns a new kickoff. Do not let a terminalization
+        // fence for the previous goal consume that kickoff. Release the old
+        // reservation immediately only when the authoritative replacement no
+        // longer carries its accounting; an indistinguishable charge still
+        // needs the guarded reconciliation below to block explicitly.
+        terminalizationStates.delete(update.sessionId);
+        if (!reservation || !reservationStateMatches(update.goal, reservation.after)) {
+          if (reservations.get(update.sessionId) === reservation) reservations.delete(update.sessionId);
+        }
+      }
+      if (resumeUpdate && reservation) {
+        const explicitAccountingReset = update.goal.turnsUsed === 0;
+        const reservationCanBeResolvedByResume = explicitAccountingReset
+          && (reservation.postAttempts === 0
+            || reservation.dispatchOutcome === 'rejected'
+            || terminalizationStates.has(update.sessionId));
+        if (reservationCanBeResolvedByResume) {
+          // Resume authoritatively reset the turn counter. A rejected or
+          // terminalization reservation belongs to the previous accounting
+          // segment, so its charge/fence is gone and the kickoff must create a
+          // fresh reservation for the resumed tail.
+          reservations.delete(update.sessionId);
+        } else {
+          // Edit-in-place may change identity/freshness while preserving the
+          // accounting counters. Rebind the reservation to that authoritative
+          // goal; do not discard it merely because metadata changed.
+          rebindPendingReservation(
+            reservation,
+            update.goal,
+            update.directory || directoryHint || reservation.directory,
+            { resetAccounting: true },
+          );
+        }
+      }
+      if (update.goal.status !== 'active') resumeSnapshots.delete(update.sessionId);
+      if (freshGoal || newGoalDuringWork || lifecycleUpdate) {
+        pendingAborts.delete(update.sessionId);
+        advanceGeneration(update.sessionId);
+        resetRetry(update.sessionId);
+        if (reservation) {
+          const directory = update.directory || directoryHint || reservation.directory;
+          void reconcileDroppedReservation({
+            sessionId: update.sessionId,
+            directory,
+            reservation,
+            generation: getGeneration(update.sessionId),
+            preserveAccounting: update.goal.status === 'active' && reservation.resolutionState !== 'pending',
+          });
+        }
+        clearTimer(update.sessionId);
+        clearPendingArm(update.sessionId);
+        disabledRecoverySessions.delete(update.sessionId);
+        disabledRecoveryDirectories.delete(update.sessionId);
+      }
+    }
     if (
       update
       && !update.parentID
       && update.goal
       && update.goal.status === 'active'
-      && (update.goal.turnsUsed === 0 || update.goal.statusReason === 'resumed')
-      && !timers.has(update.sessionId)
-      && !inflight.has(update.sessionId)
+      && (update.goal.turnsUsed === 0 || update.goal.statusReason === 'resumed' || freshGoal || newGoalDuringWork)
     ) {
-      const quiet = update.goal.statusReason === 'resumed' ? RESUME_KICKOFF_MS : kickoffQuietMs;
+      const isResume = update.goal.statusReason === 'resumed';
+      // CAS identity intentionally excludes updatedAt and effective file text.
+      // Resume dedup needs a separate lifecycle signal so a real file edit that
+      // reuses the same goal identity is not mistaken for duplicate delivery.
+      const resumeKey = JSON.stringify([
+        goalMetadataIdentityKey(update.goal),
+        update.goal.updatedAt,
+        update.sessionUpdatedAt,
+      ]);
+      const duplicateResume = resumeSnapshots.get(update.sessionId) === resumeKey;
+      if (isResume && duplicateResume) {
+        return;
+      }
+      if (isResume) {
+        resumeSnapshots.set(update.sessionId, resumeKey);
+        terminalizationStates.delete(update.sessionId);
+        recoveryHolds.delete(update.sessionId);
+        recoveryHoldDirectories.delete(update.sessionId);
+        disabledRecoverySessions.delete(update.sessionId);
+        disabledRecoveryDirectories.delete(update.sessionId);
+        advanceGeneration(update.sessionId);
+        pendingAborts.delete(update.sessionId);
+        resetRetry(update.sessionId);
+        clearTimer(update.sessionId);
+        clearPendingArm(update.sessionId);
+      } else if (!freshGoal && !newGoalDuringWork && (timers.has(update.sessionId) || isInflight(update.sessionId))) {
+        return;
+      }
+      const quiet = isResume ? RESUME_KICKOFF_MS : kickoffQuietMs;
       armTimer(update.sessionId, update.directory || directoryHint, quiet);
     }
   };
 
+  const start = async ({ listDirectories, resetRetryWindow = false } = {}) => {
+    if (stopped || !isCallable(listDirectories)) return;
+    scanEpoch += 1;
+    const epoch = scanEpoch;
+    const isCurrentScan = () => !stopped && epoch === scanEpoch;
+    if (resetRetryWindow) {
+      startupRecoveryAttempts = 0;
+      clearStartupRecoveryTimer();
+    }
+    let directories;
+    try {
+      directories = await listDirectories();
+    } catch (error) {
+      if (!isCurrentScan()) return;
+      console.warn(`[session-goal] restart directory scan failed: ${error?.message || error}`);
+      scheduleStartupRecovery(listDirectories);
+      return;
+    }
+    if (!isCurrentScan()) return;
+    if (!Array.isArray(directories)) {
+      if (!isCurrentScan()) return;
+      scheduleStartupRecovery(listDirectories);
+      return;
+    }
+    let scanFailed = false;
+    const queue = [...new Set(directories.filter((value) => isString(value) && value))];
+    const scanDirectory = async (directory) => {
+      if (!isCurrentScan()) return;
+      let sessions;
+      try {
+        sessions = await openCodeFetch('/session', {
+          directory,
+          query: { archived: 'false', roots: 'true', limit: String(MESSAGE_FETCH_LIMIT * 10) },
+        });
+      } catch (error) {
+        if (!isCurrentScan()) return;
+        // One unavailable project must not prevent recovery in unrelated ones.
+        console.warn(`[session-goal] restart scan failed for ${directory}: ${error?.message || error}`);
+        scanFailed = true;
+        return;
+      }
+      if (!isCurrentScan()) return;
+      if (!Array.isArray(sessions)) {
+        scanFailed = true;
+        return;
+      }
+      if (!isCurrentScan()) return;
+      for (const candidate of sessions) {
+        if (!isCurrentScan()) return;
+        if (
+          !candidate
+          || !isPlainObject(candidate)
+          || !isString(candidate.id)
+          || !candidate.id
+          || (candidate.parentID !== undefined
+            && (!isString(candidate.parentID) || candidate.parentID))
+        ) continue;
+        if (!isCurrentScan()) return;
+        const candidateGoal = parseGoalMetadata(candidate);
+        if (!candidateGoal || candidateGoal.status !== 'active') continue;
+        const sessionId = candidate.id;
+        const sessionDirectory = isString(candidate.directory) && candidate.directory
+          ? candidate.directory
+          : directory;
+        if (!acceptSessionUpdate({
+          sessionId,
+          parentID: '',
+          goal: candidateGoal,
+          sessionUpdatedAt: Number.isFinite(candidate.time?.updated) ? candidate.time.updated : null,
+        })) continue;
+         goalSnapshots.set(sessionId, goalLogicalIdentityKey(candidateGoal));
+          goalMetadataSnapshots.set(sessionId, goalMetadataIdentityKey(candidateGoal));
+          goalRevisionSnapshots.set(sessionId, candidateGoal.updatedAt);
+          knownGoalStatuses.set(sessionId, candidateGoal.status);
+         rememberActiveGoalSession(sessionId, sessionDirectory, candidateGoal);
+         if (!isEnabled()) {
+          recoveryHolds.delete(sessionId);
+          recoveryHoldDirectories.delete(sessionId);
+          disabledRecoverySessions.add(sessionId);
+          disabledRecoveryDirectories.set(sessionId, sessionDirectory);
+          resetRetry(sessionId);
+          armTimer(sessionId, sessionDirectory, 0);
+          continue;
+        }
+        disabledRecoverySessions.delete(sessionId);
+        disabledRecoveryDirectories.delete(sessionId);
+        recoveryHolds.add(sessionId);
+        recoveryHoldDirectories.set(sessionId, sessionDirectory);
+        armTimer(sessionId, sessionDirectory, 0);
+      }
+    };
+    let cursor = 0;
+    const workerCount = Math.min(RESTART_SCAN_CONCURRENCY, queue.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (true) {
+        if (!isCurrentScan()) return;
+        const index = cursor;
+        cursor += 1;
+        if (index >= queue.length) return;
+        await scanDirectory(queue[index]);
+      }
+    });
+    await Promise.all(workers);
+    if (!isCurrentScan()) return;
+    if (scanFailed) {
+      scheduleStartupRecovery(listDirectories);
+    } else {
+      startupRecoveryAttempts = 0;
+      clearStartupRecoveryTimer();
+      if (resetRetryWindow) {
+        for (const [sessionId, directory] of activeGoalSessions.entries()) {
+          if (terminalizationStates.has(sessionId)) continue;
+          resetRetry(sessionId);
+          armTimer(sessionId, directory, 0);
+        }
+      }
+    }
+  };
+
+  const onSettingsChanged = () => {
+    if (stopped) return;
+    if (!isEnabled()) {
+      for (const [sessionId, directory] of recoveryHoldDirectories.entries()) {
+        recoveryHolds.delete(sessionId);
+        recoveryHoldDirectories.delete(sessionId);
+        disabledRecoverySessions.add(sessionId);
+        disabledRecoveryDirectories.set(sessionId, directory);
+        resetRetry(sessionId);
+        armTimer(sessionId, directory, 0);
+      }
+      return;
+    }
+    for (const [sessionId, directory] of disabledRecoveryDirectories.entries()) {
+      disabledRecoverySessions.delete(sessionId);
+      disabledRecoveryDirectories.delete(sessionId);
+      recoveryHolds.delete(sessionId);
+      resetRetry(sessionId);
+      armTimer(sessionId, directory, 0);
+    }
+    for (const [sessionId, directory] of activeGoalSessions.entries()) {
+      // Re-enable is an explicit recovery edge: clear any exhausted bounded
+      // retry window, then arm every authoritative active goal exactly once.
+      resetRetry(sessionId);
+      armTimer(sessionId, directory, 0);
+    }
+  };
+
   const stop = () => {
+    if (stopped) return;
+    const reservationsToRollback = [...reservations.entries()]
+      .filter(([, reservation]) => reservation.postAttempts === 0 || reservation.dispatchOutcome === 'rejected');
     stopped = true;
+    clearStartupRecoveryTimer();
+    terminalizationStates.clear();
+    settlementMarkers.clear();
+    for (const sessionId of new Set([
+      ...generations.keys(),
+      ...timers.keys(),
+      ...inflight.keys(),
+      ...writeQueues.keys(),
+      ...reservations.keys(),
+      ...pendingAborts.keys(),
+    ])) {
+      advanceGeneration(sessionId);
+    }
     for (const { timer } of timers.values()) {
       clearTimeout(timer);
     }
     timers.clear();
+    inflightArmPoints.clear();
+    pendingArms.clear();
+    for (const [sessionId, reservation] of reservations.entries()) {
+      if (reservation.postAttempts > 0 && reservation.dispatchOutcome !== 'rejected') reservations.delete(sessionId);
+    }
+    pendingAborts.clear();
+    retryStates.clear();
+    goalSnapshots.clear();
+    resumeSnapshots.clear();
+    goalMetadataSnapshots.clear();
+    goalRevisionSnapshots.clear();
+    knownGoalStatuses.clear();
+    clearedGoalSessions.clear();
+    recoveryHolds.clear();
+    recoveryHoldDirectories.clear();
+    disabledRecoverySessions.clear();
+    disabledRecoveryDirectories.clear();
+    activeGoalSessions.clear();
+    sessionUpdateFreshness.clear();
+    for (const [sessionId, reservation] of reservationsToRollback) {
+      void rollbackReservation({
+        sessionId,
+        directory: reservation.directory,
+        reservation,
+        allowStopped: true,
+        blockedReason: 'runtime stopped before continuation dispatch',
+      }).catch((error) => {
+        console.warn(`[session-goal] ${sessionId} shutdown reservation cleanup failed: ${error?.message || error}`);
+      });
+    }
+    for (const sessionId of writeQueues.keys()) {
+      if (!reservations.has(sessionId)) {
+        writeVersions.delete(sessionId);
+        writeQueues.delete(sessionId);
+      }
+    }
   };
 
-  return { processPayload, stop };
+  return { processPayload, start, onSettingsChanged, stop };
 };

--- a/packages/web/server/lib/session-goal/runtime.js
+++ b/packages/web/server/lib/session-goal/runtime.js
@@ -474,7 +474,15 @@ const reservationGoalState = (goal) => ({
 const reservationStateMatches = (goal, state) => Object.entries(state)
   .every(([key, value]) => goal[key] === value);
 
-const continuationAdmission = (error) => error?.admission === 'rejected' ? 'rejected' : 'ambiguous';
+// Dispatch admission is only provable by the POST attempt itself. An error
+// without an explicit admission (a pre-POST read failure, for example) carries
+// no information about whether the prompt was accepted, so it must never
+// overwrite a previously proven rejected/ambiguous dispatch outcome.
+const continuationAdmission = (error) => {
+  if (error?.admission === 'rejected') return 'rejected';
+  if (error?.admission === 'ambiguous') return 'ambiguous';
+  return null;
+};
 
 export const createSessionGoalRuntime = ({
   buildOpenCodeUrl,
@@ -571,6 +579,19 @@ export const createSessionGoalRuntime = ({
     }
     return generation;
   };
+  // A pending abort may only pause the goal revision that was active when the
+  // user aborted. Bind it to the last authoritative goal identity when one is
+  // known; otherwise anchor to the abort arrival time so a goal created
+  // afterwards is never mistaken for the aborted revision.
+  const pendingAbortMatchesGoal = (pendingAbort, goal) => {
+    if (!pendingAbort || !goal) return false;
+    if (pendingAbort.goalIdentity) {
+      return pendingAbort.goalIdentity === goalMetadataIdentityKey(goal);
+    }
+    return !(Number.isFinite(pendingAbort.abortedAt)
+      && Number.isFinite(goal.createdAt)
+      && goal.createdAt > pendingAbort.abortedAt);
+  };
   const isGenerationCurrent = (sessionId, generation) => !stopped && getGeneration(sessionId) === generation;
   const isInflight = (sessionId) => (inflight.get(sessionId) ?? 0) > 0;
   const beginInflight = (sessionId) => {
@@ -659,21 +680,25 @@ export const createSessionGoalRuntime = ({
       // A transport rejection does not tell us whether OpenCode accepted a
       // prompt before the connection died. Callers of prompt_async must
       // reconcile authoritative state rather than retrying this blindly.
-      if (isNonCallableObject(error)) error.admission = 'ambiguous';
+      // Only the POST attempt can prove admission: a failed GET for the same
+      // session says nothing about the attempted continuation.
+      if (method === 'POST' && isNonCallableObject(error)) error.admission = 'ambiguous';
       throw error;
     }
     if (!response || (response.ok !== true && response.ok !== false) || !Number.isFinite(response.status)) {
       const error = new Error(`OpenCode ${method} ${fetchPath} returned an unknown response`);
-      error.admission = 'ambiguous';
+      if (method === 'POST') error.admission = 'ambiguous';
       throw error;
     }
     if (!response.ok) {
       const status = Number.isFinite(response.status) ? response.status : null;
       const error = new Error(`OpenCode ${method} ${fetchPath} failed with ${status ?? 'unknown status'}`);
       error.status = status;
-      error.admission = status !== null && ![408, 429, 500, 502, 503, 504].includes(status)
-        ? 'rejected'
-        : 'ambiguous';
+      if (method === 'POST') {
+        error.admission = status !== null && ![408, 429, 500, 502, 503, 504].includes(status)
+          ? 'rejected'
+          : 'ambiguous';
+      }
       throw error;
     }
     // prompt_async is a 204 endpoint in OpenCode. Its HTTP status is the
@@ -1098,10 +1123,10 @@ export const createSessionGoalRuntime = ({
     return false;
   };
 
-  const settleRejectedReservation = async ({ sessionId, directory, reservation, generation, statusReason }) => {
-    if (reservations.get(sessionId) !== reservation) return false;
+  const settleUndispatchedReservation = async ({ sessionId, directory, reservation, generation, status = 'blocked', statusReason }) => {
+    if (!reservation || reservations.get(sessionId) !== reservation) return false;
     const before = reservation.before;
-    // A proven rejection cannot have consumed the prompt. Roll back the
+    // A proven non-admission cannot have consumed the prompt. Roll back the
     // accounting first, then use the normal settlement path so the goal cannot
     // remain active after the bounded dispatch window closes.
     if (!reservation.restored) {
@@ -1122,7 +1147,7 @@ export const createSessionGoalRuntime = ({
       sessionId,
       directory,
       goal: { ...reservation.goal, ...before },
-      status: 'blocked',
+      status,
       statusReason,
       note: before.note,
       tokensUsed: before.tokensUsed,
@@ -1138,7 +1163,7 @@ export const createSessionGoalRuntime = ({
   };
 
   const discardReservation = async ({ sessionId, directory, reservation, generation, rebindGeneration = false, rollback = true, blockedReason, scheduleResolutionRetry = true }) => {
-    if (reservations.get(sessionId) !== reservation) return;
+    if (!reservation || reservations.get(sessionId) !== reservation) return;
     // After prompt_async was attempted, the server may have accepted it even
     // when the response was lost. Preserve that accounting and drop only the
     // retry marker in that case.
@@ -1330,7 +1355,7 @@ export const createSessionGoalRuntime = ({
         generation,
       });
     } else if (reservation.postAttempts > 0) {
-      const settled = await settleRejectedReservation({
+      const settled = await settleUndispatchedReservation({
         sessionId,
         directory,
         reservation,
@@ -1370,6 +1395,22 @@ export const createSessionGoalRuntime = ({
       ? Math.max(0, retryDelaysMs[attempts - 1])
       : Math.max(0, idleQuietMs);
     armTimer(sessionId, directory, delay);
+    return true;
+  };
+
+  // A readiness edge or a feature re-enable gives an exhausted terminalization
+  // fence one fresh bounded window. The goal/revision fence is intentionally
+  // kept: revival never bypasses the newer-goal guard, it only re-arms the
+  // same terminal attempt. Each revival is bounded by maxRetryAttempts again,
+  // so this cannot become a self-sustaining loop.
+  const reviveTerminalization = (sessionId) => {
+    const terminalization = terminalizationStates.get(sessionId);
+    if (!terminalization) return false;
+    terminalizationStates.set(sessionId, {
+      ...terminalization,
+      attempts: 0,
+      exhausted: false,
+    });
     return true;
   };
 
@@ -1535,6 +1576,12 @@ export const createSessionGoalRuntime = ({
       if (isCallable(onDispatchAttempt)) onDispatchAttempt({ postAttempted: false });
       throw error;
     }
+    // Final objective re-read: the file is live-editable, so an edit can land
+    // after the earlier check while the final status fetch is in flight. This
+    // is the last check before the POST and must see the current file text.
+    if (!(await objectiveSnapshotIsCurrent({ sessionId, goal: finalGoal, effectiveObjective }))) {
+      return { sent: false, stale: true };
+    }
     if (stopped || (generation !== undefined && !isGenerationCurrent(sessionId, generation))) return { sent: false, stale: true };
     const agent = isString(lastAssistantInfo?.agent) && lastAssistantInfo.agent
       ? lastAssistantInfo.agent
@@ -1650,6 +1697,9 @@ export const createSessionGoalRuntime = ({
       goalRevisionSnapshots.set(sessionId, goal.updatedAt);
     }
     if (!goal || goal.status !== 'active') {
+      // A pending abort only exists to pause an active goal; an authoritative
+      // inactive/absent goal makes it obsolete.
+      pendingAborts.delete(sessionId);
       if (goal) reconcileCommittedSettlement(sessionId, directory, goal);
       return;
     }
@@ -1659,15 +1709,21 @@ export const createSessionGoalRuntime = ({
 
     const pendingAbort = pendingAborts.get(sessionId);
     if (pendingAbort?.generation === generation) {
-      const written = await writeGoal(sessionId, directory, goal, () => ({
-        status: 'paused',
-        statusReason: 'paused after abort',
-      }), { generation });
-      if (written) {
+      if (!pendingAbortMatchesGoal(pendingAbort, goal)) {
+        // The goal revision was replaced after the abort arrived. The stale
+        // stop must not pause the newer goal; fall through to normal work.
         pendingAborts.delete(sessionId);
-        activeGoalSessions.delete(sessionId);
+      } else {
+        const written = await writeGoal(sessionId, directory, goal, () => ({
+          status: 'paused',
+          statusReason: 'paused after abort',
+        }), { generation });
+        if (written) {
+          pendingAborts.delete(sessionId);
+          activeGoalSessions.delete(sessionId);
+        }
+        return;
       }
-      return;
     }
 
     // File-backed objectives: the metadata carries only a flag; the objective
@@ -1888,6 +1944,31 @@ export const createSessionGoalRuntime = ({
            await discardReservation({ sessionId, directory, reservation, generation });
            return;
         }
+        if (Number.isFinite(goal.tokenBudget) && goal.tokensUsed >= goal.tokenBudget) {
+          // Budget is a hard stop and the tick that created this reservation
+          // pre-authorized one dispatch before the authoritative budget could
+          // shrink. Re-apply it here and settle from the current authoritative
+          // goal instead of spending the reservation on an over-budget goal.
+          // The reservation's accounting still matches this goal, so the
+          // successful settlement releases it.
+          await settleGoal({
+            sessionId,
+            directory,
+            goal,
+            status: 'budgetLimited',
+            statusReason: 'token budget reached',
+            tokensUsed: goal.tokensUsed,
+            tokensBaseline: goal.tokensBaseline,
+            tokensCommitted: goal.tokensCommitted,
+            turnsUsed: goal.turnsUsed,
+            lastAccountedMessageID: goal.lastAccountedMessageID,
+            evaluationProviderID: goal.evaluationProviderID,
+            evaluationModelID: goal.evaluationModelID,
+            generation,
+            effectiveObjective,
+          });
+          return;
+        }
          if (reservation.dispatchAttempts >= maxDispatchAttempts) {
            if (reservation.postAttempts === 0) {
              await discardReservation({
@@ -1939,22 +2020,31 @@ export const createSessionGoalRuntime = ({
         }
       } catch (error) {
         console.warn(`[session-goal] continuation dispatch failed: ${error?.message || error}`);
-        const dispatchOutcome = continuationAdmission(error);
         const currentReservation = reservations.get(sessionId);
-        if (currentReservation?.postAttempts > 0) currentReservation.dispatchOutcome = dispatchOutcome;
-        if (dispatchOutcome === 'ambiguous' && currentReservation?.postAttempts > 0) {
-          currentReservation.dispatchOutcome = 'ambiguous';
+        if (currentReservation !== reservation) {
+          // The reservation this attempt belonged to was replaced or cleared
+          // while the dispatch was in flight (Resume, replacement, abort). Its
+          // outcome must not mutate or settle a newer reservation/goal.
+          if (error?.retryKind === 'fetch' && isGenerationCurrent(sessionId, generation)) {
+            scheduleRetry(sessionId, directory, generation, 'fetch');
+          }
+          return;
+        }
+        const dispatchOutcome = continuationAdmission(error);
+        if (dispatchOutcome && reservation.postAttempts > 0) reservation.dispatchOutcome = dispatchOutcome;
+        if (dispatchOutcome === 'ambiguous' && reservation.postAttempts > 0) {
+          reservation.dispatchOutcome = 'ambiguous';
           const reconciled = await reconcileAmbiguousDispatch({
             sessionId,
             directory,
-            reservation: currentReservation,
+            reservation,
             generation,
           });
           if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
             await settleGoal({
               sessionId,
               directory,
-              goal: { ...currentReservation.goal, ...currentReservation.after },
+              goal: { ...reservation.goal, ...reservation.after },
               status: 'blocked',
               statusReason: 'continuation admission unresolved',
               generation,
@@ -1962,12 +2052,12 @@ export const createSessionGoalRuntime = ({
           }
         } else if (error?.retryKind === 'fetch') {
           scheduleRetry(sessionId, directory, generation, 'fetch');
-        } else if (currentReservation?.dispatchAttempts >= maxDispatchAttempts) {
-          if (currentReservation.postAttempts === 0) {
+        } else if (reservation.dispatchAttempts >= maxDispatchAttempts) {
+          if (reservation.postAttempts === 0) {
             await discardReservation({
               sessionId,
               directory,
-              reservation: currentReservation,
+              reservation,
               generation,
               blockedReason: 'continuation dispatch rejected before continuation dispatch',
             });
@@ -2320,11 +2410,11 @@ export const createSessionGoalRuntime = ({
     }
 
     console.log(`[session-goal] continuing ${sessionId} (turn ${written.turnsUsed}/${maxAutoTurns}, tokens ${written.tokensUsed}${written.tokenBudget ? `/${written.tokenBudget}` : ''})`);
+    const dispatchReservation = reservations.get(sessionId);
+    if (!dispatchReservation) return;
     try {
-      const reservation = reservations.get(sessionId);
-      if (!reservation) return;
       if (!(await ensureObjectiveCurrent({ sessionId, directory, goal: written, effectiveObjective, generation }))) {
-        await discardReservation({ sessionId, directory, reservation, generation });
+        await discardReservation({ sessionId, directory, reservation: dispatchReservation, generation });
         return;
       }
       const sent = await sendContinuation({
@@ -2336,10 +2426,10 @@ export const createSessionGoalRuntime = ({
          lastAssistantInfo: executionInfo ?? lastAssistantInfo,
         generation,
         onDispatchAttempt: ({ postAttempted }) => {
-          reservation.dispatchAttempts += 1;
+          dispatchReservation.dispatchAttempts += 1;
           if (postAttempted) {
-            reservation.postAttempts += 1;
-            reservation.dispatchOutcome = 'pending';
+            dispatchReservation.postAttempts += 1;
+            dispatchReservation.dispatchOutcome = 'pending';
           }
         },
       });
@@ -2347,34 +2437,43 @@ export const createSessionGoalRuntime = ({
         reservations.delete(sessionId);
         resetRetry(sessionId);
       } else if (sent.ambiguous && isGenerationCurrent(sessionId, generation)) {
-        reservation.dispatchOutcome = 'ambiguous';
-        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+        dispatchReservation.dispatchOutcome = 'ambiguous';
+        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation: dispatchReservation, generation });
         if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
           await settleGoal({
             sessionId,
             directory,
-            goal: { ...reservation.goal, ...reservation.after },
+            goal: { ...dispatchReservation.goal, ...dispatchReservation.after },
             status: 'blocked',
             statusReason: 'continuation admission unresolved',
             generation,
           });
         }
       } else if (sent.stale && isGenerationCurrent(sessionId, generation)) {
-         await reconcileDroppedReservation({ sessionId, directory, reservation, generation });
+         await reconcileDroppedReservation({ sessionId, directory, reservation: dispatchReservation, generation });
        }
     } catch (error) {
       console.warn(`[session-goal] continuation dispatch failed: ${error?.message || error}`);
-      const reservation = reservations.get(sessionId);
+      const currentReservation = reservations.get(sessionId);
+      if (currentReservation !== dispatchReservation) {
+        // The reservation this attempt belonged to was replaced or cleared
+        // while the dispatch was in flight. Its outcome must not mutate or
+        // settle a newer reservation/goal.
+        if (error?.retryKind === 'fetch' && isGenerationCurrent(sessionId, generation)) {
+          scheduleRetry(sessionId, directory, generation, 'fetch');
+        }
+        return;
+      }
       const dispatchOutcome = continuationAdmission(error);
-      if (reservation?.postAttempts > 0) reservation.dispatchOutcome = dispatchOutcome;
-      if (dispatchOutcome === 'ambiguous' && reservation?.postAttempts > 0) {
-        reservation.dispatchOutcome = 'ambiguous';
-        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation, generation });
+      if (dispatchOutcome && dispatchReservation.postAttempts > 0) dispatchReservation.dispatchOutcome = dispatchOutcome;
+      if (dispatchOutcome === 'ambiguous' && dispatchReservation.postAttempts > 0) {
+        dispatchReservation.dispatchOutcome = 'ambiguous';
+        const reconciled = await reconcileAmbiguousDispatch({ sessionId, directory, reservation: dispatchReservation, generation });
         if (reconciled === 'unknown' && isGenerationCurrent(sessionId, generation)) {
           await settleGoal({
             sessionId,
             directory,
-            goal: { ...reservation.goal, ...reservation.after },
+            goal: { ...dispatchReservation.goal, ...dispatchReservation.after },
             status: 'blocked',
             statusReason: 'continuation admission unresolved',
             generation,
@@ -2382,12 +2481,12 @@ export const createSessionGoalRuntime = ({
         }
       } else if (error?.retryKind === 'fetch') {
         scheduleRetry(sessionId, directory, generation, 'fetch');
-      } else if ((reservation?.dispatchAttempts ?? maxDispatchAttempts) >= maxDispatchAttempts) {
-        if ((reservation?.postAttempts ?? 0) === 0) {
+      } else if (dispatchReservation.dispatchAttempts >= maxDispatchAttempts) {
+        if (dispatchReservation.postAttempts === 0) {
           await discardReservation({
             sessionId,
             directory,
-            reservation,
+            reservation: dispatchReservation,
             generation,
             blockedReason: 'continuation dispatch rejected before continuation dispatch',
           });
@@ -2473,6 +2572,10 @@ export const createSessionGoalRuntime = ({
   // Resume re-arms the loop (and kicks off immediately on an idle session).
   const pauseAfterAbort = async (sessionId, directory, generation) => {
     if (!isGenerationCurrent(sessionId, generation)) return;
+    const pendingAbort = pendingAborts.get(sessionId);
+    // A newer authoritative event (Resume, replacement, clear) already
+    // invalidated this abort; pausing now would hit a goal it no longer owns.
+    if (!pendingAbort) return;
     const session = await fetchSession(sessionId, directory);
     if (!isGenerationCurrent(sessionId, generation)) return;
     const goal = parseGoalMetadata(session);
@@ -2480,6 +2583,13 @@ export const createSessionGoalRuntime = ({
       if (isGenerationCurrent(sessionId, generation)) pendingAborts.delete(sessionId);
       return;
     }
+    if (!pendingAbortMatchesGoal(pendingAbort, goal)) {
+      // A newer goal revision replaced the aborted one before the pause
+      // landed; discard the stale stop instead of pausing the new goal.
+      if (isGenerationCurrent(sessionId, generation)) pendingAborts.delete(sessionId);
+      return;
+    }
+    pendingAbort.goalIdentity = goalMetadataIdentityKey(goal);
     const written = await writeGoal(sessionId, directory, goal, () => ({
       status: 'paused',
       statusReason: 'paused after abort',
@@ -2504,7 +2614,9 @@ export const createSessionGoalRuntime = ({
       // never let this old reservation trigger another provider execution.
       reservations.delete(sessionId);
     } else {
-      void reconcileDroppedReservation({ sessionId, directory, reservation, generation });
+      void reconcileDroppedReservation({ sessionId, directory, reservation, generation }).catch((error) => {
+        console.warn(`[session-goal] ${sessionId} reservation reconciliation failed: ${error?.message || error}`);
+      });
     }
     return generation;
   };
@@ -2586,7 +2698,12 @@ export const createSessionGoalRuntime = ({
       clearTimer(aborted.sessionId);
       clearPendingArm(aborted.sessionId);
       const reservation = reservations.get(aborted.sessionId);
-      pendingAborts.set(aborted.sessionId, { directory: directoryHint, generation });
+      pendingAborts.set(aborted.sessionId, {
+        directory: directoryHint,
+        generation,
+        abortedAt: Date.now(),
+        goalIdentity: goalMetadataSnapshots.get(aborted.sessionId) ?? null,
+      });
       beginInflight(aborted.sessionId);
       const cleanup = reservation
         ? discardReservation({
@@ -2642,6 +2759,8 @@ export const createSessionGoalRuntime = ({
             directory: status.directory || directoryHint || reservation.directory,
             reservation,
             generation: getGeneration(status.sessionId),
+          }).catch((error) => {
+            console.warn(`[session-goal] ${status.sessionId} reservation reconciliation failed: ${error?.message || error}`);
           });
         } else if (reservation?.dispatchOutcome === 'ambiguous') {
           // Busy/retry is authoritative evidence that an ambiguous prompt was
@@ -2737,6 +2856,12 @@ export const createSessionGoalRuntime = ({
       goalSnapshots.set(update.sessionId, nextGoalSnapshot);
       knownGoalStatuses.set(update.sessionId, update.goal.status);
       goalRevisionSnapshots.set(update.sessionId, update.goal.updatedAt);
+      // Once a goal revision that cannot be the aborted one is authoritatively
+      // observed, the stale stop is discarded rather than left to pause it.
+      const pendingAbort = pendingAborts.get(update.sessionId);
+      if (pendingAbort && !pendingAbortMatchesGoal(pendingAbort, update.goal)) {
+        pendingAborts.delete(update.sessionId);
+      }
       rememberActiveGoalSession(update.sessionId, update.directory || directoryHint, update.goal);
       clearedGoalSessions.delete(update.sessionId);
       const nextGoalMetadataSnapshot = goalMetadataIdentityKey(update.goal);
@@ -2803,6 +2928,8 @@ export const createSessionGoalRuntime = ({
             reservation,
             generation: getGeneration(update.sessionId),
             preserveAccounting: update.goal.status === 'active' && reservation.resolutionState !== 'pending',
+          }).catch((error) => {
+            console.warn(`[session-goal] ${update.sessionId} reservation reconciliation failed: ${error?.message || error}`);
           });
         }
         clearTimer(update.sessionId);
@@ -2962,7 +3089,10 @@ export const createSessionGoalRuntime = ({
       clearStartupRecoveryTimer();
       if (resetRetryWindow) {
         for (const [sessionId, directory] of activeGoalSessions.entries()) {
-          if (terminalizationStates.has(sessionId)) continue;
+          // Readiness is an explicit recovery edge: an exhausted
+          // terminalization fence gets one fresh bounded window instead of
+          // staying stranded with zero timers.
+          reviveTerminalization(sessionId);
           resetRetry(sessionId);
           armTimer(sessionId, directory, 0);
         }
@@ -2987,12 +3117,15 @@ export const createSessionGoalRuntime = ({
       disabledRecoverySessions.delete(sessionId);
       disabledRecoveryDirectories.delete(sessionId);
       recoveryHolds.delete(sessionId);
+      reviveTerminalization(sessionId);
       resetRetry(sessionId);
       armTimer(sessionId, directory, 0);
     }
     for (const [sessionId, directory] of activeGoalSessions.entries()) {
       // Re-enable is an explicit recovery edge: clear any exhausted bounded
-      // retry window, then arm every authoritative active goal exactly once.
+      // retry window, revive an exhausted terminalization fence, then arm
+      // every authoritative active goal exactly once.
+      reviveTerminalization(sessionId);
       resetRetry(sessionId);
       armTimer(sessionId, directory, 0);
     }

--- a/packages/web/server/lib/session-goal/runtime.test.js
+++ b/packages/web/server/lib/session-goal/runtime.test.js
@@ -5,6 +5,7 @@ import { createSessionGoalRuntime } from './runtime.js';
 const SESSION_ID = 'ses_parent';
 const CHILD_ID = 'ses_child';
 const DIRECTORY = '/workspace';
+const readGoalObjective = vi.fn(async () => null);
 
 const goal = {
   id: 'goal_1',
@@ -26,9 +27,22 @@ const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), 
   headers: { 'Content-Type': 'application/json' },
 });
 
-const requestPath = (input) => new URL(typeof input === 'string' ? input : input.url).pathname;
+const requestPath = (input) => new URL(input?.url ?? input).pathname;
 
-const startIdleTick = async (fetchImpl) => {
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+const startIdleTick = async (fetchImpl, options = {}) => {
   const getSmallModelService = vi.fn();
   vi.stubGlobal('fetch', fetchImpl);
   const runtime = createSessionGoalRuntime({
@@ -37,7 +51,8 @@ const startIdleTick = async (fetchImpl) => {
     getSmallModelService,
     isEnabled: () => true,
     idleQuietMs: 10,
-  });
+    ...options,
+    });
   runtime.processPayload({
     type: 'session.status',
     properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
@@ -46,81 +61,11 @@ const startIdleTick = async (fetchImpl) => {
   return { runtime, getSmallModelService };
 };
 
-const assistantMessage = (id, infoOverrides = {}) => ({
-  info: {
-    id,
-    sessionID: SESSION_ID,
-    role: 'assistant',
-    providerID: 'provider',
-    modelID: 'model',
-    time: { created: 2, completed: 2 },
-    tokens: { input: 1, output: 1, cache: { read: 0 } },
-    ...infoOverrides,
-  },
-  parts: [{ type: 'text', text: 'The agent made progress.' }],
-});
-
-const createRuntimeHarness = ({ messages, messageFactory, goalOverrides = {}, maxAutoTurns = 20 }) => {
-  const requests = [];
-  let messageFetchCount = 0;
-  const activeSession = {
-    ...session,
-    metadata: { openchamber: { goal: { ...goal, ...goalOverrides } } },
-  };
-  const service = {
-    generateSmallModelText: vi.fn(async () => ({
-      text: '{"verdict":"continue","note":"More work remains"}',
-      providerID: 'provider',
-      modelID: 'model',
-    })),
-  };
-  const fetchImpl = vi.fn(async (input, init = {}) => {
-    const pathname = requestPath(input);
-    requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
-    if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
-      activeSession.metadata = JSON.parse(init.body).metadata;
-      return jsonResponse(activeSession);
-    }
-    if (pathname === `/session/${SESSION_ID}`) return jsonResponse(activeSession);
-    if (pathname === '/session/status') return jsonResponse({});
-    if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
-    if (pathname === `/session/${SESSION_ID}/message`) {
-      const nextMessages = messageFactory ? messageFactory(messageFetchCount) : messages;
-      messageFetchCount += 1;
-      return jsonResponse(nextMessages);
-    }
-    if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
-    throw new Error(`Unexpected request: ${pathname}`);
-  });
-  vi.stubGlobal('fetch', fetchImpl);
-  const runtime = createSessionGoalRuntime({
-    buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
-    getOpenCodeAuthHeaders: () => ({}),
-    getSmallModelService: async () => service,
-    isEnabled: () => true,
-    idleQuietMs: 10,
-    maxAutoTurns,
-  });
-  return { runtime, requests, service, activeSession };
-};
-
-const runIdleTick = async (runtime) => {
-  runtime.processPayload({
-    type: 'session.status',
-    properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
-  });
-  await vi.runOnlyPendingTimersAsync();
-};
-
-const lastPatchedGoal = (requests) => {
-  const patches = requests.filter((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
-  expect(patches.length).toBeGreaterThan(0);
-  return JSON.parse(patches.at(-1).body).metadata.openchamber.goal;
-};
-
 describe('session goal live activity gate', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    readGoalObjective.mockReset();
+    readGoalObjective.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -152,7 +97,7 @@ describe('session goal live activity gate', () => {
       const pathname = requestPath(input);
       paths.push(pathname);
       if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
-      if (pathname === '/session/status') return jsonResponse({ [CHILD_ID]: { type: 'busy' } });
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' }, [CHILD_ID]: { type: 'busy' } });
       if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([{ id: CHILD_ID, parentID: SESSION_ID }]);
       throw new Error(`Unexpected request: ${pathname}`);
     }));
@@ -177,7 +122,7 @@ describe('session goal live activity gate', () => {
       if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
       if (pathname === '/session/status') return jsonResponse({ error: 'unavailable' }, 503);
       throw new Error(`Unexpected request: ${pathname}`);
-    }));
+    }), { retryDelaysMs: [10, 20], maxRetryAttempts: 2 });
 
     expect(paths).toEqual([`/session/${SESSION_ID}`, '/session/status']);
     expect(getSmallModelService).not.toHaveBeenCalled();
@@ -189,6 +134,1017 @@ describe('session goal live activity gate', () => {
       `/session/${SESSION_ID}`,
       '/session/status',
     ]);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(paths.filter((path) => path === '/session/status')).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(paths.filter((path) => path === '/session/status')).toHaveLength(3);
+    runtime.stop();
+  });
+
+  it.each([null, [], { [SESSION_ID]: null }, { [SESSION_ID]: { type: 'unknown' } }])('treats %j status responses as unknown and retries', async (malformedStatus) => {
+    let statusAttempts = 0;
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') {
+        statusAttempts += 1;
+        return statusAttempts === 1 ? jsonResponse(malformedStatus) : jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(statusAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(statusAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('recovers when a target status event is unknown before a valid idle event', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+    }));
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    let statusAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') {
+        statusAttempts += 1;
+        return statusAttempts === 1
+          ? jsonResponse({ [SESSION_ID]: { type: 'mystery' } })
+          : jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'mystery' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(audit).not.toHaveBeenCalled();
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(audit).toHaveBeenCalledOnce();
+    expect(currentGoal.status).toBe('complete');
+    runtime.stop();
+  });
+
+  it('keeps an unknown unrelated status event isolated from the target session', async () => {
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+    }));
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+       if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: 'ses_unrelated', status: { type: 'mystery' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(audit).toHaveBeenCalledOnce();
+    expect(currentGoal.status).toBe('complete');
+    runtime.stop();
+  });
+
+  it('ignores malformed unrelated status entries while preserving a valid target status', async () => {
+    const audit = vi.fn(async () => ({ text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' }));
+    let currentGoal = goal;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({
+        [SESSION_ID]: { type: 'idle' },
+        unrelated: { type: 'unknown' },
+      });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Verified.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(audit).toHaveBeenCalledOnce();
+    expect(currentGoal.status).toBe('complete');
+    runtime.stop();
+  });
+
+  it.each([null, {}])('treats %j session responses as unknown and retries', async (malformedSession) => {
+    let sessionAttempts = 0;
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionAttempts += 1;
+        return sessionAttempts === 1 ? jsonResponse(malformedSession) : jsonResponse(session);
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(sessionAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sessionAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('retries an id-only session response while an active goal is known', async () => {
+    let sessionReads = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+    }));
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return sessionReads === 1
+          ? jsonResponse({ id: SESSION_ID })
+          : jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+
+    runtime.processPayload({ type: 'session.updated', properties: { info: { ...session } } });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(sessionReads).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(audit).toHaveBeenCalledOnce();
+    expect(currentGoal.status).toBe('complete');
+    expect(sessionReads).toBe(3);
+    runtime.stop();
+  });
+
+  it('accepts an id-only session response when no active goal is known', async () => {
+    let sessionReads = 0;
+    const audit = vi.fn();
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return jsonResponse({ id: SESSION_ID });
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(sessionReads).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it.each([null, {}])('retries a terminal goal write after a malformed authoritative session response (%j)', async (malformedSession) => {
+    let sessionReads = 0;
+    let currentGoal = goal;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return sessionReads === 2
+          ? jsonResponse(malformedSession)
+          : jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Verified.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({ status: 'complete', statusReason: 'verified by audit' });
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+
+  it.each([
+    {
+      status: 'complete',
+      audit: { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' },
+      statusReason: 'verified by audit',
+    },
+    {
+      status: 'budgetLimited',
+      goal: { tokenBudget: 1 },
+      statusReason: 'token budget reached',
+    },
+    {
+      status: 'blocked',
+      assistantError: { name: 'ProviderError' },
+      statusReason: 'ProviderError',
+    },
+  ])('reconciles a committed $status settlement after its PATCH response is lost exactly once', async ({ status, audit, goal: goalOverrides = {}, assistantError, statusReason }) => {
+    let currentGoal = { ...goal, ...goalOverrides, lastAccountedMessageID: '' };
+    let patchAttempts = 0;
+    let promptAttempts = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: status === 'complete' ? 'Verified.' : 'More work remains.' }],
+    };
+    if (assistantError) assistant.info.error = assistantError;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        throw new Error('terminal response lost');
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({
+        generateSmallModelText: vi.fn(async () => audit),
+      }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(patchAttempts).toBe(1);
+    expect(emitGoalNotification).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    expect(currentGoal).toMatchObject({ status, statusReason });
+    expect(patchAttempts).toBe(1);
+    expect(promptAttempts).toBe(0);
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(patchAttempts).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it.each([
+    {
+      status: 'complete',
+      audit: { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' },
+      statusReason: 'verified by audit',
+    },
+    {
+      status: 'budgetLimited',
+      goal: { tokenBudget: 1 },
+      statusReason: 'token budget reached',
+    },
+    {
+      status: 'blocked',
+      assistantError: { name: 'ProviderError' },
+      statusReason: 'ProviderError',
+    },
+  ])('reconciles a committed $status settlement from session.updated exactly once', async ({ status, audit, goal: goalOverrides = {}, assistantError, statusReason }) => {
+    let currentGoal = { ...goal, ...goalOverrides, lastAccountedMessageID: '' };
+    let patchAttempts = 0;
+    let promptAttempts = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: status === 'complete' ? 'Verified.' : 'More work remains.' }],
+    };
+    if (assistantError) assistant.info.error = assistantError;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        throw new Error('terminal response lost');
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({
+        generateSmallModelText: vi.fn(async () => audit),
+      }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(patchAttempts).toBe(1);
+    expect(emitGoalNotification).not.toHaveBeenCalled();
+
+    const settlementEvent = {
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 4 },
+          metadata: { openchamber: { goal: currentGoal } },
+        },
+      },
+    };
+    runtime.processPayload(settlementEvent);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(currentGoal).toMatchObject({ status, statusReason });
+
+    runtime.processPayload(settlementEvent);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(patchAttempts).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it.each([
+    {
+      status: 'complete',
+      audit: { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' },
+      statusReason: 'verified by audit',
+    },
+    {
+      status: 'budgetLimited',
+      goal: { tokenBudget: 1 },
+      statusReason: 'token budget reached',
+    },
+    {
+      status: 'blocked',
+      assistantError: { name: 'ProviderError' },
+      statusReason: 'ProviderError',
+    },
+  ])('does not finalize $status twice when its event arrives before PATCH success', async ({ status, audit, goal: goalOverrides = {}, assistantError, statusReason }) => {
+    let currentGoal = { ...goal, ...goalOverrides, lastAccountedMessageID: '' };
+    const terminalPatch = deferred();
+    let patchAttempts = 0;
+    let promptAttempts = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: status === 'complete' ? 'Verified.' : 'More work remains.' }],
+    };
+    if (assistantError) assistant.info.error = assistantError;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return terminalPatch.promise;
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({
+        generateSmallModelText: vi.fn(async () => audit),
+      }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(patchAttempts).toBe(1);
+    expect(emitGoalNotification).not.toHaveBeenCalled();
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 4 },
+          metadata: { openchamber: { goal: currentGoal } },
+        },
+      },
+    });
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(currentGoal).toMatchObject({ status, statusReason });
+
+    terminalPatch.resolve(jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } }));
+    await flushMicrotasks();
+    expect(patchAttempts).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(patchAttempts).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('re-arms when the authoritative session fetch fails', async () => {
+    let sessionAttempts = 0;
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionAttempts += 1;
+        return sessionAttempts === 1 ? jsonResponse({ error: 'unavailable' }, 503) : jsonResponse(session);
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(paths).toEqual([
+      `/session/${SESSION_ID}`,
+      `/session/${SESSION_ID}`,
+      '/session/status',
+    ]);
+    runtime.stop();
+  });
+
+  it.each([
+    ['session', `/session/${SESSION_ID}`],
+    ['status', '/session/status'],
+    ['children', `/session/${SESSION_ID}/children`],
+    ['message', `/session/${SESSION_ID}/message`],
+  ])('bounds %s fetch retries with exponential delays', async (_label, failingPath) => {
+    let failures = 0;
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === failingPath) {
+        if (failures < 3) {
+          failures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10, 20],
+      maxRetryAttempts: 2,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(failures).toBe(3);
+    const requestsAfterExhaustion = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterExhaustion);
+    runtime.stop();
+  });
+
+  it.each([
+    ['fetchSession', `/session/${SESSION_ID}`],
+    ['fetchSessionStatuses', '/session/status'],
+    ['children', `/session/${SESSION_ID}/children`],
+    ['fetchRecentMessages', `/session/${SESSION_ID}/message`],
+  ])('terminalizes an active goal after %s retry exhaustion without a reservation', async (_label, failingPath) => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let failures = 0;
+    let blockedWrites = 0;
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === failingPath && (init.method ?? 'GET') === 'GET' && failures < 3) {
+        failures += 1;
+        return jsonResponse({ error: 'unavailable' }, 503);
+      }
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        return jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(failures).toBe(3);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'fetch retry limit reached',
+    });
+    expect(blockedWrites).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const requestsAfterSettlement = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterSettlement);
+    expect(currentGoal.status).toBe('blocked');
+    runtime.stop();
+  });
+
+  it('does not overwrite a newer goal revision during fetch-exhaustion terminalization', async () => {
+    const originalGoal = { ...goal, updatedAt: 1 };
+    const newerGoal = { ...originalGoal, statusReason: 'resumed', updatedAt: 2 };
+    let currentGoal = originalGoal;
+    let sessionReads = 0;
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 5) currentGoal = newerGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: originalGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(currentGoal).toEqual(newerGoal);
+    expect(blockedWrites).toBe(0);
+    expect(promptAttempts).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    runtime.stop();
+  });
+
+  it('reconciles a reservation-free blocked terminalization after its PATCH response is lost', async () => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    let promptAttempts = 0;
+    const emitGoalNotification = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          currentGoal = nextGoal;
+          throw new Error('blocked terminal response lost');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'fetch retry limit reached',
+    });
+    expect(blockedWrites).toBe(1);
+    expect(promptAttempts).toBe(0);
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(blockedWrites).toBe(1);
+    expect(promptAttempts).toBe(0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('bounds reservation-free terminalization when the blocked PATCH stays unavailable', async () => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        blockedWrites += 1;
+        throw new Error('blocked write unavailable');
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 1,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(currentGoal.status).toBe('active');
+    expect(blockedWrites).toBe(2);
+    expect(promptAttempts).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    const requestsAfterExhaustion = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterExhaustion);
     runtime.stop();
   });
 
@@ -199,7 +1155,7 @@ describe('session goal live activity gate', () => {
       requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
       if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
       if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
-      if (pathname === '/session/status') return jsonResponse({});
+       if (pathname === '/session/status') return jsonResponse({});
       if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
       if (pathname === `/session/${SESSION_ID}/message`) {
         return jsonResponse([{
@@ -251,35 +1207,526 @@ describe('session goal live activity gate', () => {
     runtime.stop();
   });
 
-  it('skips audit and sends continuation prompt when assistant message finishes with length stop', async () => {
+  it('propagates the last assistant provider, model, agent, and variant to continuation dispatch', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let continuationBody;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant',
+        providerID: 'provider-from-message', modelID: 'model-from-message',
+        agent: 'agent-from-message', variant: 'variant-from-message',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        continuationBody = JSON.parse(init.body);
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"continue","note":"More work remains"}', providerID: 'audit-provider', modelID: 'audit-model',
+    }));
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(continuationBody).toMatchObject({
+      model: { providerID: 'provider-from-message', modelID: 'model-from-message' },
+      agent: 'agent-from-message',
+      variant: 'variant-from-message',
+    });
+    runtime.stop();
+  });
+
+  it('accounts and dispatches continuation for a file-backed goal with empty metadata objective', async () => {
+    const fileObjective = 'Complete the objective from the persisted file.';
+    readGoalObjective.mockResolvedValue(fileObjective);
+    let currentGoal = {
+      ...goal,
+      objective: '',
+      objectiveFile: true,
+      turnsUsed: 1,
+      lastAccountedMessageID: '',
+    };
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
     const requests = [];
     const fetchImpl = vi.fn(async (input, init = {}) => {
       const pathname = requestPath(input);
       requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse(null);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const prompt = requests.find((request) => request.pathname.endsWith('/prompt_async'));
+    expect(prompt).toBeDefined();
+    expect(JSON.parse(prompt.body).parts[0].text).toContain(fileObjective);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('bounds missing file-backed objective retries and settles the goal as blocked', async () => {
+    let currentGoal = {
+      ...goal,
+      objective: '',
+      objectiveFile: true,
+      turnsUsed: 1,
+      lastAccountedMessageID: '',
+    };
+    let objectiveReads = 0;
+    let blockedWrites = 0;
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn() };
+    readGoalObjective.mockImplementation(async () => {
+      objectiveReads += 1;
+      return null;
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(objectiveReads).toBe(3);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'objective file unavailable',
+    });
+    expect(blockedWrites).toBe(1);
+    expect(promptAttempts).toBe(0);
+    const attemptsAfterSettlement = objectiveReads;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(objectiveReads).toBe(attemptsAfterSettlement);
+    runtime.stop();
+  });
+
+  it('settles an assistant error as blocked without an audit', async () => {
+    let currentGoal = goal;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant_error', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, error: { name: 'ProviderError' },
+        },
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn() };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'ProviderError' });
+    expect(service.generateSmallModelText).not.toHaveBeenCalled();
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    runtime.stop();
+  });
+
+  it('requires three consecutive blocked audit verdicts before settling', async () => {
+    let currentGoal = { ...goal, blockedStreak: 0, lastAccountedMessageID: '' };
+    let auditCalls = 0;
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Blocked for now.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => {
+        auditCalls += 1;
+        return { text: '{"verdict":"blocked","note":"Need user input"}', providerID: 'provider', modelID: 'model' };
+      }),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idle = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal).toMatchObject({ status: 'active', blockedStreak: 1, turnsUsed: 2 });
+    expect(dispatchAttempts).toBe(1);
+
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({ status: 'active', blockedStreak: 2, turnsUsed: 3 });
+    expect(dispatchAttempts).toBe(2);
+
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({ status: 'blocked', blockedStreak: 0, statusReason: 'Need user input' });
+    expect(auditCalls).toBe(3);
+    expect(dispatchAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('allows one audit failure before blocking on the second consecutive failure', async () => {
+    let currentGoal = { ...goal, auditFailStreak: 0, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Audit may be unavailable.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn(async () => null) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idle = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal).toMatchObject({ status: 'active', auditFailStreak: 1, turnsUsed: 2 });
+    expect(dispatchAttempts).toBe(1);
+
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({ status: 'blocked', auditFailStreak: 0, statusReason: 'progress audit unavailable' });
+    expect(service.generateSmallModelText).toHaveBeenCalledTimes(2);
+    expect(dispatchAttempts).toBe(1);
+    runtime.stop();
+  });
+
+  it('keeps the idle timer when a replayed user message is older than the arm point', async () => {
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+    }));
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
       if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
       if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
       if (pathname === '/session/status') return jsonResponse({});
       if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
-      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
-      if (pathname === `/session/${SESSION_ID}/message`) {
-        return jsonResponse([{
-          info: {
-            id: 'msg_assistant_len',
-            sessionID: SESSION_ID,
-            role: 'assistant',
-            providerID: 'provider',
-            modelID: 'model',
-            finish: 'length',
-            time: { completed: 2 },
-            tokens: { input: 100, output: 4096, reasoning: 4096, cache: { read: 0 } },
-          },
-          parts: [{ type: 'reasoning', text: 'Drafting extensive implementation...' }],
-        }]);
-      }
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    vi.setSystemTime(1_000);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { id: 'msg_old', sessionID: SESSION_ID, role: 'user', time: { created: 999 } } },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(audit).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('invalidates an in-flight tick when a genuinely newer user message arrives', async () => {
+    const audit = deferred();
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still working.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(() => audit.promise) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    vi.setSystemTime(1_000);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(requests).toContainEqual({ pathname: `/session/${SESSION_ID}/message`, method: 'GET' });
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { id: 'msg_new', sessionID: SESSION_ID, role: 'user', time: { created: 1_011 } } },
+    });
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
+
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    runtime.stop();
+  });
+
+  it.each([
+    ['an old user message', 1_009],
+    ['a timestamp-less user message', null],
+  ])('does not cancel an in-flight audit for %s', async (_label, messageCreatedAt) => {
+    const audit = deferred();
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(() => audit.promise) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    vi.setSystemTime(1_000);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    const replayedMessageInfo = {
+      id: 'msg_replayed', sessionID: SESSION_ID, role: 'user',
+    };
+    if (messageCreatedAt !== null) replayedMessageInfo.time = { created: messageCreatedAt };
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: replayedMessageInfo },
+    });
+    audit.resolve({ text: '{"verdict":"complete","note":"Verified"}' });
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+
+  it('invalidates an in-flight tick when an abort is accepted', async () => {
+    const audit = deferred();
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant',
+          sessionID: SESSION_ID,
+          role: 'assistant',
+          providerID: 'provider',
+          modelID: 'model',
+          time: { completed: 2 },
+          tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Still working.' }],
+      }]);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
       throw new Error(`Unexpected request: ${pathname}`);
     });
     const service = {
-      generateSmallModelText: vi.fn(),
+      generateSmallModelText: vi.fn(() => audit.promise),
     };
     vi.stubGlobal('fetch', fetchImpl);
     const runtime = createSessionGoalRuntime({
@@ -294,57 +1741,1914 @@ describe('session goal live activity gate', () => {
       type: 'session.status',
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    });
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
     await vi.runOnlyPendingTimersAsync();
 
-    // Audit must be skipped on length-truncated turn
-    expect(service.generateSmallModelText).not.toHaveBeenCalled();
-
-    // Goal accounting is persisted and turnsUsed incremented
-    const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
-    expect(patch).toBeDefined();
-    const writtenGoal = JSON.parse(patch.body).metadata.openchamber.goal;
-    expect(writtenGoal).toMatchObject({
-      status: 'active',
-      turnsUsed: 2,
-    });
-
-    // Continuation prompt is dispatched
-    const promptAsync = requests.find((request) => request.pathname === `/session/${SESSION_ID}/prompt_async` && request.method === 'POST');
-    expect(promptAsync).toBeDefined();
-    const promptBody = JSON.parse(promptAsync.body);
-    expect(promptBody.parts[0].text).toContain('Continue working toward the active session goal.');
+    const patches = requests
+      .filter((request) => request.method === 'PATCH')
+      .map((request) => JSON.parse(request.body).metadata.openchamber.goal);
+    expect(patches.some((writtenGoal) => writtenGoal.status === 'paused')).toBe(true);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
     runtime.stop();
   });
 
-  it('skips audit and sends continuation prompt when assistant message carries MessageOutputLengthError', async () => {
+  it('rebinds a pending abort across busy/retry generations before idle', async () => {
+    const audit = deferred();
+    const abortSession = deferred();
+    let sessionReads = 0;
+    let currentGoal = goal;
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still working.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 2) return abortSession.promise;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse(null);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'busy' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'retry' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    abortSession.resolve(jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } }));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(currentGoal).toMatchObject({ status: 'paused', statusReason: 'paused after abort' });
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    runtime.stop();
+  });
+
+  it.each([null, {}])('keeps pending abort state after a malformed session response (%j)', async (malformedSession) => {
+    let sessionReads = 0;
+    let currentGoal = goal;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return sessionReads === 1
+          ? jsonResponse(malformedSession)
+          : jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    }, DIRECTORY);
+    await flushMicrotasks();
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({ status: 'paused', statusReason: 'paused after abort' });
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+
+  it('invalidates an in-flight audit when busy status arrives', async () => {
+    const audit = deferred();
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Still working.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'busy' }, directory: DIRECTORY },
+    });
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
+
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    runtime.stop();
+  });
+
+  it('checks authoritative status again immediately before dispatch', async () => {
+    let statusCalls = 0;
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still working.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+          return jsonResponse(statusCalls === 3 ? { [SESSION_ID]: { type: 'busy' } } : { [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"Keep going"}', providerID: 'provider', modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(statusCalls).toBe(3);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+
+  it('invalidates in-flight work when a fresh goal replaces the current goal', async () => {
+    const audit = deferred();
+    const requests = [];
+    const replacement = { ...goal, id: 'goal_2', turnsUsed: 0, createdAt: 3, updatedAt: 3 };
+    let activeGoal = goal;
+    let statusCalls = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: activeGoal } } });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+         return jsonResponse(statusCalls === 1 ? { [SESSION_ID]: { type: 'idle' } } : { [SESSION_ID]: { type: 'busy' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Still working.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: replacement } } } },
+    });
+    activeGoal = replacement;
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
+
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    await vi.runOnlyPendingTimersAsync();
+    expect(statusCalls).toBe(2);
+    runtime.stop();
+  });
+
+  it.each(['clear', 'pause', 'replacement'])('ignores a stale %s after a newer goal mutation and keeps its timer', async (kind) => {
+    const newerGoal = { ...goal, id: 'goal_new', turnsUsed: 0, createdAt: 2, updatedAt: 20 };
+    const staleGoal = kind === 'pause'
+      ? { ...goal, status: 'paused', statusReason: 'paused by user', updatedAt: 10 }
+      : { ...goal, id: 'goal_old', createdAt: 1, updatedAt: 10 };
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: newerGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 20 }, metadata: { openchamber: { goal: newerGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 10 },
+          metadata: kind === 'clear'
+            ? { openchamber: {} }
+            : { openchamber: { goal: staleGoal } },
+        },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(paths).toEqual([`/session/${SESSION_ID}`, '/session/status']);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    runtime.stop();
+  });
+
+  it.each(['clear', 'replacement'])('ignores a timestamp-less stale %s after a newer timestamped goal', async (kind) => {
+    const newerDirectory = '/workspace-new';
+    const staleDirectory = '/workspace-old';
+    const newerGoal = { ...goal, id: 'goal_new', turnsUsed: 0, createdAt: 2, updatedAt: 20 };
+    const staleGoal = { ...goal, id: 'goal_old', turnsUsed: 0, createdAt: 1, updatedAt: 10 };
+    const targetRequests = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) {
+        targetRequests.push(new URL(input).searchParams.get('directory'));
+        return jsonResponse({
+          ...session,
+          directory: newerDirectory,
+          metadata: { openchamber: { goal: newerGoal } },
+        });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          directory: newerDirectory,
+          time: { updated: 20 },
+          metadata: { openchamber: { goal: newerGoal } },
+        },
+      },
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          directory: staleDirectory,
+          metadata: kind === 'clear'
+            ? { openchamber: {} }
+            : { openchamber: { goal: staleGoal } },
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(targetRequests).toEqual([newerDirectory]);
+    runtime.stop();
+  });
+
+  it('rejects a stale clear after a newer replacement while an audit is in flight', async () => {
+    const audit = deferred();
+    const newerGoal = { ...goal, id: 'goal_new', turnsUsed: 0, createdAt: 2, updatedAt: 20 };
+    let currentGoal = goal;
+    let statusCalls = 0;
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        return jsonResponse(statusCalls === 1 ? { [SESSION_ID]: { type: 'idle' } } : { [SESSION_ID]: { type: 'busy' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'More work remains.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    currentGoal = newerGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 20 }, metadata: { openchamber: { goal: newerGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 10 }, metadata: { openchamber: {} } } },
+    });
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    expect(paths.filter((path) => path === `/session/${SESSION_ID}`)).toHaveLength(2);
+    expect(statusCalls).toBe(2);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('prevents writes and dispatch after stop during in-flight work', async () => {
+    const audit = deferred();
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    runtime.stop();
+    audit.resolve({ text: '{"verdict":"continue","note":"Keep going"}' });
+    await flushMicrotasks();
+
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+  });
+
+  it('prevents a metadata settlement write after stop', async () => {
+    const settlementSession = deferred();
+    let sessionReads = 0;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return sessionReads === 2 ? settlementSession.promise : jsonResponse(session);
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Verified.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    runtime.stop();
+    settlementSession.resolve(jsonResponse(session));
+    await flushMicrotasks();
+
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+  });
+
+  it('prevents continuation dispatch after stop during its authoritative check', async () => {
+    const dispatchSession = deferred();
+    let sessionReads = 0;
+    let promptAttempts = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return sessionReads === 3 ? dispatchSession.promise : jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    runtime.stop();
+    dispatchSession.resolve(jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } }));
+    await flushMicrotasks();
+
+    expect(promptAttempts).toBe(0);
+  });
+
+  it('does not inherit the length breaker across a fresh goal identity', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const replacement = { ...goal, id: 'goal_2', turnsUsed: 1, createdAt: 3, updatedAt: 3, lastAccountedMessageID: '' };
+    let messageReads = 0;
+    let promptAttempts = 0;
+    const lengthMessage = (id) => ({
+      info: {
+        id, sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+         finish: 'length', time: { completed: 2 }, tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'The answer was truncated.' }],
+    });
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+         return jsonResponse([lengthMessage(messageReads <= 3 ? 'msg_length_1' : 'msg_length_2')]);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(promptAttempts).toBe(1);
+
+    currentGoal = replacement;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: replacement } } } },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(promptAttempts).toBe(2);
+    expect(currentGoal.status).toBe('active');
+    runtime.stop();
+  });
+
+  it('rejects a runtime commit when the goal status changed during its tick', async () => {
+    let sessionReads = 0;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        const currentGoal = sessionReads > 1 ? { ...goal, status: 'paused' } : goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant',
+          sessionID: SESSION_ID,
+          role: 'assistant',
+          providerID: 'provider',
+          modelID: 'model',
+          time: { completed: 2 },
+          tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+      }]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    runtime.stop();
+  });
+
+  it.each([
+    ['objective', { objective: 'A different objective' }],
+    ['budget', { tokenBudget: 200 }],
+    ['file flag', { objectiveFile: true }],
+    ['creation time', { createdAt: 99 }],
+  ])('rejects terminal writes after same-ID %s mutation', async (_label, mutation) => {
+    let sessionReads = 0;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        const currentGoal = sessionReads > 1 ? { ...goal, ...mutation } : goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Verified.' }],
+      }]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(sessionReads).toBe(2);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    runtime.stop();
+  });
+
+  it('re-arms a failed message fetch after the in-flight tick clears', async () => {
+    const paths = [];
+    let messageAttempts = 0;
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageAttempts += 1;
+        return messageAttempts === 1 ? jsonResponse({ error: 'unavailable' }, 503) : jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(paths).toEqual([
+      `/session/${SESSION_ID}`,
+      '/session/status',
+      `/session/${SESSION_ID}/children`,
+      `/session/${SESSION_ID}/message`,
+    ]);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(paths).toEqual([
+      `/session/${SESSION_ID}`,
+      '/session/status',
+      `/session/${SESSION_ID}/children`,
+      `/session/${SESSION_ID}/message`,
+      `/session/${SESSION_ID}`,
+      '/session/status',
+      `/session/${SESSION_ID}/children`,
+      `/session/${SESSION_ID}/message`,
+    ]);
+    runtime.stop();
+  });
+
+  it('re-arms a failed child-session fetch without treating it as no children', async () => {
+    let childAttempts = 0;
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) {
+        childAttempts += 1;
+        return childAttempts === 1 ? jsonResponse({ error: 'unavailable' }, 503) : jsonResponse([]);
+      }
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(paths).toEqual([
+      `/session/${SESSION_ID}`,
+      '/session/status',
+      `/session/${SESSION_ID}/children`,
+    ]);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(paths.at(-1)).toBe(`/session/${SESSION_ID}/message`);
+    expect(childAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('replaces an existing idle timer with the explicit resume kickoff', async () => {
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10_000,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: { ...goal, statusReason: 'resumed' } } } } },
+    });
+    await vi.advanceTimersByTimeAsync(249);
+    expect(paths).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(paths).toEqual([`/session/${SESSION_ID}`, '/session/status']);
+    runtime.stop();
+  });
+
+  it('keeps the short Resume timer when a delayed idle event arrives', async () => {
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 15_000,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: { ...goal, statusReason: 'resumed' } } } } },
+    });
+    await vi.advanceTimersByTimeAsync(200);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(paths).toEqual([`/session/${SESSION_ID}`, '/session/status']);
+    runtime.stop();
+  });
+
+  it('retries a failed continuation without reserving the same tail twice', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still working.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        if (dispatchAttempts === 1) throw new Error('temporary dispatch failure');
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+     await vi.advanceTimersByTimeAsync(10);
+     expect(dispatchAttempts).toBe(1);
+     expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation admission unresolved' });
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(2);
+    runtime.stop();
+  });
+
+  it.each([null, {}])('preserves the accounting reservation after a malformed continuation session response (%j)', async (malformedSession) => {
+    let sessionReads = 0;
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 3) return jsonResponse(malformedSession);
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(dispatchAttempts).toBe(1));
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('keeps an accepted accounting PATCH and prompt retry idempotent', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let patchAttempts = 0;
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (patchAttempts === 1) throw new Error('accepted PATCH response lost');
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        if (dispatchAttempts === 1) throw new Error('prompt response lost');
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10, 20],
+      maxDispatchAttempts: 3,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(patchAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(dispatchAttempts).toBe(1));
+    expect(patchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation admission unresolved' });
+    runtime.stop();
+  });
+
+  it('settles an active goal as blocked after dispatch retries are exhausted', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let blockedWrites = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        if (dispatchAttempts <= 2) throw new Error('dispatch unavailable');
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10, 10],
+      maxDispatchAttempts: 2,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation admission unresolved' });
+    expect(blockedWrites).toBe(1);
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(dispatchAttempts).toBe(1);
+    expect(blockedWrites).toBe(1);
+
+    const resumedGoal = { ...currentGoal, status: 'active', statusReason: 'resumed' };
+    currentGoal = resumedGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: resumedGoal } } } },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(dispatchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ status: 'blocked', turnsUsed: 3 });
+    expect(blockedWrites).toBe(2);
+    runtime.stop();
+  });
+
+  it('settles and releases a reservation after bounded missing provider/model dispatch failures', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let statusCalls = 0;
+    let promptAttempts = 0;
+    let blockedWrites = 0;
+    let patchWrites = 0;
+    let enabled = true;
+    const rollbackPatchStarted = deferred();
+    const rollbackPatchResponse = deferred();
+    const resumedPromptStarted = deferred();
+    const resumedPromptResponse = deferred();
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        patchWrites += 1;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        if (patchWrites > 1 && currentGoal.status === 'active' && currentGoal.turnsUsed === 1) {
+          rollbackPatchStarted.resolve();
+          return rollbackPatchResponse.promise;
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        resumedPromptStarted.resolve();
+        return resumedPromptResponse.promise;
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => enabled,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    // The first tick persists accounting (turns 1 -> 2) before the missing
+    // provider/model dispatch fails. Wait for that write so the bounded
+    // dispatch retry is armed before advancing: a fixed microtask flush
+    // cannot drain this multi-fetch chain deterministically.
+    await vi.waitFor(() => expect(patchWrites).toBeGreaterThanOrEqual(1));
+    await vi.advanceTimersByTimeAsync(10);
+    // The bounded retry exhausts maxDispatchAttempts and rolls the
+    // undispatched charge back (turns 2 -> 1).
+    await rollbackPatchStarted.promise;
+    expect(currentGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 1,
+      lastAccountedMessageID: '',
+    });
+    expect(statusCalls).toBeLessThanOrEqual(6);
+    expect(promptAttempts).toBe(0);
+    expect(blockedWrites).toBe(0);
+
+    // Complete the rollback explicitly, then consume any retry that may have
+    // been queued while the first tick was still unwinding. Keep the runtime
+    // enabled so this proves the pending reservation cannot dispatch early.
+    const settledPatchWrites = patchWrites;
+    rollbackPatchResponse.resolve(jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } }));
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+    expect(promptAttempts).toBe(0);
+    expect(patchWrites).toBe(settledPatchWrites);
+    expect(currentGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 1,
+      lastAccountedMessageID: '',
+    });
+
+    // A settled reservation must not poison an explicit Resume. Make the
+    // resumed tail dispatchable; a stale reservation would hit the old retry
+    // limit instead of creating the next bounded continuation.
+    currentGoal = { ...currentGoal, status: 'active', statusReason: 'resumed' };
+    assistant.info.providerID = 'provider';
+    assistant.info.modelID = 'model';
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await resumedPromptStarted.promise;
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+    expect(blockedWrites).toBe(0);
+    resumedPromptResponse.resolve(jsonResponse(null));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(promptAttempts).toBe(1);
+    expect(patchWrites).toBe(settledPatchWrites + 1);
+    runtime.stop();
+  });
+
+  it('preserves an accepted accounting reservation across busy/retry events before later idle', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let patchAttempts = 0;
+    let dispatchAttempts = 0;
+    let acceptedPrompt = false;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        if (dispatchAttempts === 1) {
+          acceptedPrompt = true;
+          throw new Error('accepted prompt response lost');
+        }
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10, 20],
+      maxDispatchAttempts: 3,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(acceptedPrompt).toBe(true);
+    expect(dispatchAttempts).toBe(1);
+    expect(patchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, tokensUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+
+    for (const type of ['busy', 'retry']) {
+      runtime.processPayload({
+        type: 'session.status',
+        properties: { sessionID: SESSION_ID, status: { type }, directory: DIRECTORY },
+      });
+    }
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(dispatchAttempts).toBe(1);
+    expect(patchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, tokensUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('accounts assistant snapshots by created time, not lexical message id', async () => {
+    const oldMessage = {
+      info: {
+        id: 'msg_z',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { created: 10, completed: 11 },
+        tokens: { input: 5, output: 5, cache: { read: 0 } },
+      },
+    };
+    const newMessage = {
+      info: {
+        id: 'msg_a',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { created: 20, completed: 21 },
+        tokens: { input: 20, output: 10, cache: { read: 0 } },
+      },
+    };
+    const currentGoal = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 10,
+      lastAccountedMessageID: oldMessage.info.id,
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([newMessage, oldMessage]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(patch).toBeDefined();
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      status: 'complete',
+      tokensUsed: 30,
+      lastAccountedMessageID: 'msg_a',
+    });
+    runtime.stop();
+  });
+
+  it('classifies the baseline by created time when creation and completion cross the goal', async () => {
+    const currentGoal = { ...goal, createdAt: 100, tokensUsed: 0, lastAccountedMessageID: '' };
+    const messages = [
+      {
+        info: {
+          id: 'msg_pre_goal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 90, completed: 110 }, tokens: { input: 30, output: 10, cache: { read: 0 } },
+        },
+      },
+      {
+        info: {
+          id: 'msg_post_goal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 120, completed: 95 }, tokens: { input: 70, output: 20, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Work remains.' }],
+      },
+    ];
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      status: 'complete',
+      tokensBaseline: 40,
+      tokensUsed: 50,
+      lastAccountedMessageID: 'msg_post_goal',
+    });
+    runtime.stop();
+  });
+
+  it('preserves accounting when the cursor is outside the bounded message page', async () => {
+    const currentGoal = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 17,
+      lastAccountedMessageID: 'msg_not_in_page',
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([{
+        info: {
+          id: 'msg_new',
+          sessionID: SESSION_ID,
+          role: 'assistant',
+          providerID: 'provider',
+          modelID: 'model',
+          time: { created: 20, completed: 21 },
+          tokens: { input: 200, output: 100, cache: { read: 0 } },
+        },
+      }]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      status: 'complete',
+      tokensUsed: 17,
+      lastAccountedMessageID: 'msg_not_in_page',
+    });
+    runtime.stop();
+  });
+
+  it('keeps equal and missing timestamp messages in API order without producing NaN chronology', async () => {
+    const messages = [
+      {
+        info: {
+          id: 'msg_z_old', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 100, completed: 101 }, tokens: { input: 5, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Old turn.' }],
+      },
+      {
+        info: {
+          id: 'msg_z_equal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 200, completed: 201 }, tokens: { input: 7, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Equal z.' }],
+      },
+      {
+        info: {
+          id: 'msg_a_equal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 200, completed: 201 }, tokens: { input: 11, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Equal a.' }],
+      },
+      {
+        info: {
+          id: 'msg_z_missing', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 301 }, tokens: { input: 13, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Missing z.' }],
+      },
+      {
+        info: {
+          id: 'msg_a_missing', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { completed: 302 }, tokens: { input: 17, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Missing a.' }],
+      },
+    ];
     const requests = [];
     const fetchImpl = vi.fn(async (input, init = {}) => {
       const pathname = requestPath(input);
       requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
       if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
       if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
-      if (pathname === '/session/status') return jsonResponse({});
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
       if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
-      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
-      if (pathname === `/session/${SESSION_ID}/message`) {
-        return jsonResponse([{
-          info: {
-            id: 'msg_assistant_len_err',
-            sessionID: SESSION_ID,
-            role: 'assistant',
-            providerID: 'provider',
-            modelID: 'model',
-            error: { name: 'MessageOutputLengthError', message: 'Maximum token limit reached' },
-            time: { completed: 2 },
-            tokens: { input: 100, output: 4096, reasoning: 4096, cache: { read: 0 } },
-          },
-          parts: [{ type: 'reasoning', text: 'Drafting extensive implementation...' }],
-        }]);
-      }
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
       throw new Error(`Unexpected request: ${pathname}`);
     });
     const service = {
-      generateSmallModelText: vi.fn(),
+      generateSmallModelText: vi.fn(async (input) => {
+         expect(input.prompt).toContain('Missing a.');
+        return { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' };
+      }),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+     expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({ status: 'complete', tokensUsed: 17 });
+    runtime.stop();
+  });
+
+  it('uses API order for equal timestamps when selecting the tail and audit input', async () => {
+    const currentGoal = { ...goal, tokensUsed: 0, lastAccountedMessageID: '' };
+    const messages = [
+      {
+        info: {
+          id: 'msg_z_equal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 200, completed: 201 }, tokens: { input: 7, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'First API result.' }],
+      },
+      {
+        info: {
+          id: 'msg_a_equal', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+          time: { created: 200, completed: 201 }, tokens: { input: 11, output: 0, cache: { read: 0 } },
+        },
+        parts: [{ type: 'text', text: 'Last API result.' }],
+      },
+    ];
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async ({ prompt }) => {
+        expect(prompt).toContain('Last API result.');
+        expect(prompt).not.toContain('First API result.');
+        return { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' };
+      }),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      status: 'complete',
+      tokensUsed: 11,
+      lastAccountedMessageID: 'msg_a_equal',
+    });
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('conservatively holds the baseline when a full page hides pre-goal history', async () => {
+    const currentGoal = { ...goal, tokensUsed: 0, lastAccountedMessageID: '' };
+    const messages = Array.from({ length: 40 }, (_, index) => ({
+      info: {
+        id: `msg_${index.toString(36)}`,
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { created: 10 + index, completed: 11 + index },
+        tokens: { input: 100 + index, output: 10, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: `Post-goal turn ${index}.` }],
+    }));
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })),
+    };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      status: 'complete',
+      tokensUsed: 0,
+      lastAccountedMessageID: '',
+    });
+    runtime.stop();
+  });
+
+  it('keeps summary segmentation while using the non-summary execution model', async () => {
+    const currentGoal = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 0,
+      lastAccountedMessageID: 'msg_before',
+    };
+    const regular = {
+      info: {
+        id: 'msg_regular',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { created: 10, completed: 11 },
+        tokens: { input: 8, output: 2, cache: { read: 0 } },
+      },
+    };
+    const summary = {
+      info: {
+        id: 'msg_summary',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        summary: true,
+        time: { created: 20, completed: 21 },
+        tokens: { input: 0, output: 0, cache: { read: 0 } },
+      },
+    };
+    const cursor = {
+      info: {
+        id: 'msg_before',
+        sessionID: SESSION_ID,
+        role: 'user',
+        time: { created: 1 },
+      },
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+       if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([summary, regular, cursor]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse(null);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({
+      tokensCommitted: 10,
+      tokensUsed: 10,
+      lastAccountedMessageID: 'msg_summary',
+    });
+    runtime.stop();
+  });
+
+  it('does not duplicate a tick when idle events repeat before kickoff', async () => {
+    const paths = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      paths.push(pathname);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idlePayload = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+    runtime.processPayload(idlePayload);
+    runtime.processPayload(idlePayload);
+    await vi.runOnlyPendingTimersAsync();
+    expect(paths).toEqual([`/session/${SESSION_ID}`, '/session/status']);
+    runtime.stop();
+  });
+
+  it('does not arm a duplicate kickoff after an identical Resume has settled', async () => {
+    const resumedGoal = { ...goal, statusReason: 'resumed' };
+    let currentGoal = resumedGoal;
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const resumePayload = {
+      type: 'session.updated',
+      properties: { info: { ...session, metadata: { openchamber: { goal: resumedGoal } } } },
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
     };
     vi.stubGlobal('fetch', fetchImpl);
     const runtime = createSessionGoalRuntime({
@@ -355,29 +3659,3366 @@ describe('session goal live activity gate', () => {
       idleQuietMs: 10,
     });
 
+    runtime.processPayload(resumePayload);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(currentGoal).toMatchObject({ status: 'complete' });
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    const requestCountAfterKickoff = requests.length;
+
+    runtime.processPayload(resumePayload);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(requests).toHaveLength(requestCountAfterKickoff);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('suppresses exact duplicate Resume events but re-arms a distinct file-backed edit', async () => {
+    let currentGoal = {
+      ...goal,
+      objective: '',
+      objectiveFile: true,
+      statusReason: 'resumed',
+      updatedAt: 10,
+    };
+    const firstResume = currentGoal;
+    const secondResume = { ...currentGoal, statusReason: 'resumed', updatedAt: 11 };
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant',
+        sessionID: SESSION_ID,
+        role: 'assistant',
+        providerID: 'provider',
+        modelID: 'model',
+        time: { completed: 2 },
+        tokens: { input: 1, output: 1, cache: { read: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const makeResumePayload = (resumeGoal, updated) => ({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated },
+          metadata: { openchamber: { goal: resumeGoal } },
+        },
+      },
+    });
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    const service = {
+      generateSmallModelText: vi.fn(async ({ prompt }) => ({
+        text: '{"verdict":"complete","note":"Verified"}',
+        providerID: 'provider',
+        modelID: 'model',
+        prompt,
+      })),
+    };
+    readGoalObjective
+      .mockResolvedValueOnce('First file-backed objective')
+      .mockResolvedValueOnce('First file-backed objective')
+      .mockResolvedValueOnce('First file-backed objective')
+      .mockResolvedValueOnce('Second file-backed objective')
+      .mockResolvedValueOnce('Second file-backed objective')
+      .mockResolvedValueOnce('Second file-backed objective');
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    const firstPayload = makeResumePayload(firstResume, 100);
+    runtime.processPayload(firstPayload);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(currentGoal).toMatchObject({ status: 'complete' });
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+    const requestCountAfterFirstResume = requests.length;
+
+    runtime.processPayload(firstPayload);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(requests).toHaveLength(requestCountAfterFirstResume);
+    expect(service.generateSmallModelText).toHaveBeenCalledOnce();
+
+    currentGoal = secondResume;
+    const secondPayload = makeResumePayload(secondResume, 101);
+    runtime.processPayload(secondPayload);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(service.generateSmallModelText).toHaveBeenCalledTimes(2);
+    expect(service.generateSmallModelText.mock.calls[1][0].prompt).toContain('Second file-backed objective');
+
+    const requestCountAfterSecondResume = requests.length;
+    runtime.processPayload(secondPayload);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(requests).toHaveLength(requestCountAfterSecondResume);
+    expect(service.generateSmallModelText).toHaveBeenCalledTimes(2);
+    runtime.stop();
+  });
+
+  it('rolls back accounting when the user moves the tail before dispatch', async () => {
+    let currentGoal = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    let messageReads = 0;
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        return jsonResponse(messageReads === 1 ? [assistant] : [{
+          info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user', time: { created: 3 } },
+        }]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    expect(currentGoal).toMatchObject({
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    });
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(2);
+    runtime.stop();
+  });
+
+  it('keeps a reservation and retries resolution when both rollback writes fail', async () => {
+    const before = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    };
+    let currentGoal = before;
+    let messageReads = 0;
+    let rollbackAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const movedTail = {
+      info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user', time: { created: 3 } },
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked' || nextGoal.turnsUsed === before.turnsUsed) {
+          rollbackAttempts += 1;
+          if (rollbackAttempts <= 2) throw new Error('rollback resolution unavailable');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        return jsonResponse(messageReads === 1 ? [assistant] : [movedTail]);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) throw new Error('must not dispatch');
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal.turnsUsed).toBe(2);
+    expect(rollbackAttempts).toBe(2);
+    expect(fetchImpl.mock.calls.some(([input]) => requestPath(input).endsWith('/prompt_async'))).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(currentGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    });
+
+    const requestsAfterResolution = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls.length).toBe(requestsAfterResolution);
+    runtime.stop();
+  });
+
+  it('preserves a pending rollback reservation across pause and resume without duplicate accounting', async () => {
+    const before = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    };
+    let currentGoal = before;
+    let messageReads = 0;
+    let rollbackAttempts = 0;
+    let accountingWrites = 0;
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const movedTail = {
+      info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user', time: { created: 3 } },
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'active' && nextGoal.turnsUsed === before.turnsUsed + 1) {
+          accountingWrites += 1;
+        }
+        if (nextGoal.status === 'blocked' || nextGoal.turnsUsed === before.turnsUsed) {
+          rollbackAttempts += 1;
+          if (rollbackAttempts <= 2) throw new Error('rollback resolution unavailable');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        return jsonResponse(messageReads === 1 ? [assistant] : [movedTail]);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        throw new Error('stale continuation must not dispatch');
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 2,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal.turnsUsed).toBe(2);
+    expect(accountingWrites).toBe(1);
+    expect(rollbackAttempts).toBe(2);
+
+    const pausedGoal = { ...currentGoal, status: 'paused', statusReason: 'paused by user' };
+    currentGoal = pausedGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 2 }, metadata: { openchamber: { goal: pausedGoal } } } },
+    });
+
+    const resumedGoal = { ...pausedGoal, status: 'active', statusReason: 'resumed', updatedAt: 3 };
+    currentGoal = resumedGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 3 }, metadata: { openchamber: { goal: resumedGoal } } } },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await flushMicrotasks();
+
+    expect(rollbackAttempts).toBe(3);
+    expect(accountingWrites).toBe(1);
+    expect(dispatchAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({
+      status: 'active',
+      statusReason: 'resumed',
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    });
+    runtime.stop();
+  });
+
+  it('rebinds a pending rollback to the real Resume accounting state and continues once', async () => {
+    const before = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 0,
+      tokensCommitted: 0,
+      lastAccountedMessageID: '',
+    };
+    let currentGoal = before;
+    let messageReads = 0;
+    let rollbackFailuresRemaining = 2;
+    let rollbackWrites = 0;
+    let blockedFallbackWrites = 0;
+    let accountingWrites = 0;
+    let dispatchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const movedTail = {
+      info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user', time: { created: 4 } },
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'active' && nextGoal.tokensUsed === 20) {
+          accountingWrites += 1;
+        } else if (rollbackFailuresRemaining > 0) {
+          rollbackFailuresRemaining -= 1;
+          if (nextGoal.status === 'blocked') blockedFallbackWrites += 1;
+          else rollbackWrites += 1;
+          throw new Error('rollback resolution unavailable');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        return jsonResponse(messageReads === 1 ? [assistant] : (messageReads === 2 ? [movedTail] : [assistant]));
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [1000],
+      maxRetryAttempts: 1,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, tokensUsed: 20, lastAccountedMessageID: 'msg_assistant' });
+    expect(rollbackFailuresRemaining).toBe(0);
+    expect(rollbackWrites).toBe(1);
+    expect(blockedFallbackWrites).toBe(1);
+
+    const pausedGoal = { ...currentGoal, status: 'paused', statusReason: 'paused by user' };
+    currentGoal = pausedGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 2 }, metadata: { openchamber: { goal: pausedGoal } } } },
+    });
+
+    const resumedGoal = {
+      ...pausedGoal,
+      status: 'active',
+      statusReason: 'resumed',
+      tokensUsed: 0,
+      tokensBaseline: 0,
+      tokensCommitted: 0,
+      turnsUsed: 0,
+      lastAccountedMessageID: '',
+      updatedAt: 3,
+    };
+    currentGoal = resumedGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 3 },
+          metadata: { openchamber: { goal: resumedGoal } },
+        },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await flushMicrotasks();
+
+    expect(accountingWrites).toBe(2);
+    expect(rollbackWrites).toBe(1);
+    expect(blockedFallbackWrites).toBe(1);
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({
+      status: 'active',
+      turnsUsed: 1,
+      tokensUsed: 20,
+      tokensBaseline: 0,
+      tokensCommitted: 0,
+      lastAccountedMessageID: 'msg_assistant',
+    });
+    runtime.stop();
+  });
+
+  it('notifies through settlement when rollback fallback blocks a goal and removes the reservation', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, tokensBaseline: 2, tokensCommitted: 3, lastAccountedMessageID: 'msg_before' };
+    let currentGoal = before;
+    let messageReads = 0;
+    let rollbackWrites = 0;
+    let accountingAccepted = false;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const movedTail = { info: { id: 'msg_user', sessionID: SESSION_ID, role: 'user', time: { created: 3 } } };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'active' && nextGoal.turnsUsed === before.turnsUsed && accountingAccepted) {
+          rollbackWrites += 1;
+          throw new Error('rollback unavailable');
+        }
+        if (nextGoal.status === 'active' && nextGoal.turnsUsed === before.turnsUsed + 1) accountingAccepted = true;
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        return jsonResponse(messageReads === 1 ? [assistant] : [movedTail]);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) throw new Error('must not dispatch');
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
     runtime.processPayload({
       type: 'session.status',
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
     await vi.runOnlyPendingTimersAsync();
 
-    // Audit must be skipped on MessageOutputLengthError
-    expect(service.generateSmallModelText).not.toHaveBeenCalled();
-
-    // Goal remains active and turnsUsed incremented
-    const patch = requests.find((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
-    expect(patch).toBeDefined();
-    const writtenGoal = JSON.parse(patch.body).metadata.openchamber.goal;
-    expect(writtenGoal).toMatchObject({
-      status: 'active',
-      turnsUsed: 2,
+    expect(rollbackWrites).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation tail changed before dispatch' });
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(emitGoalNotification).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: SESSION_ID,
+      status: 'blocked',
+      goal: expect.objectContaining({ status: 'blocked' }),
+    }));
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
-
-    // Continuation prompt is dispatched
-    const promptAsync = requests.find((request) => request.pathname === `/session/${SESSION_ID}/prompt_async` && request.method === 'POST');
-    expect(promptAsync).toBeDefined();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     runtime.stop();
   });
+
+  it('rolls back accepted accounting before pausing an aborted reservation', async () => {
+    const latestMessages = deferred();
+    let currentGoal = {
+      ...goal,
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, cache: { read: 3, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    let messageReads = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        if (messageReads === 1) return jsonResponse([assistant]);
+        return latestMessages.promise;
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) throw new Error('must not dispatch');
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal.turnsUsed).toBe(2);
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    }, DIRECTORY);
+    latestMessages.resolve(jsonResponse([assistant]));
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(currentGoal).toMatchObject({
+      status: 'paused',
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    });
+    runtime.stop();
+  });
+
+  it('rejects a stale file-backed terminal result after the objective changes in flight', async () => {
+    const audit = deferred();
+    let fileObjective = 'Original objective';
+    let currentGoal = { ...goal, objective: '', objectiveFile: true, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    readGoalObjective.mockImplementation(async () => fileObjective);
+    vi.stubGlobal('fetch', fetchImpl);
+    const service = { generateSmallModelText: vi.fn(() => audit.promise) };
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fileObjective = 'Changed objective';
+    audit.resolve({ text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' });
+    await flushMicrotasks();
+
+    expect(currentGoal.status).toBe('active');
+    expect(requests.some((request) => request.method === 'PATCH')).toBe(false);
+    expect(requests.some((request) => request.pathname.endsWith('/prompt_async'))).toBe(false);
+    runtime.stop();
+  });
+
+  it('recovers from a length finish without an error marker', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_length_finish', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+         finish: 'length', time: { completed: 2 }, tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'The answer was truncated.' }],
+    };
+    const audit = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(promptAttempts).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+    expect(currentGoal.status).toBe('active');
+    runtime.stop();
+  });
+
+  it('recovers from a MessageOutputLengthError without a length finish marker', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_length_error', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, error: { name: 'MessageOutputLengthError' },
+        tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'The answer was truncated.' }],
+    };
+    const audit = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(promptAttempts).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+    expect(currentGoal.status).toBe('active');
+    runtime.stop();
+  });
+
+  it('recovers from an output-length finish without auditing the incomplete reply', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_length', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        finish: 'length', time: { completed: 2 }, error: { name: 'MessageOutputLengthError' },
+        tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'The answer was truncated.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const audit = vi.fn();
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(currentGoal.status).toBe('active');
+    expect(currentGoal.turnsUsed).toBe(2);
+    expect(promptAttempts).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it('blocks after repeated output-length finishes', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let messageReads = 0;
+    const assistant = (id, created, completed) => ({
+      info: {
+        id, sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        finish: 'length', time: { created, completed }, tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still truncated.' }],
+    });
+    const firstLength = assistant('msg_length_1', 10, 11);
+    const secondLength = assistant('msg_length_2', 20, 21);
+    let promptAttempts = 0;
+    const audit = vi.fn();
+    const emitGoalNotification = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        // Lifecycle dispatch reads the transcript three times per continuing
+        // tick (initial, pre-dispatch, final admission), so keep the first
+        // tick's three reads on a single tail before exposing the streak.
+        return jsonResponse(messageReads <= 3 ? [firstLength] : [firstLength, secondLength]);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    // First truncation continues with one prompt and no audit.
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal.status).toBe('active');
+    expect(audit).not.toHaveBeenCalled();
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Second consecutive completed non-summary truncation blocks.
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal.status).toBe('blocked');
+    expect(currentGoal.statusReason).toBe('repeated output truncation');
+    expect(audit).not.toHaveBeenCalled();
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(emitGoalNotification.mock.calls[0][0].goal.statusReason).toBe('repeated output truncation');
+    runtime.stop();
+  });
+
+  it.each([
+    ['token budget', { tokenBudget: 3 }, 'budgetLimited', 'token budget reached'],
+    ['auto-continuation cap', { turnsUsed: 1 }, 'blocked', 'auto-continuation limit reached'],
+  ])('keeps the %s terminal check ahead of the length breaker', async (_label, goalOverride, status, statusReason) => {
+    let currentGoal = { ...goal, ...goalOverride, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_length', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        finish: 'length', time: { completed: 2 }, tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still truncated.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) throw new Error('must not dispatch');
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      maxAutoTurns: goalOverride.turnsUsed === 1 ? 1 : 20,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(currentGoal).toMatchObject({ status, statusReason });
+    runtime.stop();
+  });
+
+  it('gives a genuine assistant error precedence over a length finish', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_error', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        finish: 'length', time: { completed: 2 }, error: { name: 'ProviderError' },
+      },
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'ProviderError' });
+    runtime.stop();
+  });
+
+  it('does not count a length-marked summary as a repeated truncation', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: 'msg_regular' };
+    const regular = {
+      info: {
+        id: 'msg_regular', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 1, completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+    };
+    const summary = {
+      info: {
+        id: 'msg_summary', sessionID: SESSION_ID, role: 'assistant', summary: true, finish: 'length',
+        time: { created: 3, completed: 4 }, tokens: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      },
+    };
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([regular, summary]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal.status).toBe('active');
+    expect(promptAttempts).toBe(1);
+    runtime.stop();
+  });
+
+  it('rolls back an undispatched reservation when authoritative status retries exhaust', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, tokensBaseline: 2, tokensCommitted: 3, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let statusCalls = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 5, output: 2, cache: { read: 1, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        return statusCalls === 1 ? jsonResponse({ [SESSION_ID]: { type: 'idle' } }) : jsonResponse(null, 503);
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        throw new Error('dispatch should not be reached');
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 1,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(currentGoal.turnsUsed).toBe(2);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(statusCalls).toBeGreaterThanOrEqual(3);
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 1, tokensUsed: 7, tokensBaseline: 2, tokensCommitted: 3 });
+    runtime.stop();
+  });
+
+  it('retries malformed recent messages instead of treating them as an empty tail', async () => {
+    let messageAttempts = 0;
+    const audit = vi.fn();
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageAttempts += 1;
+        return messageAttempts === 1 ? jsonResponse([{}]) : jsonResponse([]);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(messageAttempts).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(messageAttempts).toBe(2);
+    expect(audit).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it('audits and dispatches when the parent and child are omitted from a valid idle status map', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"continue","note":"More work remains"}',
+      providerID: 'provider',
+      modelID: 'model',
+    }));
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([{ id: CHILD_ID, parentID: SESSION_ID }]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(audit).toHaveBeenCalledOnce();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+    runtime.stop();
+  });
+
+  it('retries malformed child records instead of treating them as no children', async () => {
+    let childAttempts = 0;
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(session);
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) {
+        childAttempts += 1;
+        return childAttempts === 1 ? jsonResponse([{}]) : jsonResponse([]);
+      }
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(childAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(childAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('includes reasoning and cache write tokens in authoritative totals', async () => {
+    const currentGoal = { ...goal, tokensUsed: 0, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_tokens', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 2, reasoning: 3, cache: { read: 4, write: 5 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') return jsonResponse(session);
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const service = { generateSmallModelText: vi.fn(async () => ({
+      text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+    })) };
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({ status: 'complete', tokensUsed: 15 });
+    runtime.stop();
+  });
+
+  it('rolls back an undispatched reservation when pause arrives after accounting', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, tokensBaseline: 2, tokensCommitted: 3, lastAccountedMessageID: 'msg_before' };
+    let currentGoal = before;
+    let runtime;
+    let pauseEmitted = false;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 10, output: 4, reasoning: 3, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'active' && !pauseEmitted) {
+          pauseEmitted = true;
+          currentGoal = { ...nextGoal, status: 'paused', statusReason: 'paused by user' };
+          runtime.processPayload({
+            type: 'session.updated',
+            properties: { info: { ...session, metadata: { openchamber: { goal: currentGoal } } } },
+          });
+          return jsonResponse({ ...session, metadata: { openchamber: { goal: nextGoal } } });
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    expect(promptAttempts).toBe(0);
+    await vi.waitFor(() => expect(currentGoal).toMatchObject({
+      status: 'paused',
+      turnsUsed: 1,
+      tokensUsed: 7,
+      tokensBaseline: 2,
+      tokensCommitted: 3,
+      lastAccountedMessageID: 'msg_before',
+    }));
+    runtime.stop();
+  });
+
+  it('rolls back an undispatched reservation when status invalidates final admission', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let runtime;
+    let sessionReads = 0;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 3) {
+          runtime.processPayload({
+            type: 'session.status',
+            properties: { sessionID: SESSION_ID, status: { type: 'busy' }, directory: DIRECTORY },
+          });
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' });
+    runtime.stop();
+  });
+
+  it('rolls back an undispatched reservation when the runtime stops after accounting', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let runtime;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        currentGoal = nextGoal;
+        if (nextGoal.status === 'active' && nextGoal.turnsUsed === before.turnsUsed + 1) runtime.stop();
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.waitFor(() => expect(currentGoal).toMatchObject({ turnsUsed: 1, tokensUsed: 7 }));
+
+    expect(promptAttempts).toBe(0);
+  });
+
+  it('blocks a replacement that still carries an indistinguishable old charge', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let runtime;
+    let promptAttempts = 0;
+    let replacementEmitted = false;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'active' && !replacementEmitted) {
+          replacementEmitted = true;
+          currentGoal = {
+            ...nextGoal,
+            id: 'goal_replacement',
+            objective: 'A replacement objective',
+            createdAt: 99,
+          };
+          runtime.processPayload({
+            type: 'session.updated',
+            properties: { info: { ...session, metadata: { openchamber: { goal: currentGoal } } } },
+          });
+          return jsonResponse({ ...session, metadata: { openchamber: { goal: nextGoal } } });
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.waitFor(() => expect(currentGoal).toMatchObject({
+      id: 'goal_replacement',
+      status: 'blocked',
+      statusReason: 'continuation reservation could not be reconciled',
+    }));
+
+    expect(promptAttempts).toBe(0);
+    runtime.stop();
+  });
+
+  it('starts a bounded restart scan and holds an ambiguous persisted accounting tail', async () => {
+    const currentGoal = { ...goal, turnsUsed: 2, tokensUsed: 2, lastAccountedMessageID: 'msg_assistant' };
+    let promptAttempts = 0;
+    const directories = [DIRECTORY, '/workspace-two', '/workspace-three', '/workspace-four', '/workspace-five'];
+    const scannedDirectories = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        scannedDirectories.push(new URL(input).searchParams.get('directory'));
+        return jsonResponse(scannedDirectories.length === 1
+          ? [{ ...session, metadata: { openchamber: { goal: currentGoal } } }]
+          : []);
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      if (init.method === 'PATCH') return jsonResponse(session);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    await runtime.start({ listDirectories: async () => directories });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(scannedDirectories).toEqual(directories);
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, tokensUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('retries startup recovery after the session list is unavailable', async () => {
+    let scanAttempts = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        scanAttempts += 1;
+        return scanAttempts === 1
+          ? jsonResponse({ error: 'OpenCode is still starting' }, 503)
+          : jsonResponse([{ ...session, metadata: { openchamber: { goal: currentGoal } } }]);
+      }
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      startupRecoveryDelaysMs: [10],
+      maxStartupRecoveryAttempts: 1,
+    });
+
+    await runtime.start({ listDirectories: async () => [DIRECTORY] });
+    expect(scanAttempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(scanAttempts).toBe(2);
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('retries startup recovery after the settings directory scan fails without SSE', async () => {
+    let scanAttempts = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        return jsonResponse([{ ...session, metadata: { openchamber: { goal: currentGoal } } }]);
+      }
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      startupRecoveryDelaysMs: [10],
+      maxStartupRecoveryAttempts: 1,
+    });
+
+    await runtime.start({
+      listDirectories: async () => {
+        scanAttempts += 1;
+        return scanAttempts === 1 ? null : [DIRECTORY];
+      },
+    });
+    expect(scanAttempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(scanAttempts).toBe(2);
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('retries startup recovery after array-shaped settings fail, then rearms an idle goal after readiness', async () => {
+    let scanAttempts = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        return jsonResponse([{ ...session, metadata: { openchamber: { goal: currentGoal } } }]);
+      }
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      startupRecoveryDelaysMs: [10],
+      maxStartupRecoveryAttempts: 1,
+    });
+
+    await runtime.start({
+      listDirectories: async () => {
+        scanAttempts += 1;
+        if (scanAttempts === 1) throw new Error('Settings file is malformed (expected object payload)');
+        return [DIRECTORY];
+      },
+    });
+    expect(scanAttempts).toBe(1);
+
+    await runtime.start({
+      listDirectories: async () => {
+        scanAttempts += 1;
+        return [DIRECTORY];
+      },
+      resetRetryWindow: true,
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(scanAttempts).toBe(2);
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('retries terminalization after dispatch exhaustion without sending another prompt', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let restoreAttempts = 0;
+    let blockedWrites = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          if (blockedWrites === 1) throw new Error('terminal blocked write unavailable');
+          currentGoal = nextGoal;
+          return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+        }
+        if (nextGoal.turnsUsed < currentGoal.turnsUsed) {
+          restoreAttempts += 1;
+          throw new Error('terminal restore unavailable');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(dispatchAttempts).toBe(2);
+    expect(currentGoal.status).toBe('active');
+    expect(restoreAttempts).toBe(1);
+    expect(blockedWrites).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'continuation dispatch retry limit reached before continuation dispatch',
+    });
+    expect(restoreAttempts).toBe(2);
+    expect(blockedWrites).toBe(2);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(dispatchAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('reconciles a committed blocked terminalization after its PATCH response is lost', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let blockedWrites = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          currentGoal = nextGoal;
+          if (blockedWrites === 1) throw new Error('blocked terminal response lost');
+        } else if (nextGoal.turnsUsed < currentGoal.turnsUsed) {
+          throw new Error('terminal restore unavailable');
+        } else {
+          currentGoal = nextGoal;
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    expect(dispatchAttempts).toBe(2);
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    expect(currentGoal.status).toBe('blocked');
+    expect(blockedWrites).toBe(1);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(dispatchAttempts).toBe(2);
+    expect(blockedWrites).toBe(1);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('blocks after repeated explicit dispatch rejections while rolling back accounting', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let blockedWrites = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    expect(dispatchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'continuation dispatch retry limit reached',
+      turnsUsed: 1,
+      tokensUsed: 0,
+      lastAccountedMessageID: '',
+    });
+    expect(blockedWrites).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+
+    const requestsAfterSettlement = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterSettlement);
+    expect(dispatchAttempts).toBe(2);
+    expect(blockedWrites).toBe(1);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('continues blocked settlement when a committed rollback response is lost', async () => {
+    const before = { ...goal, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let dispatchAttempts = 0;
+    let rollbackAttempts = 0;
+    let blockedWrites = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          currentGoal = nextGoal;
+        } else if (nextGoal.turnsUsed === before.turnsUsed + 1) {
+          currentGoal = nextGoal;
+        } else if (nextGoal.turnsUsed === before.turnsUsed) {
+          rollbackAttempts += 1;
+          currentGoal = nextGoal;
+          if (rollbackAttempts === 1) throw new Error('rollback response lost after commit');
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+
+    expect(rollbackAttempts).toBe(1);
+    expect(blockedWrites).toBe(1);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'continuation dispatch retry limit reached',
+      turnsUsed: 1,
+      tokensUsed: 0,
+      lastAccountedMessageID: '',
+    });
+    expect(dispatchAttempts).toBe(2);
+    runtime.stop();
+  });
+
+  it('preserves a rejected reservation across status events before idle settlement', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let blockedWrites = 0;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+    const idle = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'busy' }, directory: DIRECTORY },
+    });
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+
+    expect(dispatchAttempts).toBe(2);
+    expect(blockedWrites).toBe(1);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      statusReason: 'continuation dispatch retry limit reached',
+      turnsUsed: 1,
+      tokensUsed: 0,
+      lastAccountedMessageID: '',
+    });
+    runtime.stop();
+  });
+
+  it('reconciles a blocked terminalization event before dropping its reservation', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let dispatchAttempts = 0;
+    let blockedWrites = 0;
+    let patchAttempts = 0;
+    let runtime;
+    const emitGoalNotification = vi.fn();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          currentGoal = nextGoal;
+          if (blockedWrites === 1) {
+            runtime.processPayload({
+              type: 'session.updated',
+              properties: {
+                info: {
+                  ...session,
+                  time: { updated: 2 },
+                  metadata: { openchamber: { goal: currentGoal } },
+                },
+              },
+            });
+            throw new Error('blocked terminal response lost');
+          }
+        } else if (nextGoal.turnsUsed < currentGoal.turnsUsed) {
+          throw new Error('terminal restore unavailable');
+        } else {
+          currentGoal = nextGoal;
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(dispatchAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    expect(dispatchAttempts).toBe(2);
+    expect(currentGoal.status).toBe('blocked');
+    expect(blockedWrites).toBe(1);
+    const patchesAfterTerminalization = patchAttempts;
+
+    await flushMicrotasks();
+
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(blockedWrites).toBe(1);
+    expect(patchAttempts).toBe(patchesAfterTerminalization);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(dispatchAttempts).toBe(2);
+    expect(blockedWrites).toBe(1);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('does not let pending terminalization consume a fresh replacement kickoff', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const replacement = {
+      ...goal,
+      id: 'goal_new',
+      objective: 'Finish the replacement task',
+      turnsUsed: 0,
+      lastAccountedMessageID: 'msg_assistant',
+      createdAt: 3,
+      updatedAt: 3,
+    };
+    let dispatchAttempts = 0;
+    let terminalizationWrites = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked' || nextGoal.turnsUsed < currentGoal.turnsUsed) {
+          terminalizationWrites += 1;
+          throw new Error('old terminalization unavailable');
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        return currentGoal.id === replacement.id
+          ? new Response(null, { status: 204 })
+          : jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+      maxRetryAttempts: 2,
+    });
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(dispatchAttempts).toBe(2);
+    const oldTerminalizationWrites = terminalizationWrites;
+
+    currentGoal = replacement;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 3 },
+          metadata: { openchamber: { goal: replacement } },
+        },
+      },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(dispatchAttempts).toBe(3);
+    expect(currentGoal).toMatchObject({ id: replacement.id, status: 'active', turnsUsed: 1 });
+    expect(terminalizationWrites).toBe(oldTerminalizationWrites);
+    runtime.stop();
+  });
+
+  it('rebinds a rejected terminalization reservation after Resume resets turns without losing kickoff', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let resumed = false;
+    let dispatchAttempts = 0;
+    let accountingWrites = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (!resumed && (nextGoal.status === 'blocked' || nextGoal.turnsUsed < currentGoal.turnsUsed)) {
+          throw new Error('terminalization resolution unavailable');
+        }
+        if (nextGoal.turnsUsed === 2) accountingWrites += 1;
+        if (resumed && nextGoal.turnsUsed === 1) accountingWrites += 1;
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        dispatchAttempts += 1;
+        if (!resumed) return jsonResponse({ error: 'dispatch rejected' }, 400);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+      maxRetryAttempts: 2,
+    });
+    const idle = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(dispatchAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+
+    resumed = true;
+    currentGoal = {
+      ...currentGoal,
+      status: 'active',
+      statusReason: 'resumed',
+      turnsUsed: 0,
+      lastAccountedMessageID: 'msg_assistant',
+      updatedAt: 3,
+    };
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          time: { updated: 3 },
+          metadata: { openchamber: { goal: currentGoal } },
+        },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await flushMicrotasks();
+
+    expect(dispatchAttempts).toBe(3);
+    expect(accountingWrites).toBe(2);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 1, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('does not arm or run a stale restart candidate after a newer session update', async () => {
+    const newerDirectory = '/workspace-new';
+    const staleDirectory = '/workspace-old';
+    const newerGoal = { ...goal, id: 'goal_new', turnsUsed: 0, createdAt: 2, updatedAt: 20 };
+    const staleGoal = { ...goal, id: 'goal_old', turnsUsed: 0, createdAt: 1, updatedAt: 10 };
+    const targetRequests = [];
+    const fetchImpl = vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        return jsonResponse([{
+          ...session,
+          directory: staleDirectory,
+          time: { updated: 10 },
+          metadata: { openchamber: { goal: staleGoal } },
+        }]);
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        targetRequests.push(new URL(input).searchParams.get('directory'));
+        return jsonResponse({
+          ...session,
+          directory: newerDirectory,
+          metadata: { openchamber: { goal: newerGoal } },
+        });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'busy' } });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: {
+        info: {
+          ...session,
+          directory: newerDirectory,
+          time: { updated: 20 },
+          metadata: { openchamber: { goal: newerGoal } },
+        },
+      },
+    });
+    await runtime.start({ listDirectories: async () => [staleDirectory] });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(targetRequests).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(targetRequests).toEqual([newerDirectory]);
+    runtime.stop();
+  });
+
+  it('recovers an active timer consumed while disabled without a new event', async () => {
+    let enabled = true;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const audit = vi.fn(async () => ({
+      text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+    }));
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => enabled,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    enabled = false;
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(promptAttempts).toBe(0);
+
+    enabled = true;
+    runtime.onSettingsChanged();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(audit).toHaveBeenCalledOnce();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('recovers a disabled restart scan after re-enabling without transcript activity', async () => {
+    let enabled = false;
+    let currentGoal = { ...goal, turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') return jsonResponse([{ ...session, metadata: { openchamber: { goal: currentGoal } } }]);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => enabled,
+      idleQuietMs: 10,
+      retryDelaysMs: [10, 20],
+      maxRetryAttempts: 2,
+    });
+
+    await runtime.start({ listDirectories: async () => [DIRECTORY] });
+    expect(promptAttempts).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(100);
+    enabled = true;
+    runtime.onSettingsChanged();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 3, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('uses the transcript to block a second truncation after restart', async () => {
+    let currentGoal = { ...goal, turnsUsed: 2, lastAccountedMessageID: 'msg_length_1' };
+    const lengthMessage = (id) => ({
+      info: {
+        id, sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model', finish: 'length',
+        time: { created: id.endsWith('1') ? 2 : 4, completed: id.endsWith('1') ? 3 : 5 },
+        tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still truncated.' }],
+    });
+    let promptAttempts = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') return jsonResponse([{ ...session, metadata: { openchamber: { goal: currentGoal } } }]);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([lengthMessage('msg_length_1'), lengthMessage('msg_length_2')]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    await runtime.start({ listDirectories: async () => [DIRECTORY] });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(promptAttempts).toBe(0);
+     expect(currentGoal.status).toBe('blocked');
+     expect(currentGoal.statusReason).toBe('repeated output truncation');
+    runtime.stop();
+  });
+
+  it('does not blindly resend after an accepted prompt loses its response', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: promptAttempts > 0 ? { type: 'busy' } : { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        throw new Error('prompt response lost after admission');
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+    runtime.stop();
+  });
+
+  it('retries a prompt only after an explicit pre-admission rejection', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return promptAttempts === 1 ? jsonResponse({ error: 'rejected before admission' }, 400) : jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(promptAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+    runtime.stop();
+  });
+
+  it('settles an ambiguous prompt admission when authoritative status stays unknown', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let statusCalls = 0;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        return statusCalls >= 4 ? jsonResponse(null) : jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return { ok: true };
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation admission unresolved' });
+    runtime.stop();
+  });
+
+  it('invalidates final admission on an explicit clear event without a goal payload', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    let runtime;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    let statusCalls = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return currentGoal
+          ? jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } })
+          : jsonResponse({ ...session, metadata: { openchamber: {} } });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        if (statusCalls === 3) {
+          currentGoal = null;
+          runtime.processPayload({
+            type: 'session.updated',
+            properties: { info: { ...session, metadata: {} } },
+          });
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toBeNull();
+    runtime.stop();
+  });
+
+  it('accepts clear then idle as a legitimate no-goal response after active tracking and pending reservation', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let runtime;
+    let statusCalls = 0;
+    let sessionReads = 0;
+    const requests = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET' });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        return currentGoal
+          ? jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } })
+          : jsonResponse({ ...session, metadata: {} });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        if (statusCalls === 3) {
+          // Keep both the in-flight reservation and a pending idle re-arm
+          // present when Clear invalidates the old goal.
+          runtime.processPayload({
+            type: 'session.status',
+            properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+          });
+          currentGoal = null;
+          runtime.processPayload({
+            type: 'session.updated',
+            properties: { info: { ...session, time: { updated: 2 }, metadata: {} } },
+          });
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    expect(currentGoal).toBeNull();
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(statusCalls).toBe(3);
+    const readsAfterClear = sessionReads;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(sessionReads).toBe(readsAfterClear);
+    expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
+    runtime.stop();
+  });
+
+  it('rolls back accounting when a newer user message invalidates final admission', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let runtime;
+    let promptAttempts = 0;
+    let messages = [];
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 10, output: 4, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    let statusCalls = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        if (statusCalls === 3) {
+          messages = [assistant, { info: { id: 'msg_user_new', sessionID: SESSION_ID, role: 'user', time: { created: 110 } } }];
+          runtime.processPayload({
+            type: 'message.updated',
+            properties: { info: messages[1].info },
+          }, DIRECTORY);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages.length ? messages : [assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    vi.setSystemTime(100);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' });
+    runtime.stop();
+  });
+
+  it('rebinds an undispatched reservation when a real edit preserves accounting', async () => {
+    const before = { ...goal, turnsUsed: 1, tokensUsed: 7, lastAccountedMessageID: '' };
+    let currentGoal = before;
+    let runtime;
+    let promptAttempts = 0;
+    let edited = false;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 10, output: 4, cache: { read: 2, write: 1 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (!edited && nextGoal.turnsUsed === 2) {
+          edited = true;
+          currentGoal = { ...nextGoal, objective: 'Edited objective', statusReason: 'resumed', updatedAt: 2 };
+          runtime.processPayload({
+            type: 'session.updated',
+            properties: {
+              info: {
+                ...session,
+                time: { updated: 2 },
+                metadata: { openchamber: { goal: currentGoal } },
+              },
+            },
+          });
+        } else {
+          currentGoal = nextGoal;
+        }
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: nextGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    expect(promptAttempts).toBe(0);
+    expect(currentGoal).toMatchObject({ objective: 'Edited objective', status: 'active', statusReason: 'resumed', turnsUsed: 2, tokensUsed: 17 });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+     await vi.advanceTimersByTimeAsync(100);
+     expect(promptAttempts).toBe(1);
+    expect(currentGoal.turnsUsed).toBe(2);
+     runtime.stop();
+  });
+
+  it('does not count a pre-goal truncation toward the fresh goal breaker', async () => {
+    let currentGoal = { ...goal, createdAt: 100, turnsUsed: 1, lastAccountedMessageID: 'msg_before' };
+    let promptAttempts = 0;
+    const lengthMessage = (id, created) => ({
+      info: {
+        id, sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model', finish: 'length',
+        time: { created, completed: created + 1 }, tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Still truncated.' }],
+    });
+    const messages = [lengthMessage('msg_old_length', 90), lengthMessage('msg_new_length', 110)];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+    runtime.stop();
+  });
+
+  it('does not count assistant truncations with missing or non-finite creation times toward the breaker', async () => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let messageReads = 0;
+    let promptAttempts = 0;
+    const assistant = (id, created) => {
+      const info = {
+        id, sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model', finish: 'length',
+        time: { completed: 3 },
+        tokens: { input: 1, output: 2, cache: { read: 0, write: 0 } },
+      };
+      if (created !== undefined) info.time.created = created;
+      return { info, parts: [{ type: 'text', text: 'Still truncated.' }] };
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        messageReads += 1;
+        const id = messageReads <= 3 ? 'msg_unknown_1' : 'msg_unknown_2';
+        const created = messageReads <= 3 ? undefined : Number.NaN;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [assistant(id, created)],
+        };
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse(null);
+      }
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idle = { type: 'session.status', properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY } };
+    runtime.processPayload(idle);
+    await vi.runOnlyPendingTimersAsync();
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(promptAttempts).toBe(2);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 3 });
+    runtime.stop();
+  });
+
+  it('keeps API order for missing timestamps without using IDs as chronology', async () => {
+    const known = {
+      info: {
+        id: 'msg_known', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 100, completed: 101 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Known.' }],
+    };
+    const apiLast = {
+      info: {
+        id: 'msg_a_missing', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 202 }, tokens: { input: 11, output: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'API last.' }],
+    };
+    const earlierUnknown = {
+      info: {
+        id: 'msg_z_missing', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 201 }, tokens: { input: 7, output: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'API earlier.' }],
+    };
+    let currentGoal = { ...goal, lastAccountedMessageID: known.info.id };
+    const messages = [known, earlierUnknown, apiLast];
+    const requests = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse(messages);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    const audit = vi.fn(async ({ prompt }) => {
+      expect(prompt).toContain('API last.');
+      return { text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model' };
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: audit }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    const patch = requests.find((request) => request.method === 'PATCH');
+    expect(audit).toHaveBeenCalledOnce();
+    expect(JSON.parse(patch.body).metadata.openchamber.goal).toMatchObject({ status: 'complete', tokensUsed: 11, lastAccountedMessageID: 'msg_a_missing' });
+    runtime.stop();
+  });
+
+  it('rechecks a file objective immediately before the final metadata write', async () => {
+    let currentGoal = { ...goal, objective: '', objectiveFile: true, lastAccountedMessageID: '' };
+    let objectiveReads = 0;
+    let patchAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'Verified.' }],
+    };
+    readGoalObjective.mockImplementation(async () => {
+      objectiveReads += 1;
+      return objectiveReads < 3 ? 'Original objective' : 'Edited objective';
+    });
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        patchAttempts += 1;
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"complete","note":"Verified"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(objectiveReads).toBe(3);
+    expect(patchAttempts).toBe(0);
+    expect(currentGoal.status).toBe('active');
+    runtime.stop();
+  });
+});
+
+describe('session goal upstream length/Resume regression (transcript-derived)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readGoalObjective.mockReset();
+    readGoalObjective.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const upstreamAssistantMessage = (id, infoOverrides = {}) => ({
+    info: {
+      id,
+      sessionID: SESSION_ID,
+      role: 'assistant',
+      providerID: 'provider',
+      modelID: 'model',
+      time: { created: 2, completed: 2 },
+      tokens: { input: 1, output: 1, cache: { read: 0 } },
+      ...infoOverrides,
+    },
+    parts: [{ type: 'text', text: 'The agent made progress.' }],
+  });
+
+  const createRuntimeHarness = ({ messages, messageFactory, goalOverrides = {}, maxAutoTurns = 20 }) => {
+    const requests = [];
+    let messageFetchCount = 0;
+    const activeSession = {
+      ...session,
+      metadata: { openchamber: { goal: { ...goal, ...goalOverrides } } },
+    };
+    const service = {
+      generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}',
+        providerID: 'provider',
+        modelID: 'model',
+      })),
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      requests.push({ pathname, method: init.method ?? 'GET', body: init.body });
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        activeSession.metadata = JSON.parse(init.body).metadata;
+        return jsonResponse(activeSession);
+      }
+      if (pathname === `/session/${SESSION_ID}`) return jsonResponse(activeSession);
+      if (pathname === '/session/status') return jsonResponse({});
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) {
+        const nextMessages = messageFactory ? messageFactory(messageFetchCount) : messages;
+        messageFetchCount += 1;
+        return jsonResponse(nextMessages);
+      }
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) return jsonResponse({ ok: true });
+      throw new Error(`Unexpected request: ${pathname}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => service,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      maxAutoTurns,
+    });
+    return { runtime, requests, service, activeSession };
+  };
+
+  const runIdleTick = async (runtime) => {
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+  };
+
+  const lastPatchedGoal = (requests) => {
+    const patches = requests.filter((request) => request.pathname === `/session/${SESSION_ID}` && request.method === 'PATCH');
+    expect(patches.length).toBeGreaterThan(0);
+    return JSON.parse(patches.at(-1).body).metadata.openchamber.goal;
+  };
 
   it.each([
     { name: 'APIError', error: { name: 'APIError', message: 'provider failed' } },
@@ -385,7 +7026,7 @@ describe('session goal live activity gate', () => {
     { name: 'unnamed errors', error: {} },
   ])('blocks a length finish when the assistant also has a non-length $name', async ({ error }) => {
     const { runtime, requests, service } = createRuntimeHarness({
-      messages: [assistantMessage('msg_assistant_error', { finish: 'length', error })],
+      messages: [upstreamAssistantMessage('msg_assistant_error', { finish: 'length', error })],
     });
 
     await runIdleTick(runtime);
@@ -400,11 +7041,11 @@ describe('session goal live activity gate', () => {
   });
 
   it('blocks after two consecutive length-truncated agent turns without persisting a counter, regardless of message IDs', async () => {
-    const firstLength = assistantMessage('z', { finish: 'length', time: { created: 10, completed: 11 } });
-    const summary = assistantMessage('summary', { summary: true, time: { created: 15, completed: 16 } });
-    const secondLength = assistantMessage('a', { finish: 'length', time: { created: 20, completed: 21 } });
+    const firstLength = upstreamAssistantMessage('z', { finish: 'length', time: { created: 10, completed: 11 } });
+    const summary = upstreamAssistantMessage('summary', { summary: true, time: { created: 15, completed: 16 } });
+    const secondLength = upstreamAssistantMessage('a', { finish: 'length', time: { created: 20, completed: 21 } });
     const { runtime, requests, service } = createRuntimeHarness({
-      messageFactory: (fetchCount) => fetchCount < 2 ? [firstLength] : [firstLength, summary, secondLength],
+      messageFactory: (fetchCount) => fetchCount < 3 ? [firstLength] : [firstLength, summary, secondLength],
     });
 
     await runIdleTick(runtime);
@@ -424,8 +7065,8 @@ describe('session goal live activity gate', () => {
   });
 
   it('allows one explicit Resume after repeated truncation, then blocks another cutoff', async () => {
-    const first = assistantMessage('first', { finish: 'length', time: { created: 10, completed: 11 } });
-    const second = assistantMessage('second', { finish: 'length', time: { created: 20, completed: 21 } });
+    const first = upstreamAssistantMessage('first', { finish: 'length', time: { created: 10, completed: 11 } });
+    const second = upstreamAssistantMessage('second', { finish: 'length', time: { created: 20, completed: 21 } });
     const messages = [first, second];
     const { runtime, requests, activeSession } = createRuntimeHarness({ messages });
     try {
@@ -436,7 +7077,7 @@ describe('session goal live activity gate', () => {
       await runIdleTick(runtime);
       expect(lastPatchedGoal(requests)).toMatchObject({ status: 'active', statusReason: '', turnsUsed: 1 });
       expect(requests.filter((request) => request.pathname.endsWith('/prompt_async'))).toHaveLength(1);
-      messages.push(assistantMessage('third', { finish: 'length', time: { created: 30, completed: 31 } }));
+      messages.push(upstreamAssistantMessage('third', { finish: 'length', time: { created: 30, completed: 31 } }));
       await runIdleTick(runtime);
       expect(lastPatchedGoal(requests)).toMatchObject({ status: 'blocked', statusReason: 'repeated output truncation' });
       expect(requests.filter((request) => request.pathname.endsWith('/prompt_async'))).toHaveLength(1);
@@ -451,7 +7092,7 @@ describe('session goal live activity gate', () => {
   ])('keeps $expectedStatus protection on explicit Resume', async ({ tokenBudget, error, expectedStatus }) => {
     const { runtime, requests } = createRuntimeHarness({
       goalOverrides: { statusReason: 'resumed', tokenBudget },
-      messages: [assistantMessage('resumed', { finish: 'length', error })],
+      messages: [upstreamAssistantMessage('resumed', { finish: 'length', error })],
     });
     try {
       await runIdleTick(runtime);
@@ -463,14 +7104,14 @@ describe('session goal live activity gate', () => {
   });
 
   it('continues after a truncated agent turn followed by a length-finished summary', async () => {
-    const firstLength = assistantMessage('agent-length', { finish: 'length', time: { created: 10, completed: 11 } });
-    const summary = assistantMessage('summary', {
+    const firstLength = upstreamAssistantMessage('agent-length', { finish: 'length', time: { created: 10, completed: 11 } });
+    const summary = upstreamAssistantMessage('summary', {
       summary: true,
       finish: 'length',
       time: { created: 15, completed: 16 },
     });
     const { runtime, requests, service } = createRuntimeHarness({
-      messageFactory: (fetchCount) => fetchCount < 2 ? [firstLength] : [firstLength, summary],
+      messageFactory: (fetchCount) => fetchCount < 3 ? [firstLength] : [firstLength, summary],
     });
 
     await runIdleTick(runtime);
@@ -483,10 +7124,10 @@ describe('session goal live activity gate', () => {
   });
 
   it('does not infer a repeated streak when a completed assistant timestamp is missing', async () => {
-    const firstLength = assistantMessage('z', { finish: 'length', time: { completed: 11 } });
-    const secondLength = assistantMessage('a', { finish: 'length', time: { created: 20, completed: 21 } });
+    const firstLength = upstreamAssistantMessage('z', { finish: 'length', time: { completed: 11 } });
+    const secondLength = upstreamAssistantMessage('a', { finish: 'length', time: { created: 20, completed: 21 } });
     const { runtime, requests, service } = createRuntimeHarness({
-      messageFactory: (fetchCount) => fetchCount < 2 ? [firstLength] : [firstLength, secondLength],
+      messageFactory: (fetchCount) => fetchCount < 3 ? [firstLength] : [firstLength, secondLength],
     });
 
     await runIdleTick(runtime);
@@ -498,33 +7139,24 @@ describe('session goal live activity gate', () => {
     runtime.stop();
   });
 
-  it('ignores a missing timestamp on an older assistant when known post-goal turns establish a streak', async () => {
-    const olderLength = assistantMessage('legacy', { finish: 'length', time: { completed: 5 } });
-    const firstLength = assistantMessage('z', { finish: 'length', time: { created: 10, completed: 11 } });
-    const secondLength = assistantMessage('a', { finish: 'length', time: { created: 20, completed: 21 } });
-    const { runtime, requests, service } = createRuntimeHarness({
-      goalOverrides: { createdAt: 6 },
-      messageFactory: (fetchCount) => fetchCount < 2 ? [firstLength] : [olderLength, firstLength, secondLength],
-    });
-
-    await runIdleTick(runtime);
-    await runIdleTick(runtime);
-
-    expect(service.generateSmallModelText).not.toHaveBeenCalled();
-    expect(requests.filter((request) => request.pathname === `/session/${SESSION_ID}/prompt_async`)).toHaveLength(1);
-    expect(lastPatchedGoal(requests)).toMatchObject({
-      status: 'blocked',
-      statusReason: 'repeated output truncation',
-    });
-    runtime.stop();
-  });
+  // NOTE (lifecycle divergence): upstream also has 'ignores a missing timestamp
+  // on an older assistant when known post-goal turns establish a streak'. It is
+  // intentionally not ported: this runtime sorts the transcript (unknown
+  // timestamps sort last), so an unknown-timestamp assistant always becomes the
+  // sorted-last latest and hasRepeatedLengthTail correctly declines a streak
+  // (latest created unknown). Upstream selects latest in raw API order, where
+  // the unknown-older-first array still yields the known second as latest and
+  // blocks. Unknown-timestamp coverage is retained by 'does not infer a
+  // repeated streak when a completed assistant timestamp is missing'. Follow-up:
+  // align tick latest-selection with the helper's unknown-timestamp philosophy
+  // if the upstream streak-through-unknown behavior is required.
 
   it('does not count a previous truncated turn created at the goal boundary', async () => {
-    const firstLength = assistantMessage('before-boundary', { finish: 'length', time: { created: 10, completed: 11 } });
-    const secondLength = assistantMessage('after-boundary', { finish: 'length', time: { created: 20, completed: 21 } });
+    const firstLength = upstreamAssistantMessage('before-boundary', { finish: 'length', time: { created: 10, completed: 11 } });
+    const secondLength = upstreamAssistantMessage('after-boundary', { finish: 'length', time: { created: 20, completed: 21 } });
     const { runtime, requests, service } = createRuntimeHarness({
       goalOverrides: { createdAt: 10 },
-      messageFactory: (fetchCount) => fetchCount < 2 ? [firstLength] : [firstLength, secondLength],
+      messageFactory: (fetchCount) => fetchCount < 3 ? [firstLength] : [firstLength, secondLength],
     });
 
     await runIdleTick(runtime);
@@ -537,11 +7169,11 @@ describe('session goal live activity gate', () => {
   });
 
   it('allows length recovery after an ordinary assistant turn breaks the streak', async () => {
-    const firstLength = assistantMessage('msg_length_before_normal', { finish: 'length' });
-    const normal = assistantMessage('msg_normal');
-    const secondLength = assistantMessage('msg_length_after_normal', { finish: 'length' });
+    const firstLength = upstreamAssistantMessage('msg_length_before_normal', { finish: 'length' });
+    const normal = upstreamAssistantMessage('msg_normal');
+    const secondLength = upstreamAssistantMessage('msg_length_after_normal', { finish: 'length' });
     const { runtime, requests, service } = createRuntimeHarness({
-      messageFactory: (fetchCount) => fetchCount < 2
+      messageFactory: (fetchCount) => fetchCount < 3
         ? [firstLength]
         : [firstLength, normal, secondLength],
     });
@@ -555,26 +7187,10 @@ describe('session goal live activity gate', () => {
     runtime.stop();
   });
 
-  it('keeps MessageAbortedError pause behavior instead of continuing', async () => {
-    const { runtime, requests, service } = createRuntimeHarness({
-      messages: [assistantMessage('msg_aborted', { error: { name: 'MessageAbortedError' } })],
-    });
-
-    await runIdleTick(runtime);
-
-    expect(service.generateSmallModelText).not.toHaveBeenCalled();
-    expect(requests.some((request) => request.pathname === `/session/${SESSION_ID}/prompt_async`)).toBe(false);
-    expect(lastPatchedGoal(requests)).toMatchObject({
-      status: 'paused',
-      statusReason: 'paused after abort',
-    });
-    runtime.stop();
-  });
-
   it('checks the token budget before allowing length recovery', async () => {
     const { runtime, requests, service } = createRuntimeHarness({
       goalOverrides: { tokenBudget: 5 },
-      messages: [assistantMessage('msg_budget_length', {
+      messages: [upstreamAssistantMessage('msg_budget_length', {
         finish: 'length',
         tokens: { input: 3, output: 3, cache: { read: 0 } },
       })],
@@ -591,7 +7207,7 @@ describe('session goal live activity gate', () => {
   it('checks the auto-continuation cap before allowing length recovery', async () => {
     const { runtime, requests, service } = createRuntimeHarness({
       maxAutoTurns: 1,
-      messages: [assistantMessage('msg_cap_length', { finish: 'length' })],
+      messages: [upstreamAssistantMessage('msg_cap_length', { finish: 'length' })],
     });
 
     await runIdleTick(runtime);
@@ -602,6 +7218,237 @@ describe('session goal live activity gate', () => {
       status: 'blocked',
       statusReason: 'auto-continuation limit reached',
     });
+    runtime.stop();
+  });
+});
+
+describe('session goal restart recovery over all known directories', () => {
+  // NOTE (startup non-blocking): the non-blocking startup guarantee lives at
+  // the index.js call site — main() launches
+  // `sessionGoalRuntime.start(...)` fire-and-forget with `.catch()` logging
+  // instead of awaiting it — so there is no runtime.js unit test asserting
+  // that `start()` itself returns promptly. `start()` intentionally awaits
+  // the bounded scan so callers and tests observe completed recovery; the
+  // onOpenCodeReady edge (`start({ resetRetryWindow: true })`) remains the
+  // authoritative recovery trigger.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    readGoalObjective.mockReset();
+    readGoalObjective.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  const continueAssistant = {
+    info: {
+      id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+      time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+    },
+    parts: [{ type: 'text', text: 'More work remains.' }],
+  };
+
+  const createRecoveryHarness = (sessionByDirectory) => {
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    const scannedDirectories = [];
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        const directory = new URL(input).searchParams.get('directory');
+        scannedDirectories.push(directory);
+        const entry = sessionByDirectory[directory];
+        if (entry === 'throw') throw new Error(`project unavailable: ${directory}`);
+        return jsonResponse(entry ? [entry] : []);
+      }
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([continueAssistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      maxStartupRecoveryAttempts: 0,
+    });
+    return { runtime, scannedDirectories, getPromptAttempts: () => promptAttempts, getGoal: () => currentGoal };
+  };
+
+  it('recovers an active goal in the fifth directory of a six-project scan', async () => {
+    const directories = ['/workspace-one', '/workspace-two', '/workspace-three', '/workspace-four', '/workspace-five', '/workspace-six'];
+    const fifthGoal = { ...goal, lastAccountedMessageID: '' };
+    const { runtime, scannedDirectories, getPromptAttempts, getGoal } = createRecoveryHarness({
+      [directories[4]]: { ...session, directory: directories[4], metadata: { openchamber: { goal: fifthGoal } } },
+    });
+
+    await runtime.start({ listDirectories: async () => directories });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect([...scannedDirectories].sort()).toEqual([...directories].sort());
+    expect(getPromptAttempts()).toBe(1);
+    expect(getGoal()).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('isolates a per-directory failure so later directories still recover', async () => {
+    const directories = ['/workspace-one', '/workspace-broken', '/workspace-three', '/workspace-four', '/workspace-five'];
+    const lateGoal = { ...goal, lastAccountedMessageID: '' };
+    const { runtime, scannedDirectories, getPromptAttempts, getGoal } = createRecoveryHarness({
+      [directories[1]]: 'throw',
+      [directories[4]]: { ...session, directory: directories[4], metadata: { openchamber: { goal: lateGoal } } },
+    });
+
+    await runtime.start({ listDirectories: async () => directories });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect([...scannedDirectories].sort()).toEqual([...directories].sort());
+    expect(getPromptAttempts()).toBe(1);
+    expect(getGoal()).toMatchObject({ status: 'active', turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
+    runtime.stop();
+  });
+
+  it('bounds the scan to three concurrent per-directory fetches', async () => {
+    const directories = ['/workspace-one', '/workspace-two', '/workspace-three', '/workspace-four', '/workspace-five', '/workspace-six'];
+    const scannedDirectories = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    vi.stubGlobal('fetch', vi.fn(async (input) => {
+      const pathname = requestPath(input);
+      if (pathname !== '/session') throw new Error(`Unexpected request: ${pathname}`);
+      const directory = new URL(input).searchParams.get('directory');
+      scannedDirectories.push(directory);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await gate;
+      inFlight -= 1;
+      return jsonResponse([]);
+    }));
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      maxStartupRecoveryAttempts: 0,
+    });
+
+    const started = runtime.start({ listDirectories: async () => directories });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(maxInFlight).toBeGreaterThan(1);
+    release();
+    await started;
+
+    expect([...scannedDirectories].sort()).toEqual([...directories].sort());
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    runtime.stop();
+  });
+
+  it('supersedes an overlapping scan so only the newest scan recovers', async () => {
+    const STALE_SESSION_ID = 'ses_stale';
+    const gate = deferred();
+    let sessionListCalls = 0;
+    const promptTargets = [];
+    const goalsBySession = new Map([
+      [STALE_SESSION_ID, { ...goal, lastAccountedMessageID: '' }],
+      [SESSION_ID, { ...goal, lastAccountedMessageID: '' }],
+    ]);
+    const messageFor = (sessionId) => ({
+      info: {
+        id: 'msg_assistant', sessionID: sessionId, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === '/session') {
+        sessionListCalls += 1;
+        if (sessionListCalls === 1) {
+          await gate.promise;
+          return jsonResponse([{
+            ...session, id: STALE_SESSION_ID, directory: DIRECTORY,
+            metadata: { openchamber: { goal: goalsBySession.get(STALE_SESSION_ID) } },
+          }]);
+        }
+        return jsonResponse([{
+          ...session, metadata: { openchamber: { goal: goalsBySession.get(SESSION_ID) } },
+        }]);
+      }
+      const sessionMatch = pathname === '/session/status'
+        ? null
+        : pathname.match(/^\/session\/([^/]+)(\/.*)?$/);
+      if (sessionMatch) {
+        const [, sessionId, suffix] = sessionMatch;
+        if (!goalsBySession.has(sessionId)) throw new Error(`Unexpected request: ${pathname}`);
+        if (suffix === undefined) {
+          if (init.method === 'PATCH') {
+            goalsBySession.set(sessionId, JSON.parse(init.body).metadata.openchamber.goal);
+          }
+          return jsonResponse({
+            ...session, id: sessionId, directory: DIRECTORY,
+            metadata: { openchamber: { goal: goalsBySession.get(sessionId) } },
+          });
+        }
+        if (suffix === '/children') return jsonResponse([]);
+        if (suffix === '/message') return jsonResponse([messageFor(sessionId)]);
+        if (suffix === '/prompt_async') {
+          promptTargets.push(sessionId);
+          return new Response(null, { status: 204 });
+        }
+      }
+      if (pathname === '/session/status') {
+        return jsonResponse({ [STALE_SESSION_ID]: { type: 'idle' }, [SESSION_ID]: { type: 'idle' } });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    }));
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      maxStartupRecoveryAttempts: 0,
+    });
+
+    const first = runtime.start({ listDirectories: async () => [DIRECTORY] });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(sessionListCalls).toBe(1);
+    const second = runtime.start({ listDirectories: async () => [DIRECTORY], resetRetryWindow: true });
+    gate.resolve();
+    await first;
+    await second;
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(sessionListCalls).toBe(2);
+    expect(promptTargets).toEqual([SESSION_ID]);
+    expect(goalsBySession.get(SESSION_ID)).toMatchObject({ status: 'active', turnsUsed: 2 });
+    expect(goalsBySession.get(STALE_SESSION_ID)).toMatchObject({ status: 'active', turnsUsed: 1 });
     runtime.stop();
   });
 });

--- a/packages/web/server/lib/session-goal/runtime.test.js
+++ b/packages/web/server/lib/session-goal/runtime.test.js
@@ -34,12 +34,30 @@ const flushMicrotasks = async () => {
   await Promise.resolve();
 };
 
+// Fake timers replace the global timers. Capture the real setImmediate at
+// module load so a test can drain the current macrotask/microtask chain
+// without advancing the fake clock. This is one event-loop turn, not a sleep.
+const realSetImmediate = globalThis.setImmediate;
+const flushEventLoop = () => new Promise((resolve) => realSetImmediate(resolve));
+
+// vi.waitFor polls with real timers and advances the fake clock by the poll
+// interval on every check, which can fire timers the test did not intend.
+// Pump only fake timers and microtasks until the barrier condition holds.
+const pumpUntil = async (condition, iterations = 8) => {
+  for (let pump = 0; pump < iterations && !condition(); pump += 1) {
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+  }
+};
+
 const deferred = () => {
   let resolve;
-  const promise = new Promise((resolvePromise) => {
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 };
 
 const startIdleTick = async (fetchImpl, options = {}) => {
@@ -568,7 +586,8 @@ describe('session goal live activity gate', () => {
     expect(emitGoalNotification).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     expect(currentGoal).toMatchObject({ status, statusReason });
     expect(patchAttempts).toBe(1);
     expect(promptAttempts).toBe(0);
@@ -1064,7 +1083,8 @@ describe('session goal live activity gate', () => {
     await vi.advanceTimersByTimeAsync(10);
     await flushMicrotasks();
 
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     expect(currentGoal).toMatchObject({
       status: 'blocked',
       statusReason: 'fetch retry limit reached',
@@ -1145,6 +1165,264 @@ describe('session goal live activity gate', () => {
     const requestsAfterExhaustion = fetchImpl.mock.calls.length;
     await vi.advanceTimersByTimeAsync(100);
     expect(fetchImpl.mock.calls).toHaveLength(requestsAfterExhaustion);
+    runtime.stop();
+  });
+
+  it('revives an exhausted terminalization fence on readiness and settles the goal', async () => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    let blockedAvailable = false;
+    const emitGoalNotification = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          if (!blockedAvailable) throw new Error('blocked write unavailable');
+          currentGoal = nextGoal;
+          return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      emitGoalNotification,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 1,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    // Parked: the bounded terminalization window exhausted with zero timers
+    // while the goal is still active.
+    expect(currentGoal.status).toBe('active');
+    expect(blockedWrites).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // OpenCode is ready again: the readiness edge must revive the same fence
+    // for one fresh bounded window instead of staying stranded.
+    blockedAvailable = true;
+    await runtime.start({ listDirectories: async () => [], resetRetryWindow: true });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'fetch retry limit reached' });
+    expect(blockedWrites).toBe(3);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(blockedWrites).toBe(3);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    runtime.stop();
+  });
+
+  it('re-parks a revived terminalization fence when settlement fails again', async () => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        blockedWrites += 1;
+        throw new Error('blocked write unavailable');
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 1,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+    expect(blockedWrites).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Revival with the terminal write still unavailable runs one fresh bounded
+    // window, then parks again instead of looping forever.
+    await runtime.start({ listDirectories: async () => [], resetRetryWindow: true });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(currentGoal.status).toBe('active');
+    expect(blockedWrites).toBe(4);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(blockedWrites).toBe(4);
+    expect(vi.getTimerCount()).toBe(0);
+    runtime.stop();
+  });
+
+  it('revives an exhausted terminalization fence when the feature is re-enabled', async () => {
+    let currentGoal = { ...goal, updatedAt: 1 };
+    let enabled = true;
+    let statusFailures = 0;
+    let blockedWrites = 0;
+    let blockedAvailable = false;
+    const emitGoalNotification = vi.fn();
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'blocked') {
+          blockedWrites += 1;
+          if (!blockedAvailable) throw new Error('blocked write unavailable');
+          currentGoal = nextGoal;
+          return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+        }
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        if (statusFailures < 3) {
+          statusFailures += 1;
+          return jsonResponse({ error: 'unavailable' }, 503);
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: vi.fn(),
+      emitGoalNotification,
+      isEnabled: () => enabled,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxRetryAttempts: 1,
+    });
+
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 1 }, metadata: { openchamber: { goal: currentGoal } } } },
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+    expect(currentGoal.status).toBe('active');
+    expect(blockedWrites).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Disable then re-enable: the re-enable edge revives the fence and settles
+    // once the terminal write is available again.
+    enabled = false;
+    runtime.onSettingsChanged();
+    enabled = true;
+    blockedAvailable = true;
+    runtime.onSettingsChanged();
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'fetch retry limit reached' });
+    expect(blockedWrites).toBe(3);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(blockedWrites).toBe(3);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     runtime.stop();
   });
 
@@ -1881,6 +2159,219 @@ describe('session goal live activity gate', () => {
     runtime.stop();
   });
 
+  it('discards a stale abort when a first goal arrives after the pause read fails', async () => {
+    vi.setSystemTime(1_000);
+    const newGoal = {
+      ...goal,
+      id: 'goal_new',
+      objective: 'New task',
+      turnsUsed: 0,
+      createdAt: 2_000,
+      updatedAt: 2_000,
+    };
+    let currentGoal = newGoal;
+    let sessionReads = 0;
+    let pauseWrites = 0;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        const nextGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (nextGoal.status === 'paused') pauseWrites += 1;
+        currentGoal = nextGoal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        // The abort-time pause read fails once; authoritative reads return
+        // the current goal afterwards.
+        if (sessionReads === 1) throw new Error('transient session read failure');
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+
+    // The abort finds no goal because the pause read fails, and the session
+    // had no prior goal tracking. Drain the abort chain (no timer advance) so
+    // the session is genuinely idle when the first goal appears.
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    }, DIRECTORY);
+    await flushEventLoop();
+    expect(pauseWrites).toBe(0);
+
+    // A first goal is neither a "fresh goal" (no previous snapshot) nor
+    // "during work"; the stale stop must not pause it.
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 2_000 }, metadata: { openchamber: { goal: newGoal } } } },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(pauseWrites).toBe(0);
+    expect(currentGoal).toMatchObject({ id: newGoal.id, status: 'active' });
+    expect(promptAttempts).toBeGreaterThanOrEqual(1);
+    runtime.stop();
+  });
+
+  it('drops a failed-read abort after an authoritative no-goal tick', async () => {
+    vi.setSystemTime(1_000);
+    const newGoal = {
+      ...goal,
+      id: 'goal_new',
+      objective: 'New task',
+      turnsUsed: 0,
+      createdAt: 2_000,
+      updatedAt: 2_000,
+    };
+    let currentGoal = null;
+    let sessionReads = 0;
+    let pauseWrites = 0;
+    let promptAttempts = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { completed: 2 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'paused') pauseWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 1) throw new Error('transient session read failure');
+        // No goal exists yet: the namespace is present, the key is absent.
+        if (!currentGoal) return jsonResponse({ ...session, metadata: { openchamber: {} } });
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      kickoffQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    }, DIRECTORY);
+    // Let the failed pause read retry on its failure-armed tick; the
+    // authoritative response has no goal, so the pending abort must not linger.
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+    expect(pauseWrites).toBe(0);
+    expect(promptAttempts).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+
+    currentGoal = newGoal;
+    runtime.processPayload({
+      type: 'session.updated',
+      properties: { info: { ...session, time: { updated: 2_000 }, metadata: { openchamber: { goal: newGoal } } } },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+    expect(pauseWrites).toBe(0);
+    expect(currentGoal).toMatchObject({ id: newGoal.id, status: 'active' });
+    expect(promptAttempts).toBeGreaterThanOrEqual(1);
+    runtime.stop();
+  });
+
+  it('still pauses the aborted goal when the pause read fails but the goal is unchanged', async () => {
+    vi.setSystemTime(1_000);
+    const abortedGoal = { ...goal, createdAt: 1, updatedAt: 1 };
+    let currentGoal = abortedGoal;
+    let sessionReads = 0;
+    let pauseWrites = 0;
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'paused') pauseWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        sessionReads += 1;
+        if (sessionReads === 1) throw new Error('transient session read failure');
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) throw new Error('must not dispatch');
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn() }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { role: 'assistant', sessionID: SESSION_ID, error: { name: 'MessageAbortedError' } } },
+    }, DIRECTORY);
+    await flushMicrotasks();
+    expect(pauseWrites).toBe(0);
+
+    // The failure-armed retry tick observes the same active goal, whose
+    // creation predates the abort, so stop semantics still apply.
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(pauseWrites).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'paused', statusReason: 'paused after abort' });
+    runtime.stop();
+  });
+
   it('invalidates an in-flight audit when busy status arrives', async () => {
     const audit = deferred();
     const requests = [];
@@ -2586,6 +3077,82 @@ describe('session goal live activity gate', () => {
     runtime.stop();
   });
 
+  it('runs exactly one follow-up tick when an external idle arrives during a tick', async () => {
+    const auditGate = deferred();
+    let auditCalls = 0;
+    let promptAttempts = 0;
+    let currentGoal = { ...goal, lastAccountedMessageID: '' };
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => {
+        auditCalls += 1;
+        if (auditCalls === 1) return auditGate.promise;
+        return {
+          text: '{"verdict":"complete","note":"Verified"}',
+          providerID: 'provider',
+          modelID: 'model',
+        };
+      }) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const idle = {
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    };
+
+    // Tick #1 starts and parks inside the audit barrier.
+    runtime.processPayload(idle);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(auditCalls).toBe(1);
+
+    // An authoritative external idle event arrives while the tick is in
+    // flight; it must be remembered as a pending arm, not dropped.
+    runtime.processPayload(idle);
+    expect(vi.getTimerCount()).toBe(0);
+
+    auditGate.resolve({ text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model' });
+    await vi.runOnlyPendingTimersAsync();
+    await vi.runOnlyPendingTimersAsync();
+    await flushMicrotasks();
+
+    // Exactly one follow-up tick ran: it audited and settled the goal.
+    expect(auditCalls).toBe(2);
+    expect(promptAttempts).toBe(1);
+    expect(currentGoal).toMatchObject({ status: 'complete' });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(auditCalls).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+    runtime.stop();
+  });
+
   it('replaces an existing idle timer with the explicit resume kickoff', async () => {
     const paths = [];
     const fetchImpl = vi.fn(async (input) => {
@@ -2777,8 +3344,8 @@ describe('session goal live activity gate', () => {
     expect(dispatchAttempts).toBe(0);
     expect(currentGoal).toMatchObject({ turnsUsed: 2, lastAccountedMessageID: 'msg_assistant' });
 
-    await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(dispatchAttempts).toBe(1));
+    await pumpUntil(() => dispatchAttempts >= 1);
+    expect(dispatchAttempts).toBe(1);
     expect(requests.filter((request) => request.method === 'PATCH')).toHaveLength(1);
     expect(service.generateSmallModelText).toHaveBeenCalledOnce();
     runtime.stop();
@@ -2839,12 +3406,14 @@ describe('session goal live activity gate', () => {
       type: 'session.status',
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
+    // The accepted-but-lost accounting PATCH and the lost prompt response each
+    // arm bounded retries; pump fake timers until the settlement completes
+    // instead of racing a real-time poll against newly armed timers.
+    await pumpUntil(() => currentGoal.status === 'blocked');
     await vi.runOnlyPendingTimersAsync();
-    expect(patchAttempts).toBe(1);
-    expect(currentGoal.turnsUsed).toBe(2);
+    await flushMicrotasks();
 
-    await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(dispatchAttempts).toBe(1));
+    expect(dispatchAttempts).toBe(1);
     expect(patchAttempts).toBe(2);
     expect(currentGoal).toMatchObject({ status: 'blocked', statusReason: 'continuation admission unresolved' });
     runtime.stop();
@@ -3001,12 +3570,19 @@ describe('session goal live activity gate', () => {
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
     await vi.runOnlyPendingTimersAsync();
-    // The first tick persists accounting (turns 1 -> 2) before the missing
-    // provider/model dispatch fails. Wait for that write so the bounded
-    // dispatch retry is armed before advancing: a fixed microtask flush
-    // cannot drain this multi-fetch chain deterministically.
-    await vi.waitFor(() => expect(patchWrites).toBeGreaterThanOrEqual(1));
-    await vi.advanceTimersByTimeAsync(10);
+    // Drive both bounded configuration attempts without real-time waitFor
+    // polling: pump fake timers and microtasks until the second attempt's
+    // guarded rollback write is observed. The deferred rollback response is
+    // the deterministic barrier; a fixed microtask flush cannot drain the
+    // multi-fetch chain, and real-time polling advances the clock arbitrarily.
+    let rollbackStarted = false;
+    rollbackPatchStarted.promise.then(() => {
+      rollbackStarted = true;
+    });
+    for (let pump = 0; pump < 6 && !rollbackStarted; pump += 1) {
+      await vi.runOnlyPendingTimersAsync();
+      await flushMicrotasks();
+    }
     // The bounded retry exhausts maxDispatchAttempts and rolls the
     // undispatched charge back (turns 2 -> 1).
     await rollbackPatchStarted.promise;
@@ -3054,6 +3630,260 @@ describe('session goal live activity gate', () => {
     await vi.advanceTimersByTimeAsync(10);
     expect(promptAttempts).toBe(1);
     expect(patchWrites).toBe(settledPatchWrites + 1);
+    runtime.stop();
+  });
+
+  it('ignores a dispatch failure whose reservation was invalidated while in flight', async () => {
+    vi.setSystemTime(1_000);
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    let blockedWrites = 0;
+    const postStarted = deferred();
+    const postResponse = deferred();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        postStarted.resolve();
+        return postResponse.promise;
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    const pumpUntil = async (condition, iterations = 8) => {
+      for (let pump = 0; pump < iterations && !condition(); pump += 1) {
+        await vi.runOnlyPendingTimersAsync();
+        await flushMicrotasks();
+      }
+    };
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await pumpUntil(() => promptAttempts >= 1);
+    await postStarted.promise;
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+
+    // A genuinely newer user message invalidates the in-flight reservation and
+    // advances the generation before the POST fails.
+    runtime.processPayload({
+      type: 'message.updated',
+      properties: { info: { id: 'msg_user_new', sessionID: SESSION_ID, role: 'user', time: { created: 1_010 } } },
+    });
+    postResponse.reject(new Error('transport lost after invalidation'));
+    await flushEventLoop();
+    await flushEventLoop();
+
+    // The removed reservation's failure must not crash the dispatch handler,
+    // settle the goal, or arm bogus work.
+    const tickFailures = warn.mock.calls.filter(([message]) => String(message).includes('tick failed'));
+    expect(tickFailures).toHaveLength(0);
+    expect(blockedWrites).toBe(0);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+
+    const requestsAfterFailure = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterFailure);
+    expect(promptAttempts).toBe(1);
+    warn.mockRestore();
+    runtime.stop();
+  });
+
+  it('keeps a rejected dispatch outcome across a transient pre-POST read failure', async () => {
+    let currentGoal = { ...goal, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    let blockedWrites = 0;
+    let transientReadFailed = false;
+    let failPrePostRead = false;
+    let lastPathname = '';
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        lastPathname = pathname;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        // The pre-POST read follows the final tail read. Fail it once, like a
+        // transient network error on a GET, after the first POST rejection.
+        if (failPrePostRead && !transientReadFailed && lastPathname === `/session/${SESSION_ID}/message`) {
+          transientReadFailed = true;
+          lastPathname = pathname;
+          throw new Error('transient session read failure');
+        }
+        lastPathname = pathname;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      lastPathname = pathname;
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        if (promptAttempts === 1) failPrePostRead = true;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+    const pumpUntil = async (condition, iterations = 8) => {
+      for (let pump = 0; pump < iterations && !condition(); pump += 1) {
+        await vi.runOnlyPendingTimersAsync();
+        await flushMicrotasks();
+      }
+    };
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await pumpUntil(() => transientReadFailed);
+    expect(transientReadFailed).toBe(true);
+
+    // A pre-POST read failure carries no admission: it must not overwrite the
+    // proven rejected outcome, settle the goal, or skip the rollback window.
+    // Drain microtasks without advancing timers so the retry stays pending.
+    await flushEventLoop();
+
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
+    expect(blockedWrites).toBe(0);
+
+    // Once the bounded dispatch window closes, the undispatched charge is
+    // rolled back and the goal settles blocked with restored accounting.
+    await pumpUntil(() => currentGoal.status === 'blocked');
+    expect(promptAttempts).toBe(2);
+    expect(blockedWrites).toBe(1);
+    expect(currentGoal).toMatchObject({
+      status: 'blocked',
+      turnsUsed: 1,
+      tokensUsed: 0,
+      lastAccountedMessageID: '',
+    });
+    runtime.stop();
+  });
+
+  it('settles a rejected reservation as budgetLimited instead of redispatching over budget', async () => {
+    let currentGoal = { ...goal, tokenBudget: 100, turnsUsed: 1, lastAccountedMessageID: '' };
+    let promptAttempts = 0;
+    let blockedWrites = 0;
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 5, output: 5, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        if (currentGoal.status === 'blocked') blockedWrites += 1;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return jsonResponse({ error: 'dispatch rejected' }, 400);
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      isEnabled: () => true,
+      idleQuietMs: 10,
+      retryDelaysMs: [10],
+      maxDispatchAttempts: 2,
+    });
+    const pumpUntil = async (condition, iterations = 8) => {
+      for (let pump = 0; pump < iterations && !condition(); pump += 1) {
+        await vi.runOnlyPendingTimersAsync();
+        await flushMicrotasks();
+      }
+    };
+
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await pumpUntil(() => promptAttempts >= 1);
+    expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2, tokensUsed: 10 });
+
+    // The user shrinks the budget below the persisted usage while the rejected
+    // reservation waits for its bounded redispatch.
+    currentGoal = { ...currentGoal, tokenBudget: 3 };
+    await pumpUntil(() => currentGoal.status === 'budgetLimited');
+
+    expect(promptAttempts).toBe(1);
+    expect(blockedWrites).toBe(0);
+    expect(currentGoal).toMatchObject({
+      status: 'budgetLimited',
+      statusReason: 'token budget reached',
+      turnsUsed: 2,
+      tokensUsed: 10,
+    });
+    const requestsAfterSettlement = fetchImpl.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchImpl.mock.calls).toHaveLength(requestsAfterSettlement);
+    expect(promptAttempts).toBe(1);
     runtime.stop();
   });
 
@@ -4950,14 +5780,15 @@ describe('session goal live activity gate', () => {
     await flushMicrotasks();
 
     expect(promptAttempts).toBe(0);
-    await vi.waitFor(() => expect(currentGoal).toMatchObject({
+    await pumpUntil(() => currentGoal.status === 'paused');
+    expect(currentGoal).toMatchObject({
       status: 'paused',
       turnsUsed: 1,
       tokensUsed: 7,
       tokensBaseline: 2,
       tokensCommitted: 3,
       lastAccountedMessageID: 'msg_before',
-    }));
+    });
     runtime.stop();
   });
 
@@ -5066,7 +5897,8 @@ describe('session goal live activity gate', () => {
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
     await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(currentGoal).toMatchObject({ turnsUsed: 1, tokensUsed: 7 }));
+    await pumpUntil(() => currentGoal.turnsUsed === 1 && currentGoal.tokensUsed === 7);
+    expect(currentGoal).toMatchObject({ turnsUsed: 1, tokensUsed: 7 });
 
     expect(promptAttempts).toBe(0);
   });
@@ -5130,11 +5962,12 @@ describe('session goal live activity gate', () => {
       properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
     });
     await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(currentGoal).toMatchObject({
+    await pumpUntil(() => currentGoal.id === 'goal_replacement' && currentGoal.status === 'blocked');
+    expect(currentGoal).toMatchObject({
       id: 'goal_replacement',
       status: 'blocked',
       statusReason: 'continuation reservation could not be reconciled',
-    }));
+    });
 
     expect(promptAttempts).toBe(0);
     runtime.stop();
@@ -5536,7 +6369,8 @@ describe('session goal live activity gate', () => {
     await vi.runOnlyPendingTimersAsync();
     await flushMicrotasks();
     expect(dispatchAttempts).toBe(2);
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     expect(currentGoal.status).toBe('blocked');
     expect(blockedWrites).toBe(1);
     expect(emitGoalNotification).toHaveBeenCalledOnce();
@@ -5606,7 +6440,8 @@ describe('session goal live activity gate', () => {
     expect(currentGoal).toMatchObject({ status: 'active', turnsUsed: 2 });
 
     await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
     expect(dispatchAttempts).toBe(2);
     expect(currentGoal).toMatchObject({
       status: 'blocked',
@@ -5690,7 +6525,8 @@ describe('session goal live activity gate', () => {
     await vi.runOnlyPendingTimersAsync();
     expect(dispatchAttempts).toBe(1);
     await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
 
     expect(rollbackAttempts).toBe(1);
     expect(blockedWrites).toBe(1);
@@ -5766,7 +6602,8 @@ describe('session goal live activity gate', () => {
     runtime.processPayload(idle);
     await vi.advanceTimersByTimeAsync(10);
     await vi.advanceTimersByTimeAsync(10);
-    await vi.waitFor(() => expect(emitGoalNotification).toHaveBeenCalledOnce());
+    await pumpUntil(() => emitGoalNotification.mock.calls.length > 0);
+    expect(emitGoalNotification).toHaveBeenCalledOnce();
 
     expect(dispatchAttempts).toBe(2);
     expect(blockedWrites).toBe(1);
@@ -6932,6 +7769,77 @@ describe('session goal live activity gate', () => {
     expect(objectiveReads).toBe(3);
     expect(patchAttempts).toBe(0);
     expect(currentGoal.status).toBe('active');
+    runtime.stop();
+  });
+
+  it('rechecks the file objective after the final status fetch before dispatching', async () => {
+    let currentGoal = { ...goal, objective: '', objectiveFile: true, lastAccountedMessageID: '' };
+    let fileObjective = 'Original objective';
+    let statusCalls = 0;
+    let promptAttempts = 0;
+    const finalStatusStarted = deferred();
+    const finalStatusGate = deferred();
+    const assistant = {
+      info: {
+        id: 'msg_assistant', sessionID: SESSION_ID, role: 'assistant', providerID: 'provider', modelID: 'model',
+        time: { created: 2, completed: 3 }, tokens: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: 'text', text: 'More work remains.' }],
+    };
+    readGoalObjective.mockImplementation(async () => fileObjective);
+    const fetchImpl = vi.fn(async (input, init = {}) => {
+      const pathname = requestPath(input);
+      if (pathname === `/session/${SESSION_ID}` && init.method === 'PATCH') {
+        currentGoal = JSON.parse(init.body).metadata.openchamber.goal;
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === `/session/${SESSION_ID}`) {
+        return jsonResponse({ ...session, metadata: { openchamber: { goal: currentGoal } } });
+      }
+      if (pathname === '/session/status') {
+        statusCalls += 1;
+        if (statusCalls === 3) {
+          // The final admission status fetch: hold it open while the
+          // objective file changes underneath the tick.
+          finalStatusStarted.resolve();
+          return finalStatusGate.promise;
+        }
+        return jsonResponse({ [SESSION_ID]: { type: 'idle' } });
+      }
+      if (pathname === `/session/${SESSION_ID}/children`) return jsonResponse([]);
+      if (pathname === `/session/${SESSION_ID}/message`) return jsonResponse([assistant]);
+      if (pathname === `/session/${SESSION_ID}/prompt_async`) {
+        promptAttempts += 1;
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${pathname} ${init.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchImpl);
+    const runtime = createSessionGoalRuntime({
+      buildOpenCodeUrl: (pathname) => `http://opencode.test${pathname}`,
+      getOpenCodeAuthHeaders: () => ({}),
+      getSmallModelService: async () => ({ generateSmallModelText: vi.fn(async () => ({
+        text: '{"verdict":"continue","note":"More work remains"}', providerID: 'provider', modelID: 'model',
+      })) }),
+      readGoalObjective,
+      isEnabled: () => true,
+      idleQuietMs: 10,
+    });
+    runtime.processPayload({
+      type: 'session.status',
+      properties: { sessionID: SESSION_ID, status: { type: 'idle' }, directory: DIRECTORY },
+    });
+    await vi.runOnlyPendingTimersAsync();
+    await finalStatusStarted.promise;
+
+    // The user edits the objective file while the final status fetch is open.
+    fileObjective = 'Edited objective';
+    finalStatusGate.resolve(jsonResponse({ [SESSION_ID]: { type: 'idle' } }));
+    await flushEventLoop();
+    await flushEventLoop();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(promptAttempts).toBe(0);
     runtime.stop();
   });
 });


### PR DESCRIPTION
## Intent

Fixes #3279. The Session Goal runtime could strand an active goal, dispatch stale work after explicit user intent, lose wakeups, or double-count after partial failures. This PR hardens the server-side lifecycle and keeps the #3278 length-recovery contract intact.

Built on `main` at `c498beaa` (#3437). The original rebuild commit is `4319f1bd`; the final hardening commit is `b2ac18dd`.

## Scope

Server-side Session Goal lifecycle correctness only.

- **Bounded retry with explicit terminal settlement.** Fetch and quiet failures retry at most 4 times with exponential backoff. On exhaustion the runtime re-reads the authoritative goal and settles an active goal as `blocked`, never a blind continuation.
- **Restart recovery.** One-shot scan over all known directories (MRU-first from `lastDirectory` plus `projects` by `lastOpenedAt`), bounded concurrency (3), per-directory isolation, 10s timeouts, bounded retry, epoch-superseded overlapping scans. The startup scan is fire-and-forget. A protocol-neutral `onOpenCodeReady` edge retries recovery with a fresh bounded window. No permanent polling.
- **Stale work and user intent.** Stop/abort, Pause, Clear, Complete, goal replacement/edit, and newer user activity invalidate stale scheduled or in-flight work. A same-message abort is handled without depending on the message ID. A pending abort is bound to the goal revision that was active when it arrived, so it cannot pause a newer goal.
- **Dispatch admission.** `prompt_async` outcomes are classified from the POST attempt only. A proven pre-admission failure retries boundedly, known admission is never re-POSTed, ambiguous admission settles safely, and explicit rejection rolls back accounting and settles `blocked`. Rollback-response loss and status-event races are reconciled against authoritative state.
- **Accounting.** `turnsUsed` increments once per admitted continuation. Stale, dropped, or pre-admission work rolls back through guarded, idempotent writes. Terminal settlement is idempotent across PATCH responses and authoritative `session.updated` events. Token budget and `maxAutoTurns` stay separate hard stops, and the budget is re-checked before redispatching a pending reservation.
- **Chronology.** Completed turns use finite `time.created`, never opaque IDs. Equal or missing timestamps keep API order. Reasoning and cache-write tokens are included in the authoritative total. Compaction segmentation and monotonic accounting are unchanged.
- **Strict settings.** Array-shaped or malformed payloads reject instead of masquerading as empty success. Lenient reads keep their behavior.
- **Readiness hook.** `onOpenCodeReady` fires on each not-ready to ready transition. `index.js` uses it to retry bounded Session Goal recovery after the fire-and-forget startup scan. It consumes readiness state and is not an OpenCode lifecycle implementation.

## Non-goals

- No OpenCode V2 lifecycle ownership: no opencode2 discovery, `service start`, `Service.discover()`, shared-service ownership, V2 auth/health/reconnect/SSE, or protocol adapters. #3007 owns that infrastructure.
- No changes to #3007 or #3424.
- No UI behavior changes.
- No new dependencies, persisted schema fields, migrations, or public API changes.

## Validation (final candidate `b2ac18dd`)

| Check | Result |
|---|---|
| `bunx vitest run server/lib/session-goal/runtime.test.js` | 170 passed, 0 failed, 8 of 8 consecutive runs. The old `4319f1bd` head had a timing-dependent flake; `vi.waitFor` polling is gone, replaced by fake-timer pumps and promise barriers. |
| `bunx vitest run server/lib/session-goal/` | 173 passed |
| `bunx vitest run server/lib/opencode/lifecycle.test.js server/lib/opencode/settings-runtime.test.js` | 44 passed, 1 skipped |
| `node --check` on changed JS | Passed |
| `bun run type-check:web` | Passed |
| `bun run lint:web` | Passed |
| `bunx oxlint` on changed JS | 45 pre-existing anti-slop findings in `runtime.js` (43 `no-runtime-typeof`, 2 `no-conditional-empty-object-spread`), identical count and classes to the pre-fix head, no new findings |
| `bun run docs:validate` | Passed, 517 pages, 47 sidebar links |
| `git diff --check` | Passed |
| Remote `pr checks` | Two runs on this SHA failed on unrelated flaky tests in packages this PR does not touch: `packages/ui/src/components/views/useFilePreviewScrollPosition.test.tsx` (about 4/33 failures on pristine `main` `961f1611c`) and, on the `ready_for_review` rerun, `packages/vscode/webview/api/settings.test.ts` (also failing on unrelated branches the same day). Rerunning upstream jobs needs upstream repository rights. |
| Fresh-main merge gate | Clean merge with `main` at `961f1611c`; the merged tree passed 170 session-goal tests, lifecycle/settings 49 passed + 1 skipped, `node --check`, type-check, and lint. The PR is not rebased; the gate checks compatibility only. |

## Risks and failure behavior

- Runtime-local CAS cannot atomically join an external UI or separate process PATCH. That cross-process limit is documented.
- A hard crash after accounting persistence but before dispatch cannot be exactly-once without a persisted reservation schema. The restart hold prevents re-counting and blind duplicate dispatch and waits for a new tail or explicit Resume.
- If admission cannot be proven, the goal settles `blocked` instead of risking a duplicate provider execution.
- The abort-time fallback for sessions with no known goal identity compares `goal.createdAt` with the abort arrival. A goal created in the same millisecond could still match; identity binding covers every tracked path.
- The budget hard stop settles `budgetLimited` with the reservation accounting intact. The rejected-dispatch path rolls its charge back. Both are terminal and monotonic.
- The restart scan fetches at most 400 root sessions per directory. "Logically complete" means every known directory, not exhaustive pagination. An older active goal beyond that page is recovered by a later event.
- Rollback: revert the two commits.
