### PR TITLE
feat(questions): read pending questions via native V2 in directory bootstrap

### DIFF
--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 type QuestionFixture = {
   id: string;
@@ -58,6 +58,7 @@ const makeV1ListResult = (items: QuestionFixture[]) => ({
 
 type V2Response =
   | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'v2-404' }
   | { kind: 'server-error' }
   | { kind: 'throw' };
 
@@ -80,6 +81,8 @@ const questionV2ListMock = mock((args?: { location?: { directory?: string } }) =
         // violates the QuestionFixture contract; the parser under test must
         // reject it.
         resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else if (r.kind === 'v2-404') {
+        resolve(makeV2ErrorResult(404));
       } else {
         resolve(makeV2ErrorResult(500));
       }
@@ -137,7 +140,13 @@ mock.module('@/lib/startupTrace', () => ({
   markStartupTrace: mock(() => undefined),
 }));
 
-const { opencodeClient } = await import(`./client?cache-test-questions=${Date.now()}`);
+const { opencodeClient, resetQuestionsV2FallbackWarningsForTests } = await import(`./client?cache-test-questions=${Date.now()}`);
+
+const consoleWarnCalls: string[] = [];
+const consoleWarnSpy = mock((message: string) => {
+  consoleWarnCalls.push(message);
+});
+const originalConsoleWarn = console.warn;
 
 const resolveV2Calls = (responses: V2Response[]) => {
   queueMicrotask(() => {
@@ -153,6 +162,13 @@ beforeEach(() => {
   v2ListArgs.length = 0;
   v1ListArgs.length = 0;
   v1ListResult = makeV1ListResult([]);
+  resetQuestionsV2FallbackWarningsForTests();
+  consoleWarnCalls.length = 0;
+  console.warn = consoleWarnSpy;
+});
+
+afterEach(() => {
+  console.warn = originalConsoleWarn;
 });
 
 describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
@@ -192,6 +208,40 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
 
     expect(result).toEqual([v1Question]);
     expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+  });
+
+  test('falls back to V1 on V2 404 route-miss without console.warn (pre-V2 compat path)', async () => {
+    const v1Question = makeQuestion('v1notfound');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'v2-404' },
+      { kind: 'v2-404' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+    expect(consoleWarnCalls).toEqual([]);
+  });
+
+  test('falls back to V1 on V2 network throw with a single stable-marker warn', async () => {
+    const v1Question = makeQuestion('v1net2');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'throw' },
+      { kind: 'throw' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('network-error');
+    expect(consoleWarnCalls[0]).toContain('falling back to V1');
   });
 
   test('falls back to V1 when the V2 SDK call throws (network failure)', async () => {
@@ -260,6 +310,29 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
     expect(result).toEqual([v1Question, scopedQuestion]);
     expect(v1ListArgs).toEqual([undefined]);
     expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('falls back to V1 with a warn when a 200 V2 payload is malformed (contract drift)', async () => {
+    // SAFETY: the malformed-payload test intentionally feeds a payload that
+    // violates the V2 contract; the reader under test must reject it.
+    const v1Question = makeQuestion('v1drift');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Same-version contract drift: the 200 envelope is valid, but the item
+      // itself is not — `questions` carries a string instead of the option
+      // array. Typed as `unknown` at the mock boundary on purpose.
+      { kind: 'ok', items: [{ ...makeQuestion('q-drift'), questions: 'missing' }] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('malformed-payload');
   });
 
   test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -56,8 +56,36 @@ const makeV1ListResult = (items: QuestionFixture[]) => ({
   response: new Response(null, { status: 200 }),
 });
 
+/**
+ * A closed set of non-array payload shapes the contract-drift test feeds.
+ * The reader under test only checks `Array.isArray(response.data?.data)`,
+ * so any non-array value triggers the warn-and-fall-back path. The closed
+ * union is intentional: this test is the parser-of-last-resort for the
+ * wire drift, not a generic value passthrough.
+ */
+type NonArrayPayload =
+  | { readonly tag: 'object' }
+  | null
+  | string
+  | number
+  | boolean;
+
+/**
+ * Build a 200 success result whose `data.data` is NOT an item array. This is
+ * the same-version contract-drift case where the typed SDK path no longer
+ * matches the wire envelope — the reader under test must reject it
+ * conservatively (warn once, fall back to V1).
+ */
+const makeV2NonArrayPayloadResult = (payload: NonArrayPayload) => ({
+  data: { data: payload },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
 type V2Response =
   | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'non-array-payload'; payload: unknown }
   | { kind: 'v2-404' }
   | { kind: 'server-error' }
   | { kind: 'throw' };
@@ -81,6 +109,14 @@ const questionV2ListMock = mock((args?: { location?: { directory?: string } }) =
         // violates the QuestionFixture contract; the parser under test must
         // reject it.
         resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else if (r.kind === 'non-array-payload') {
+        // SAFETY: the contract-drift test intentionally feeds a 200 status
+        // whose `data.data` is not an item array; the reader under test
+        // must reject it (warn once, fall back to V1). `r.payload` is
+        // intentionally typed `unknown` in the discriminator (any non-array
+        // value is valid here), so we narrow it to the closed
+        // `NonArrayPayload` union at the helper boundary by construction.
+        resolve(makeV2NonArrayPayloadResult(r.payload as NonArrayPayload));
       } else if (r.kind === 'v2-404') {
         resolve(makeV2ErrorResult(404));
       } else {
@@ -324,6 +360,31 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
       // itself is not — `questions` carries a string instead of the option
       // array. Typed as `unknown` at the mock boundary on purpose.
       { kind: 'ok', items: [{ ...makeQuestion('q-drift'), questions: 'missing' }] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(consoleWarnCalls.length).toBe(1);
+    expect(consoleWarnCalls[0]).toContain('[questions-v2]');
+    expect(consoleWarnCalls[0]).toContain('malformed-payload');
+  });
+
+  test('falls back to V1 with a warn when a 200 V2 payload is not an item array (contract drift)', async () => {
+    // SAFETY: the contract-drift test intentionally feeds a 200 status whose
+    // `data.data` is NOT an array (here: a bare object). The reader under
+    // test must reject it conservatively (warn once, fall back to V1) and
+    // must NOT treat it as an empty success.
+    const v1Question = makeQuestion('v1driftna');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Same-version contract drift: the 200 envelope is valid, but the
+      // payload the reader expects (an item array) is replaced by a plain
+      // object literal, satisfying the closed `NonArrayPayload` union.
+      { kind: 'non-array-payload', payload: { tag: 'object' } },
       { kind: 'ok', items: [] },
     ]);
     const result = await promise;

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type QuestionFixture = {
+  id: string;
+  sessionID: string;
+  questions: Array<{
+    question: string;
+    header: string;
+    options: Array<{ label: string; description: string }>;
+    multiple?: boolean;
+  }>;
+  tool?: { messageID: string; callID: string };
+};
+
+const makeQuestion = (id: string, overrides?: Partial<QuestionFixture>): QuestionFixture => ({
+  id,
+  sessionID: `ses_${id}`,
+  questions: [
+    {
+      question: `${id}: proceed with the plan?`,
+      header: 'Build',
+      options: [
+        { label: 'Yes', description: 'Proceed' },
+        { label: 'No', description: 'Cancel' },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+/**
+ * Build a HeyApi success result matching the wrapper's V2 expectations:
+ *   - error === undefined (success branch)
+ *   - data.data === the item array (200 status payload nests the list
+ *     under its own `data` field, same as session.permission.*)
+ *   - response.status === 200
+ */
+const makeV2SuccessResult = (items: QuestionFixture[]) => ({
+  data: { data: items },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+const makeV2ErrorResult = (status: number) => ({
+  data: undefined,
+  error: { name: 'ServerError', data: { message: 'err' } },
+  request: new Request('http://test/'),
+  response: new Response(null, { status }),
+});
+
+const makeV1ListResult = (items: QuestionFixture[]) => ({
+  data: items,
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+type V2Response =
+  | { kind: 'ok'; items: QuestionFixture[] | unknown[] }
+  | { kind: 'server-error' }
+  | { kind: 'throw' };
+
+/**
+ * Calls arrive in listPendingQuestions' fixed order: unscoped first, then
+ * one call per unique normalized directory. Each test resolves every call
+ * it triggered, so index-order resolution is unambiguous.
+ */
+const v2PendingResolutions: Array<(r: V2Response) => void> = [];
+const v2ListArgs: Array<{ location?: { directory?: string } } | undefined> = [];
+
+const questionV2ListMock = mock((args?: { location?: { directory?: string } }) => {
+  v2ListArgs.push(args);
+  return new Promise<unknown>((resolve, reject) => {
+    v2PendingResolutions.push((r: V2Response) => {
+      if (r.kind === 'throw') {
+        reject(new Error('network down'));
+      } else if (r.kind === 'ok') {
+        // SAFETY: the malformed-item test intentionally feeds a payload that
+        // violates the QuestionFixture contract; the parser under test must
+        // reject it.
+        resolve(makeV2SuccessResult(r.items as QuestionFixture[]));
+      } else {
+        resolve(makeV2ErrorResult(500));
+      }
+    });
+  });
+});
+
+let v1ListResult: unknown = makeV1ListResult([]);
+const v1ListArgs: Array<{ directory?: string } | undefined> = [];
+
+const questionV1ListMock = mock((args?: { directory?: string }) => {
+  v1ListArgs.push(args);
+  return Promise.resolve(v1ListResult);
+});
+
+const createOpencodeClientMock = mock(() => ({
+  question: {
+    list: questionV1ListMock,
+  },
+  v2: {
+    question: {
+      request: {
+        list: questionV2ListMock,
+      },
+    },
+  },
+}));
+
+mock.module('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: createOpencodeClientMock,
+}));
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: mock(() => null),
+}));
+
+mock.module('@/lib/runtime-url', () => ({
+  getRuntimeUrlResolver: mock(() => ({
+    api: (path: string) => path,
+  })),
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: mock(() => ''),
+  getRuntimeKey: mock(() => 'test-runtime'),
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(async () => new Response(JSON.stringify([]), {
+    headers: { 'Content-Type': 'application/json' },
+  })),
+}));
+
+mock.module('@/lib/startupTrace', () => ({
+  markStartupTrace: mock(() => undefined),
+}));
+
+const { opencodeClient } = await import(`./client?cache-test-questions=${Date.now()}`);
+
+const resolveV2Calls = (responses: V2Response[]) => {
+  queueMicrotask(() => {
+    for (const [i, response] of responses.entries()) {
+      const resolver = v2PendingResolutions[i];
+      if (resolver) resolver(response);
+    }
+  });
+};
+
+beforeEach(() => {
+  v2PendingResolutions.length = 0;
+  v2ListArgs.length = 0;
+  v1ListArgs.length = 0;
+  v1ListResult = makeV1ListResult([]);
+});
+
+describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
+  test('maps V2 items 1:1, preserving unscoped + per-directory merge and id-dedupe', async () => {
+    // Same-id duplicate across the unscoped and per-directory results is
+    // deduped; the unscoped occurrence (first result) wins.
+    const globalQuestion = makeQuestion('q1', { tool: { messageID: 'msg_1', callID: 'call_1' } });
+    const duplicateQuestion = makeQuestion('q1');
+    const scopedQuestion = makeQuestion('q2', {
+      questions: [
+        { question: 'q2: pick one', header: 'Mode', options: [{ label: 'Fast', description: 'Fast' }], multiple: true },
+      ],
+    });
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'ok', items: [globalQuestion] },
+      { kind: 'ok', items: [duplicateQuestion, scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([globalQuestion, scopedQuestion]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+    expect(v1ListArgs).toEqual([]);
+  });
+
+  test('falls back to V1 per-directory results when every V2 call errors', async () => {
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'server-error' },
+      { kind: 'server-error' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+  });
+
+  test('falls back to V1 when the V2 SDK call throws (network failure)', async () => {
+    const v1Question = makeQuestion('v1net');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'throw' },
+      { kind: 'throw' },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question]);
+    expect(v1ListArgs).toEqual([undefined, { directory: '/repo' }]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('rejects the V2 attempt when any item is malformed and falls back conservatively', async () => {
+    // Malformed unscoped item (missing questions array) → whole V2 attempt
+    // for that call is rejected; V1 answers unscoped while the scoped V2
+    // call still succeeds per call.
+    const scopedQuestion = makeQuestion('v2q');
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      // Malformed unscoped item (missing questions array): the parser under
+      // test must reject it; V1 answers unscoped while the scoped V2 call
+      // still succeeds per call.
+      { kind: 'ok', items: [{ id: 'broken', sessionID: 'ses_broken' }] },
+      { kind: 'ok', items: [scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question, scopedQuestion]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
+  test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      { kind: 'ok', items: [] },
+      { kind: 'ok', items: [] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+    expect(v1ListArgs).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/opencode/client.questions.test.ts
+++ b/packages/ui/src/lib/opencode/client.questions.test.ts
@@ -233,6 +233,35 @@ describe('opencodeClient.listPendingQuestions (V2 read adoption)', () => {
     expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
   });
 
+  test('rejects the V2 attempt when a nested question entry is malformed and falls back conservatively', async () => {
+    // Valid top-level item, but its `questions` array contains a malformed
+    // entry (a bare string): the nested validation under test must reject
+    // the whole call; V1 answers unscoped while the scoped V2 call still
+    // succeeds per call.
+    const scopedQuestion = makeQuestion('v2q');
+    const v1Question = makeQuestion('v1q');
+    v1ListResult = makeV1ListResult([v1Question]);
+
+    const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
+    resolveV2Calls([
+      {
+        kind: 'ok',
+        items: [
+          // SAFETY: the malformed-item test intentionally feeds a payload
+          // that violates the QuestionFixture contract; the parser under
+          // test must reject it.
+          { ...makeQuestion('broken'), questions: ['not-a-question'] },
+        ],
+      },
+      { kind: 'ok', items: [scopedQuestion] },
+    ]);
+    const result = await promise;
+
+    expect(result).toEqual([v1Question, scopedQuestion]);
+    expect(v1ListArgs).toEqual([undefined]);
+    expect(v2ListArgs).toEqual([undefined, { location: { directory: '/repo' } }]);
+  });
+
   test('keeps the V2 unscoped + per-directory call pattern when V2 succeeds empty', async () => {
     const promise = opencodeClient.listPendingQuestions({ directories: ['/repo'] });
     resolveV2Calls([

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1,8 +1,6 @@
 import type { ContextPartMetadata } from '@/lib/messages/contextParts';
 import { createOpencodeClient, OpencodeClient } from "@opencode-ai/sdk/v2";
 import type { PermissionV2Request, PermissionV2Effect, PermissionV2Source } from "@opencode-ai/sdk/v2/client";
-import type { QuestionV2Request } from "@opencode-ai/sdk/v2/client";
-import { z } from 'zod';
 import type { FilesAPI } from "../api/types";
 import { getDesktopHomeDirectory } from "../desktop";
 import type {
@@ -19,6 +17,16 @@ import { isAmbiguousTransportFailure, markAmbiguousTransportFailure } from "@/li
 import { FilesystemError, parseFilesystemErrorReason } from "@/lib/api/files-errors";
 import type { PermissionRequest } from "@/types/permission";
 import type { QuestionRequest } from "@/types/question";
+
+import {
+  listPendingQuestionsViaV2,
+  resetQuestionsV2FallbackWarningsForTests,
+} from "./questions-v2";
+
+// Re-exported so existing callers (notably the V2 read test that destructures
+// `resetQuestionsV2FallbackWarningsForTests` from `./client`) keep working
+// after the helper moved into its own module.
+export { resetQuestionsV2FallbackWarningsForTests };
 
 /**
  * Tagged result of `OpencodeService.fetchPermission()`. The caller can
@@ -72,79 +80,6 @@ type SdkResult<T> = {
 };
 
 type DirectoryAvailability = "available" | "missing" | "unknown";
-
-/**
- * Parses one native V2 question item before it crosses into the shared
- * `QuestionRequest` contract. The SDK types the payload, but the
- * pending-question UI treats this read as authoritative, so a misbehaving
- * server must fail over to V1 instead of surfacing malformed items. The
- * schema validates every field the UI-consumed shape actually carries
- * (see `QuestionRequest` consumers) — values are mapped fresh from the
- * parsed payload, nothing is passed through unvalidated.
- */
-const questionV2ItemSchema = z.object({
-  id: z.string().min(1),
-  sessionID: z.string(),
-  questions: z.array(
-    z.object({
-      question: z.string(),
-      header: z.string(),
-      options: z.array(
-        z.object({
-          label: z.string(),
-          description: z.string(),
-        }),
-      ),
-      multiple: z.boolean().optional(),
-    }),
-  ),
-  tool: z
-    .object({
-      messageID: z.string(),
-      callID: z.string(),
-    })
-    .optional(),
-});
-
-const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
-  const parsed = questionV2ItemSchema.safeParse(item);
-  if (!parsed.success) return null;
-  const request: QuestionRequest = {
-    id: parsed.data.id,
-    sessionID: parsed.data.sessionID,
-    questions: parsed.data.questions.map((question) => ({
-      question: question.question,
-      header: question.header,
-      multiple: question.multiple,
-      options: question.options.map((option) => ({
-        label: option.label,
-        description: option.description,
-      })),
-    })),
-  };
-  if (parsed.data.tool) {
-    request.tool = parsed.data.tool;
-  }
-  return request;
-};
-
-/**
- * Warn once per process per failure kind for V2 question-read fallbacks
- * that are NOT the expected pre-V2 404 compat path, so a same-version
- * upstream contract break cannot silently degrade question reads to V1
- * forever (see {@link fetchPendingQuestionsV2} for the transition plan).
- */
-const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
-const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
-  if (questionsV2WarnedKinds.has(kind)) return;
-  questionsV2WarnedKinds.add(kind);
-  console.warn(`[questions-v2] ${kind}: ${detail}`);
-};
-
-/** Clear the once-per-process V2 fallback warnings between tests. */
-export const resetQuestionsV2FallbackWarningsForTests = (): void => {
-  questionsV2WarnedKinds.clear();
-};
 
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
@@ -1516,7 +1451,7 @@ class OpencodeService {
       const trimmed = typeof directory === 'string' ? directory.trim() : '';
       // Native V2 read first; the V1 `question.list` call below stays as the
       // fallback for pre-1.18 servers and any V2 failure (see
-      // {@link fetchPendingQuestionsV2}).
+      // {@link listPendingQuestionsViaV2}).
       const viaV2 = await this.fetchPendingQuestionsV2(trimmed || undefined);
       if (viaV2) {
         return viaV2;
@@ -1562,80 +1497,15 @@ class OpencodeService {
   }
 
   /**
-   * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
-   * `question.request.list` (unscoped for global pending items, or scoped
-   * via `location.directory`).
-   *
-   * Returns the pending questions on success, or `null` on failure so the
-   * caller can use the V1 `question.list` path unchanged. Each item is
-   * schema-validated before being accepted (see {@link parseQuestionV2Item})
-   * — any malformed item fails the whole V2 attempt conservatively.
-   *
-   * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
-   * malformed payload with a 200 status) are warned once per process per
-   * failure kind before the silent `null` fallback — read-only fallback is
-   * transitional, not a standing behavior.
-   *
-   * Removal condition: this V1 fallback is transitional. End-state is
-   * capability selection via runtime protocol detection (`openCodeProtocol`
-   * from `/health`, infra tracked in #3007, separate follow-up), or
-   * removal of the V1 path once the supported-runtime policy sets a
-   * minimum OpenCode version. Reference: #3259.
+   * Thin facade over the shared V2 question-read helper (see
+   * {@link listPendingQuestionsViaV2}). Kept on the class so the
+   * `OpencodeService.listPendingQuestions` call site reads as a single
+   * V2-then-V1 sequence; all V2 semantics (schema, warn-once, fallback
+   * classification) live in `questions-v2.ts` and are shared with the
+   * directory-bootstrap caller (#3288 / unit-5).
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
-    try {
-      const response = await this.client.v2.question.request.list(
-        directory ? { location: { directory } } : undefined,
-      );
-      // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
-      // payload nests the array under its own `data` field.
-      if (response.error !== undefined) {
-        const status = response.response?.status;
-        // A server-confirmed 404 is the expected pre-V2 route-miss compat
-        // path — silent fallback. Any other failure (5xx, auth/contract
-        // drift) must not degrade to V1 invisibly, so warn (once per kind).
-        if (status === 404) return null;
-        warnQuestionsV2FallbackOnce(
-          status === undefined ? 'network-error' : 'server-error',
-          `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
-        );
-        return null;
-      }
-      const items = response.data?.data;
-      if (!Array.isArray(items)) {
-        // Same-version contract drift: 200 status but a payload the typed
-        // SDK path no longer matches. Warn, then fall back to V1.
-        warnQuestionsV2FallbackOnce(
-          'malformed-payload',
-          'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
-        );
-        return null;
-      }
-      const validated: QuestionRequest[] = [];
-      for (const item of items) {
-        const parsed = parseQuestionV2Item(item);
-        // Malformed item: reject the whole V2 attempt conservatively — the
-        // caller falls back to V1 instead of returning partial data.
-        if (!parsed) {
-          warnQuestionsV2FallbackOnce(
-            'malformed-payload',
-            'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
-          );
-          return null;
-        }
-        validated.push(parsed);
-      }
-      return validated;
-    } catch (error) {
-      // Network failure or runtimeFetch throwing → fall back. Never the
-      // provably-pre-V2 404 path (that responds with an error result, not a
-      // throw), so surface it once per kind.
-      warnQuestionsV2FallbackOnce(
-        'network-error',
-        `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
-      );
-      return null;
-    }
+    return listPendingQuestionsViaV2(this.client, directory);
   }
 
   // Configuration

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -71,6 +71,29 @@ type SdkResult<T> = {
 
 type DirectoryAvailability = "available" | "missing" | "unknown";
 
+/**
+ * Runtime guard for one native V2 question item before it crosses into the
+ * shared `QuestionRequest` contract. The SDK types the payload, but the
+ * pending-question UI treats this read as authoritative, so a misbehaving
+ * server must fail over to V1 instead of surfacing malformed items.
+ * Mirrors the minimal per-item checks the V1 merge loop already applies.
+ */
+const parseQuestionV2Item = (value: unknown): QuestionRequest | null => {
+  if (!value || typeof value !== 'object') return null;
+  // SAFETY: shape probe only — each field below is re-validated before it
+  // is copied into the trusted contract.
+  const candidate = value as Partial<QuestionRequest>;
+  if (typeof candidate.id !== 'string' || candidate.id.length === 0) return null;
+  if (typeof candidate.sessionID !== 'string') return null;
+  if (!Array.isArray(candidate.questions)) return null;
+  return {
+    id: candidate.id,
+    sessionID: candidate.sessionID,
+    questions: candidate.questions,
+    tool: candidate.tool,
+  };
+};
+
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
     return error.reason === "not-found" || error.reason === "not-directory";
@@ -1439,6 +1462,13 @@ class OpencodeService {
 
     const fetchForDirectory = async (directory?: string | null): Promise<QuestionRequest[]> => {
       const trimmed = typeof directory === 'string' ? directory.trim() : '';
+      // Native V2 read first; the V1 `question.list` call below stays as the
+      // fallback for pre-1.18 servers and any V2 failure (see
+      // {@link fetchPendingQuestionsV2}).
+      const viaV2 = await this.fetchPendingQuestionsV2(trimmed || undefined);
+      if (viaV2) {
+        return viaV2;
+      }
       const result = await this.client.question.list(trimmed ? { directory: trimmed } : undefined);
       if (result.error) {
         throw new Error(`question.list failed: ${formatSdkError(result.error)}`);
@@ -1477,6 +1507,43 @@ class OpencodeService {
     }
 
     return merged;
+  }
+
+  /**
+   * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
+   * `question.request.list` (unscoped for global pending items, or scoped
+   * via `location.directory`).
+   *
+   * Returns the pending questions on success, or `null` on any failure
+   * (network error, 4xx/5xx response, missing/unexpected payload, or a
+   * pre-1.18 server without the V2 endpoint) so the caller can use the
+   * V1 `question.list` path unchanged. Each item is validated minimally
+   * (string `id`/`sessionID`, array `questions`) before being accepted —
+   * any malformed item fails the whole V2 attempt conservatively.
+   */
+  private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
+    try {
+      const response = await this.client.v2.question.request.list(
+        directory ? { location: { directory } } : undefined,
+      );
+      // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
+      // payload nests the array under its own `data` field.
+      if (response.error !== undefined) return null;
+      const items = response.data?.data;
+      if (!Array.isArray(items)) return null;
+      const validated: QuestionRequest[] = [];
+      for (const item of items) {
+        const parsed = parseQuestionV2Item(item);
+        // Malformed item: reject the whole V2 attempt conservatively — the
+        // caller falls back to V1 instead of returning partial data.
+        if (!parsed) return null;
+        validated.push(parsed);
+      }
+      return validated;
+    } catch {
+      // Network failure, pre-V2 server, or runtimeFetch throwing → fall back.
+      return null;
+    }
   }
 
   // Configuration

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1,6 +1,8 @@
 import type { ContextPartMetadata } from '@/lib/messages/contextParts';
 import { createOpencodeClient, OpencodeClient } from "@opencode-ai/sdk/v2";
 import type { PermissionV2Request, PermissionV2Effect, PermissionV2Source } from "@opencode-ai/sdk/v2/client";
+import type { QuestionV2Request } from "@opencode-ai/sdk/v2/client";
+import { z } from 'zod';
 import type { FilesAPI } from "../api/types";
 import { getDesktopHomeDirectory } from "../desktop";
 import type {
@@ -72,26 +74,58 @@ type SdkResult<T> = {
 type DirectoryAvailability = "available" | "missing" | "unknown";
 
 /**
- * Runtime guard for one native V2 question item before it crosses into the
- * shared `QuestionRequest` contract. The SDK types the payload, but the
+ * Parses one native V2 question item before it crosses into the shared
+ * `QuestionRequest` contract. The SDK types the payload, but the
  * pending-question UI treats this read as authoritative, so a misbehaving
- * server must fail over to V1 instead of surfacing malformed items.
- * Mirrors the minimal per-item checks the V1 merge loop already applies.
+ * server must fail over to V1 instead of surfacing malformed items. The
+ * schema validates every field the UI-consumed shape actually carries
+ * (see `QuestionRequest` consumers) — values are mapped fresh from the
+ * parsed payload, nothing is passed through unvalidated.
  */
-const parseQuestionV2Item = (value: unknown): QuestionRequest | null => {
-  if (!value || typeof value !== 'object') return null;
-  // SAFETY: shape probe only — each field below is re-validated before it
-  // is copied into the trusted contract.
-  const candidate = value as Partial<QuestionRequest>;
-  if (typeof candidate.id !== 'string' || candidate.id.length === 0) return null;
-  if (typeof candidate.sessionID !== 'string') return null;
-  if (!Array.isArray(candidate.questions)) return null;
-  return {
-    id: candidate.id,
-    sessionID: candidate.sessionID,
-    questions: candidate.questions,
-    tool: candidate.tool,
+const questionV2ItemSchema = z.object({
+  id: z.string().min(1),
+  sessionID: z.string(),
+  questions: z.array(
+    z.object({
+      question: z.string(),
+      header: z.string(),
+      options: z.array(
+        z.object({
+          label: z.string(),
+          description: z.string(),
+        }),
+      ),
+      multiple: z.boolean().optional(),
+    }),
+  ),
+  tool: z
+    .object({
+      messageID: z.string(),
+      callID: z.string(),
+    })
+    .optional(),
+});
+
+const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
+  const parsed = questionV2ItemSchema.safeParse(item);
+  if (!parsed.success) return null;
+  const request: QuestionRequest = {
+    id: parsed.data.id,
+    sessionID: parsed.data.sessionID,
+    questions: parsed.data.questions.map((question) => ({
+      question: question.question,
+      header: question.header,
+      multiple: question.multiple,
+      options: question.options.map((option) => ({
+        label: option.label,
+        description: option.description,
+      })),
+    })),
   };
+  if (parsed.data.tool) {
+    request.tool = parsed.data.tool;
+  }
+  return request;
 };
 
 const isMissingDirectoryError = (error: unknown): boolean => {
@@ -1517,9 +1551,9 @@ class OpencodeService {
    * Returns the pending questions on success, or `null` on any failure
    * (network error, 4xx/5xx response, missing/unexpected payload, or a
    * pre-1.18 server without the V2 endpoint) so the caller can use the
-   * V1 `question.list` path unchanged. Each item is validated minimally
-   * (string `id`/`sessionID`, array `questions`) before being accepted —
-   * any malformed item fails the whole V2 attempt conservatively.
+   * V1 `question.list` path unchanged. Each item is schema-validated
+   * before being accepted (see {@link parseQuestionV2Item}) — any
+   * malformed item fails the whole V2 attempt conservatively.
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
     try {

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -128,6 +128,24 @@ const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null =>
   return request;
 };
 
+/**
+ * Warn once per process per failure kind for V2 question-read fallbacks
+ * that are NOT the expected pre-V2 404 compat path, so a same-version
+ * upstream contract break cannot silently degrade question reads to V1
+ * forever (see {@link fetchPendingQuestionsV2} for the transition plan).
+ */
+const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
+const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
+  if (questionsV2WarnedKinds.has(kind)) return;
+  questionsV2WarnedKinds.add(kind);
+  console.warn(`[questions-v2] ${kind}: ${detail}`);
+};
+
+/** Clear the once-per-process V2 fallback warnings between tests. */
+export const resetQuestionsV2FallbackWarningsForTests = (): void => {
+  questionsV2WarnedKinds.clear();
+};
+
 const isMissingDirectoryError = (error: unknown): boolean => {
   if (error instanceof FilesystemError) {
     return error.reason === "not-found" || error.reason === "not-directory";
@@ -1548,12 +1566,21 @@ class OpencodeService {
    * `question.request.list` (unscoped for global pending items, or scoped
    * via `location.directory`).
    *
-   * Returns the pending questions on success, or `null` on any failure
-   * (network error, 4xx/5xx response, missing/unexpected payload, or a
-   * pre-1.18 server without the V2 endpoint) so the caller can use the
-   * V1 `question.list` path unchanged. Each item is schema-validated
-   * before being accepted (see {@link parseQuestionV2Item}) — any
-   * malformed item fails the whole V2 attempt conservatively.
+   * Returns the pending questions on success, or `null` on failure so the
+   * caller can use the V1 `question.list` path unchanged. Each item is
+   * schema-validated before being accepted (see {@link parseQuestionV2Item})
+   * — any malformed item fails the whole V2 attempt conservatively.
+   *
+   * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
+   * malformed payload with a 200 status) are warned once per process per
+   * failure kind before the silent `null` fallback — read-only fallback is
+   * transitional, not a standing behavior.
+   *
+   * Removal condition: this V1 fallback is transitional. End-state is
+   * capability selection via runtime protocol detection (`openCodeProtocol`
+   * from `/health`, infra tracked in #3007, separate follow-up), or
+   * removal of the V1 path once the supported-runtime policy sets a
+   * minimum OpenCode version. Reference: #3259.
    */
   private async fetchPendingQuestionsV2(directory?: string): Promise<QuestionRequest[] | null> {
     try {
@@ -1562,20 +1589,51 @@ class OpencodeService {
       );
       // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
       // payload nests the array under its own `data` field.
-      if (response.error !== undefined) return null;
+      if (response.error !== undefined) {
+        const status = response.response?.status;
+        // A server-confirmed 404 is the expected pre-V2 route-miss compat
+        // path — silent fallback. Any other failure (5xx, auth/contract
+        // drift) must not degrade to V1 invisibly, so warn (once per kind).
+        if (status === 404) return null;
+        warnQuestionsV2FallbackOnce(
+          status === undefined ? 'network-error' : 'server-error',
+          `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
+        );
+        return null;
+      }
       const items = response.data?.data;
-      if (!Array.isArray(items)) return null;
+      if (!Array.isArray(items)) {
+        // Same-version contract drift: 200 status but a payload the typed
+        // SDK path no longer matches. Warn, then fall back to V1.
+        warnQuestionsV2FallbackOnce(
+          'malformed-payload',
+          'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
+        );
+        return null;
+      }
       const validated: QuestionRequest[] = [];
       for (const item of items) {
         const parsed = parseQuestionV2Item(item);
         // Malformed item: reject the whole V2 attempt conservatively — the
         // caller falls back to V1 instead of returning partial data.
-        if (!parsed) return null;
+        if (!parsed) {
+          warnQuestionsV2FallbackOnce(
+            'malformed-payload',
+            'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
+          );
+          return null;
+        }
         validated.push(parsed);
       }
       return validated;
-    } catch {
-      // Network failure, pre-V2 server, or runtimeFetch throwing → fall back.
+    } catch (error) {
+      // Network failure or runtimeFetch throwing → fall back. Never the
+      // provably-pre-V2 404 path (that responds with an error result, not a
+      // throw), so surface it once per kind.
+      warnQuestionsV2FallbackOnce(
+        'network-error',
+        `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
+      );
       return null;
     }
   }

--- a/packages/ui/src/lib/opencode/questions-v2.ts
+++ b/packages/ui/src/lib/opencode/questions-v2.ts
@@ -1,0 +1,172 @@
+/**
+ * Shared native V2 question-read helper (SDK 1.18.25 `Request2.list`).
+ *
+ * Lives in its own module so callers that receive an SDK client as a
+ * parameter (e.g. the sync/bootstrap layer) can use the V2 read without
+ * importing the `OpencodeService` facade — test files that partially mock
+ * `@/lib/opencode/client` must not break bootstrap's import graph
+ * (see #3259 unit-5 CI finding).
+ *
+ * Owned by #3266 (unit-2-questions-v2-read): the OpencodeService read path
+ * delegates to this helper, and #3288 (unit-5-questions-v2-bootstrap) builds
+ * the directory-bootstrap caller on top of this same module. Any change to
+ * V2 read semantics lands here first.
+ */
+import { z } from 'zod';
+import type { QuestionV2Request, OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { QuestionRequest } from "@/types/question";
+
+/**
+ * Parses one native V2 question item before it crosses into the shared
+ * `QuestionRequest` contract. The SDK types the payload, but the
+ * pending-question UI treats this read as authoritative, so a misbehaving
+ * server must fail over to V1 instead of surfacing malformed items. The
+ * schema validates every field the UI-consumed shape actually carries
+ * (see `QuestionRequest` consumers) — values are mapped fresh from the
+ * parsed payload, nothing is passed through unvalidated.
+ */
+const questionV2ItemSchema = z.object({
+  id: z.string().min(1),
+  sessionID: z.string(),
+  questions: z.array(
+    z.object({
+      question: z.string(),
+      header: z.string(),
+      options: z.array(
+        z.object({
+          label: z.string(),
+          description: z.string(),
+        }),
+      ),
+      multiple: z.boolean().optional(),
+    }),
+  ),
+  tool: z
+    .object({
+      messageID: z.string(),
+      callID: z.string(),
+    })
+    .optional(),
+});
+
+const parseQuestionV2Item = (item: QuestionV2Request): QuestionRequest | null => {
+  const parsed = questionV2ItemSchema.safeParse(item);
+  if (!parsed.success) return null;
+  const request: QuestionRequest = {
+    id: parsed.data.id,
+    sessionID: parsed.data.sessionID,
+    questions: parsed.data.questions.map((question) => ({
+      question: question.question,
+      header: question.header,
+      multiple: question.multiple,
+      options: question.options.map((option) => ({
+        label: option.label,
+        description: option.description,
+      })),
+    })),
+  };
+  if (parsed.data.tool) {
+    request.tool = parsed.data.tool;
+  }
+  return request;
+};
+
+/**
+ * Warn once per process per failure kind for V2 question-read fallbacks
+ * that are NOT the expected pre-V2 404 compat path, so a same-version
+ * upstream contract break cannot silently degrade question reads to V1
+ * forever (see {@link listPendingQuestionsViaV2} for the transition plan).
+ */
+const questionsV2WarnedKinds = new Set<'network-error' | 'server-error' | 'malformed-payload'>();
+const warnQuestionsV2FallbackOnce = (kind: 'network-error' | 'server-error' | 'malformed-payload', detail: string): void => {
+  if (questionsV2WarnedKinds.has(kind)) return;
+  questionsV2WarnedKinds.add(kind);
+  console.warn(`[questions-v2] ${kind}: ${detail}`);
+};
+
+/** Clear the once-per-process V2 fallback warnings between tests. */
+export const resetQuestionsV2FallbackWarningsForTests = (): void => {
+  questionsV2WarnedKinds.clear();
+};
+
+/**
+ * Native V2 question read introduced in OpenCode SDK v1.18.25. Wraps
+ * `question.request.list` (unscoped for global pending items, or scoped
+ * via `location.directory`) on any SDK client instance, so both the
+ * `OpencodeService` read path and the directory bootstrap read path share
+ * one authoritative implementation (see #3259 unit-2 / unit-5).
+ *
+ * Returns the pending questions on success, or `null` on failure so the
+ * caller can use the V1 `question.list` path unchanged. Each item is
+ * schema-validated before being accepted (see {@link parseQuestionV2Item})
+ * — any malformed item fails the whole V2 attempt conservatively.
+ *
+ * Failures other than a server-confirmed pre-V2 404 (network error, 5xx,
+ * malformed payload with a 200 status) are warned once per process per
+ * failure kind before the silent `null` fallback — read-only fallback is
+ * transitional, not a standing behavior.
+ *
+ * Removal condition: this V1 fallback is transitional. End-state is
+ * capability selection via runtime protocol detection (`openCodeProtocol`
+ * from `/health`, infra tracked in #3007, separate follow-up), or
+ * removal of the V1 path once the supported-runtime policy sets a
+ * minimum OpenCode version. Reference: #3259.
+ */
+export async function listPendingQuestionsViaV2(
+  sdk: Pick<OpencodeClient, 'v2'>,
+  directory?: string,
+): Promise<QuestionRequest[] | null> {
+  try {
+    const response = await sdk.v2.question.request.list(
+      directory ? { location: { directory } } : undefined,
+    );
+    // HeyApi `RequestResult` discriminates on `error`/`data`; the 200
+    // payload nests the array under its own `data` field.
+    if (response.error !== undefined) {
+      const status = response.response?.status;
+      // A server-confirmed 404 is the expected pre-V2 route-miss compat
+      // path — silent fallback. Any other failure (5xx, auth/contract
+      // drift) must not degrade to V1 invisibly, so warn (once per kind).
+      if (status === 404) return null;
+      warnQuestionsV2FallbackOnce(
+        status === undefined ? 'network-error' : 'server-error',
+        `question.request.list failed${status === undefined ? '' : ` (HTTP ${status})`}; falling back to V1 question.list`,
+      );
+      return null;
+    }
+    const items = response.data?.data;
+    if (!Array.isArray(items)) {
+      // Same-version contract drift: 200 status but a payload the typed
+      // SDK path no longer matches. Warn, then fall back to V1.
+      warnQuestionsV2FallbackOnce(
+        'malformed-payload',
+        'question.request.list returned a 200 payload that is not an item array; falling back to V1 question.list',
+      );
+      return null;
+    }
+    const validated: QuestionRequest[] = [];
+    for (const item of items) {
+      const parsed = parseQuestionV2Item(item);
+      // Malformed item: reject the whole V2 attempt conservatively — the
+      // caller falls back to V1 instead of returning partial data.
+      if (!parsed) {
+        warnQuestionsV2FallbackOnce(
+          'malformed-payload',
+          'question.request.list returned an item failing the V2 question schema; falling back to V1 question.list',
+        );
+        return null;
+      }
+      validated.push(parsed);
+    }
+    return validated;
+  } catch (error) {
+    // Network failure or runtimeFetch throwing → fall back. Never the
+    // provably-pre-V2 404 path (that responds with an error result, not a
+    // throw), so surface it once per kind.
+    warnQuestionsV2FallbackOnce(
+      'network-error',
+      `question.request.list threw (${error instanceof Error ? error.message : 'unknown error'}); falling back to V1 question.list`,
+    );
+    return null;
+  }
+}

--- a/packages/ui/src/sync/bootstrap.test.ts
+++ b/packages/ui/src/sync/bootstrap.test.ts
@@ -3,7 +3,19 @@ import type { OpencodeClient, Project } from "@opencode-ai/sdk/v2/client"
 import { bootstrapDirectory } from "./bootstrap"
 import { INITIAL_STATE, type State } from "./types"
 
-const createSdk = (options?: { commandList?: () => Promise<{ data: unknown[] }> }) => ({
+type V2QuestionRequestListResponse = {
+  data?: { data?: unknown };
+  error?: unknown;
+  response?: { status?: number };
+};
+
+type V1QuestionListFn = (args?: { directory?: string }) => Promise<{ data?: unknown[] }>;
+
+const createSdk = (options?: {
+  commandList?: () => Promise<{ data: unknown[] }>
+  v2QuestionRequestList?: (args?: { location?: { directory?: string } }) => Promise<V2QuestionRequestListResponse>
+  v1QuestionList?: V1QuestionListFn
+}) => ({
   project: { current: async () => ({ data: { id: "project-a" } }) },
   config: { get: async () => ({ data: {} }) },
   path: { get: async () => ({ data: { state: "", config: "", worktree: "/repo", directory: "/repo", home: "/home" } }) },
@@ -12,8 +24,13 @@ const createSdk = (options?: { commandList?: () => Promise<{ data: unknown[] }> 
   mcp: { status: async () => ({ data: {} }) },
   lsp: { status: async () => ({ data: [] }) },
   vcs: { get: async () => ({ data: { branch: "main" } }) },
-  question: { list: async () => ({ data: [] }) },
+  question: { list: options?.v1QuestionList ?? (async () => ({ data: [] })) },
   permission: { list: async () => ({ data: [] }) },
+  v2: {
+    question: {
+      request: { list: options?.v2QuestionRequestList ?? (async () => ({ data: { data: [] }, error: undefined })) },
+    },
+  },
 }) as unknown as OpencodeClient
 
 const createState = (): State => ({
@@ -88,6 +105,91 @@ describe("bootstrapDirectory", () => {
 
     expect(result).toBe("failed")
     expect(state.session.map((session) => session.id)).toEqual(["cached"])
+  })
+
+  test("deferred phase reads pending questions through native V2 without calling V1", async () => {
+    const state = createState()
+    const v2Question = {
+      id: "que_v2",
+      sessionID: "ses_v2",
+      questions: [
+        {
+          question: "Proceed with the plan?",
+          header: "Build",
+          options: [
+            { label: "Yes", description: "Proceed" },
+            { label: "No", description: "Cancel" },
+          ],
+        },
+      ],
+tool: undefined,
+    }
+    const v2ListArgs: Array<{ location?: { directory?: string } } | undefined> = []
+    const v1ListCalls: Array<{ directory?: string } | undefined> = []
+    const sdk = createSdk({
+      v2QuestionRequestList: async (args) => {
+        v2ListArgs.push(args)
+        return { data: { data: [v2Question] }, error: undefined }
+      },
+      v1QuestionList: async (args) => {
+        v1ListCalls.push(args)
+        return { data: [] }
+      },
+    })
+
+    await bootstrapDirectory({
+      directory: "/repo",
+      sdk,
+      getState: () => state,
+      set: (patch) => Object.assign(state, patch),
+      global: { config: {}, projects: [project] },
+      loadSessions: async () => undefined,
+    })
+    // Deferred phase runs on a setTimeout(0); give it a tick.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(state.question["ses_v2"]?.map((q) => q.id)).toEqual(["que_v2"])
+    expect(v2ListArgs).toEqual([{ location: { directory: "/repo" } }])
+    expect(v1ListCalls).toEqual([])
+  })
+
+  test("deferred phase falls back to V1 question.list on a V2 5xx failure and still merges results", async () => {
+    const state = createState()
+    const v1Question = {
+      id: "que_v1",
+      sessionID: "ses_v1",
+      questions: [
+        {
+          question: "Pick one",
+          header: "Mode",
+          options: [{ label: "Fast", description: "Fast" }],
+        },
+      ],
+    }
+    const v1ListCalls: Array<{ directory?: string } | undefined> = []
+    const sdk = createSdk({
+      v2QuestionRequestList: async () => ({
+        error: { name: "ServerError", data: { message: "boom" } },
+        response: new Response(null, { status: 500 }),
+      }),
+      v1QuestionList: async (args) => {
+        v1ListCalls.push(args)
+        return { data: [v1Question] }
+      },
+    })
+
+    await bootstrapDirectory({
+      directory: "/repo",
+      sdk,
+      getState: () => state,
+      set: (patch) => Object.assign(state, patch),
+      global: { config: {}, projects: [project] },
+      loadSessions: async () => undefined,
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(state.question["ses_v1"]?.map((q) => q.id)).toEqual(["que_v1"])
+    expect(v1ListCalls).toEqual([{ directory: "/repo" }])
   })
 
   test("rejects stale work before committing", async () => {

--- a/packages/ui/src/sync/bootstrap.ts
+++ b/packages/ui/src/sync/bootstrap.ts
@@ -3,6 +3,7 @@ import { retry } from "./retry"
 import type { GlobalState, State } from "./types"
 import { runtimeFetch } from "../lib/runtime-fetch"
 import { emitSyncConfigChanged } from "./sync-refs"
+import { listPendingQuestionsViaV2 } from "../lib/opencode/questions-v2"
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
@@ -219,15 +220,31 @@ export async function bootstrapDirectory(input: {
       const beforeSignatures = new Map(
         Object.entries(before.question ?? {}).map(([sessionID, questions]) => [sessionID, requestSignature(questions)]),
       )
-      const x = await sdk.question.list(directory ? { directory } : undefined)
-      if (x.error) {
-        const status = (x as { response?: { status?: number } }).response?.status
-        const err = new Error(`question.list failed${status ? ` (${status})` : ""}: ${String(x.error)}`)
-        if (status !== undefined) (err as Error & { status?: number }).status = status
-        throw err
+      // Native V2 read first (same shared helper as the OpencodeService read
+      // path); the V1 `question.list` call below stays as the fallback for
+      // pre-1.18 servers and V2 failures other than a pre-V2 route-miss 404.
+      let items: QuestionRequest[]
+      const viaV2 = await listPendingQuestionsViaV2(sdk, directory || undefined)
+      if (viaV2) {
+        items = viaV2
+      } else {
+        const x = await sdk.question.list(directory ? { directory } : undefined)
+        if (x.error) {
+          // SAFETY: HeyApi results discriminate on `error`/`response`; the
+          // SDK type does not carry the status across the union, so this
+          // narrowing cast only reads `response.status` when present.
+          const status = (x as { response?: { status?: number } }).response?.status
+          const err = new Error(`question.list failed${status ? ` (${status})` : ""}: ${String(x.error)}`)
+          if (status !== undefined) (err as Error & { status?: number }).status = status
+          throw err
+        }
+        // SAFETY: the V1 question.list payload is the same wire shape this
+        // file already consumed before the V2 path existed; per-item
+        // validation happens in the groupBySession filter below.
+        items = (x.data ?? []) as QuestionRequest[]
       }
       const grouped = groupBySession(
-        (x.data ?? []).filter((q): q is QuestionRequest => !!q?.id && !!q.sessionID),
+        items.filter((q) => !!q?.id && !!q.sessionID),
       )
       const current = getState()
       const merged = { ...current.question }


### PR DESCRIPTION
## Final disposition

Closed as superseded by the #3259 selected-runtime architecture.

The production implementation in this PR belongs to the old mixed-runtime migration model and will not be merged. The historical stacking on #3266 is not preserved; both PRs are reconciled away.

Preserved:
- Bootstrap deferred-phase question merge semantics — signature-based replace, disappearance/delete handling, stale-commit guard (state changed while the deferred request was in flight), and retry-then-merge on transient failure — ported (authored as tests against current main's V1-only bootstrap) into test-only salvage PR **#3439** (`bootstrap.test.ts`). These validate `bootstrap.ts` itself, independent of whether questions come from V1 or V2.

Disposition:
- production path (`listPendingQuestionsViaV2` import, direct bootstrap V2 read, V2→V1 fallback, dependency on the #3266 helper): **dropped** — bootstrap must consume the normal application contract once an adapter owns V2; the import-graph coupling note is retained in the historical record as evidence for any future `bootstrap.ts` import change
- V2-read/V2-5xx-fallback bootstrap tests: **not ported** (encode obsolete fallback semantics)
- main-independent tests: **ported to #3439** (tests only, CI green)
- adapter-specific tests/evidence: **recorded in #3259 for future user-owned corrective work**
- #3007 remains external/read-only and was not modified

Historical implementation details below are retained as engineering evidence.
## Architecture status

> **PROPOSED / SELECTED FOR #3259 — not maintainer-approved policy.**
>
> This PR was implemented under the superseded capability-by-capability #3259 migration model: it routes the directory-bootstrap deferred-phase pending-question read through #3266's direct-V2 helper (`listPendingQuestionsViaV2`) with a classified V1 fallback.
>
> Under the current #3259 dual-runtime proposal, this production change is likely unnecessary as-is:
>
> - If the selected V2 runtime is exposed through the #3007-style application adapter (current #3007 @ `5a424cf7` already maps `question.list` → `v2.form.request.list` + `normalizeQuestion`), then bootstrap's ordinary `sdk.question.list` call becomes V2-backed through that adapter with no explicit V2 helper at all.
> - A second direct-V2 bootstrap read path would duplicate the one adapter seam and re-introduce a V1 fallback that contradicts selected-runtime authority.
>
> The branch remains open as engineering evidence. Do not infer maintainer rejection or project-wide architectural approval from this status.

### Evidence worth salvaging regardless

- Bootstrap retry (`retry()`) interaction tests: V2 read used with no V1 call; V2 5xx → V1 fallback still merges (re-express against the adapter's failure semantics).
- Signature-based merge/delete tests and stale-commit guards (bootstrap deferred-phase question merge semantics) — these validate `bootstrap.ts` itself and remain valid whatever supplies the reads.
- The real coupling bug found while implementing the old PR (bootstrap importing from the facade module vs a standalone helper module breaking partially-mocked test files) — relevant to any future import-graph change in `bootstrap.ts`.

---

## Historical implementation record

Everything below this point describes the pre-reconciliation implementation and its then-current HEADs and bases (including the dependency relationship with #3266 and the `85a95bb8e`/`85a95bb8e`-era bases). Where this historical record conflicts with the Architecture status section above, the Architecture status section is authoritative. In particular, the historical overlap note below lists #3007 as runtime-detection infrastructure only; the 2026-09-03 audit additionally established that #3007 owns the `question.list` V2 adapter, which is the reason this PR's production change is likely unnecessary.

## Intent

Migration unit #5 (tracking #3259): adopt the **native OpenCode V2 questions read path** in the directory-bootstrap deferred phase, using the shared `listPendingQuestionsViaV2(sdk, directory?)` helper owned by #3266 (`packages/ui/src/lib/opencode/questions-v2.ts`).

Concretely:

- #3266 owns the shared V2 question-read helper (zod item schema, field-by-field mapper, failure-class classifier, warn-once set, removal-condition docs). The `OpencodeService` read path on #3266 calls it through a thin facade (`fetchPendingQuestionsV2`).
- This PR's **only** incremental delta is the directory-bootstrap caller: `bootstrapDirectory`'s deferred phase (`packages/ui/src/sync/bootstrap.ts`) reads pending questions through the same shared helper instead of calling V1 `question.list` directly, keeping the existing `retry()` wrapper, signature-based merge/delete, and stale-guard commit semantics byte-identical.
- The helper's failure classification (silent on pre-V2 route-miss 404; one-time warn on network/5xx/malformed) is inherited as-is — bootstrap is the second production caller of one authoritative implementation, not a parallel implementation.

Native stock V2 only — pure mapping of an existing V2 contract; no fabricated semantics, no V1-shaped emulation.

## Non-goals

- V2 reply/reject adoption (#3267), event-reducer handling (#3267), permission listing V2 adoption.
- Runtime protocol detection / removal of the transitional fallback (blocked on #3007 infra; removal condition documented on the helper).
- Any change to bootstrap's critical-path/Phase-3 semantics, permission bootstrap, or retry behavior.

## Affected surfaces

- `packages/ui` shared UI (web, Electron, VS Code, mobile — all import the same `client.ts` wrapper).
- OpenCode API surface: `client.v2.question.request.list` (V2, SDK 1.18.25) tried first; existing `client.question.list` (V1) as the classified fallback.
- Bootstrap is used by web/Electron/VS Code/mobile directory materialization (`ChildStoreManager` → `bootstrapDirectory`); all runtimes share the one code path, so parity is unchanged by construction.
- No persisted contracts, server routes, or UI components change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariants | Never let fetch failure masquerade as authoritative empty success | V2 failure → classified V1 fallback, never fabricated data; V2 success is strictly tighter (schema-validated, extras stripped) |
| AGENTS.md instruction order / skills | Source change + shared UI data access + sync/bootstrap behavior | Loaded `openchamber-change-discipline`, `sync-state-invariants`, `ui-api-decoupling` (+ implementation-map reference), `communication-style`; bootstrap deferred-phase and blocking-request ownership rules followed |
| `packages/ui/src/sync/DOCUMENTATION.md` | Directory bootstrap scheduling + question sync ownership | Deferred phase stays deferrable (no slot extension), question state ownership/merge semantics untouched |
| ui-api-decoupling | Official OpenCode APIs go through the SDK | `client.v2.question.request.list` via the existing SDK client; no new transport, no runtime-specific branching |
| sync-state-invariants | Failure is not empty | V2 failure returns `null` → caller uses V1 path unchanged; V1 failure still throws so `retry()` fires; never swallowed into empty success |

## Validation

| Check | Result |
|---|---|
| `bunx tsc --noEmit -p packages/ui` | 0 errors |
| Focused suites (`bootstrap.test.ts` + `client.questions.test.ts`, bun test) at head `45c40a54d` | 15 pass / 0 fail (5 bootstrap + 10 client questions; incl. new: V2 read used with no V1 call; V2 5xx → V1 fallback still merges; helper tests on #3266's branch — not duplicated here) |
| Pre-restructure validation (historical, head `796d057f`) | 23/0 focused; the previous branch exposed a real coupling bug (`#3288` bootstrap imported the helper from the facade module and 3 partially-mocked test files broke with missing-export SyntaxErrors). Mitigated there by extracting the helper into `lib/opencode/questions-v2.ts`. The 2026-09-01 restructure removed that workaround by rebasing onto #3266, which owns the helper module. |
| Full `src/sync` suite (57 files) at head `45c40a54d` | Failure set byte-identical to pre-change baseline (34 pre-existing fails from cross-file mock bleed + 11 errors; every affected file green in isolation). Verified on clean `upstream/main` worktree too. |
| `bunx oxlint` (changed files) | 0 findings in authored code; all findings are pre-existing and unchanged in count or category |
| Commit ancestry | This PR's HEAD (`45c40a54d`) is built directly on top of #3266's HEAD (`751ea6d4e`). `git log 751ea6d4e..45c40a54d` = 1 commit (`feat(questions): adopt native V2 question read in directory bootstrap`). |
| Logical incremental delta over prerequisite | `git diff 751ea6d4e..45c40a54d` = **2 files, +128 / -9** (`packages/ui/src/sync/bootstrap.ts` + `packages/ui/src/sync/bootstrap.test.ts` only — no `questions-v2.ts`, no `client.ts` re-implementation, no helper duplication). |
| GitHub PR base | `main` (`85a95bb8e`). This is unavoidable: #3266 lives in `bashrusakh/openchamber`, the PR target is `openchamber/openchamber`, so GitHub cannot infer the prerequisite relationship from PR metadata. |
| Standard upstream GitHub PR diff | Currently shows **5 files** (`main..HEAD`): the 3 files inherited from #3266 (`client.questions.test.ts`, `client.ts`, `questions-v2.ts`) PLUS the 2 files of this PR's actual delta (`bootstrap.ts`, `bootstrap.test.ts`). Reviewers should focus on the 2-file logical delta above; the inherited 3-file block is the prerequisite (#3266) and will disappear from the PR diff once #3266 merges. |
| `bun run dead-code` | one known non-blocking flag: test-only export `resetQuestionsV2FallbackWarningsForTests` (same flag exists on #3266's branch; used by tests via cache-busted dynamic import invisible to static analysis) |

**Pre-change baseline:** recorded on pristine `upstream/main` worktree before edits — bootstrap 3/0, client suites 14/0, full-sync failure set identical (verified via stash-diff).

**Post-restructure verification (2026-09-01, head `45c40a54d`):** the three previously-CI-failing test files are no longer relevant to this branch because #3288 no longer carries its own helper — the helper module is owned by #3266 and the partial-mock problem does not arise here. Focused suites 15/0 (bootstrap 5/0 + client questions 10/0); tsc 0 errors; oxlint on authored code 0 new findings (the pre-existing `bootstrap.test.ts` chained-cast pattern is unchanged in count and category); full `src/sync` failure set byte-identical to baseline; knip baseline unchanged (43 unused exports — same as clean main).

**Not runtime-verified against a live OpenCode V2 server:** the V2 list endpoint is validated by the generated SDK contract (1.18.25, `Request2.list` → `V2QuestionRequestListResponses`) and unit tests; live-server probe remains part of the SessionExecution CE gate plan (#3259).

## Visual evidence

No user-visible change: on a healthy V2 backend the pending-question list content and merge semantics are identical (same items, same signature-based merge); on V2 failure the V1 path returns the same list (pre-V2 404s silently; other failure classes emit a one-time console warning). Rendered UI is unchanged — this PR swaps the data source for the same list one code path earlier (bootstrap).

## Risks and failure behavior

- Failure mode: 404 route-miss (pre-V2 server) → silent V1 fallback (compat path); network throw/5xx/malformed → one-time-per-process `[questions-v2]` warning, then V1 fallback; never fabricated data.
- Bootstrap-specific: the V2 attempt sits inside the same `retry()` arm — V1 failures still throw with `.status` attached so retry's transient classification fires; V2 returning `null` never bypasses the retry contract.
- Rollback: revert the single commit `45c40a54d` (and the inherited prerequisite commits from #3266 if those have not yet merged); no data migration, no contract change. Pre-restructure branches (e6aad7a9 → 818c66a9c → 796d057f) are superseded by the 2026-09-01 restructure and no longer carry reviewable changes.
- Cross-PR duplication: RESOLVED at the commit-ancestry level — #3288's HEAD is built directly on top of #3266's HEAD, so the V2 read helper lives in exactly one place (`lib/opencode/questions-v2.ts` from #3266). At the GitHub-PR level, the standard diff (`main..HEAD`) currently includes the inherited #3266 changes because GitHub cannot infer the prerequisite relationship from a cross-fork branch. After #3266 merges into `openchamber/openchamber`, retarget/rebase #3288 onto updated `main` and verify that the inherited 3-file block disappears from the PR diff; the 2-file logical delta should remain unchanged.

---

### Migration tracking (#3259)

```text
Tracking: #3259

Depends on:
#3266 @ 751ea6d4eef211dabaaec99af83526394cc5cb4b

Effective base:
main @ 85a95bb8ebf509749695bec29feedcf03a893e0a
+
#3266 @ 751ea6d4eef211dabaaec99af83526394cc5cb4b

Required merge order:
#3266 → #3288 (this PR)
```

SDK: @opencode-ai/sdk 1.18.25

Existing overlap:

```text
#3266 @ 751ea6d4eef211dabaaec99af83526394cc5cb4b — DEPENDS ON (owns the shared V2 read helper in `lib/opencode/questions-v2.ts`; this PR uses it as the single authoritative implementation for the bootstrap caller; no re-implementation, no duplication)
#3267 @ 1156bb9b8 — UNRELATED (mutations + events; no read-path overlap)
#3271 @ 18f7bf023 — UNRELATED (session-list pagination)
#3007 @ 5625d12dbc — COORDINATE (runtime-detection infra; fallback removal condition)

This PR's HEAD: 45c40a54ddcbcd178a59006ad6d7cfeb8d7ea32c (single commit on top of #3266)
```

Reuse strategy: `DIRECT-REUSE` of #3266's `listPendingQuestionsViaV2` export. No foreign commits cherry-picked; this PR's `bootstrapDirectory` imports the helper from `lib/opencode/questions-v2.ts` exactly as #3266's `client.ts` does, so both production callers share one authoritative implementation.

### V2 purity statement

- Native stock V2: `client.v2.question.request.list({ location: { directory } })` from generated SDK 1.18.25 (`Request2.list`, `V2QuestionRequestListResponses: { data: QuestionV2Request[] }`).
- Mapping existing semantics only; nothing fabricated; V2 404 (pre-V2) ⇒ silent V1 fallback; other V2 failures ⇒ one-time warn + V1 fallback (transitional, removal condition documented).
- Bootstrap stays read-path only: no execution ownership, no mutation semantics, no competing authoritative state (signature-guarded merge preserved).

### Engineering delta

- Pending-question reads: one V2 read implementation (owned by #3266) serving both production call sites. The logical incremental delta of #3288 over #3266 is **1 commit on `bootstrap.ts` + `bootstrap.test.ts` only** (+128 / -9), measured by `git diff 751ea6d4e..45c40a54d`.
- Bootstrap deferred phase stops using a raw V1 SDK call directly — same integration boundary as the service path.
- Duplicated-schema risk eliminated at the commit-ancestry level from the moment #3266 lands.
- **At the GitHub-PR level**, the inherited #3266 changes appear in the diff (`main..HEAD`) until #3266 merges; this is a GitHub metadata artifact, not a real duplication. After #3266 merges, retarget/rebase #3288 onto updated `main` and the inherited block disappears.





