### PR TITLE
refactor(client): remove dead legacy file/command wrappers

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -1663,52 +1663,7 @@ class OpencodeService {
   // SSE infrastructure removed — EventPipeline in sync/event-pipeline.ts handles
   // all SSE event ingestion via the SDK's global.event() async iterator.
 
-  // File Operations
-  async readFile(path: string): Promise<string> {
-    try {
-      const response = await this.client.file.read({
-        path,
-        ...(this.currentDirectory ? { directory: this.currentDirectory } : {}),
-      });
-      return String(unwrapSdkData(response, 'file.read'));
-    } catch {
-      // Return placeholder for development
-      return `// Content of ${path}\n// This would be loaded from the server`;
-    }
-  }
-
-  async listFiles(directory?: string): Promise<Record<string, unknown>[]> {
-    try {
-      const targetDir = directory || this.currentDirectory || '/';
-      const response = await this.client.file.list({
-        path: targetDir,
-        ...(this.currentDirectory ? { directory: this.currentDirectory } : {}),
-      });
-      const data = unwrapSdkData(response, 'file.list');
-      return Array.isArray(data) ? data as Record<string, unknown>[] : [];
-    } catch {
-      // Return mock data for development
-      return [];
-    }
-  }
-
   // Command Management
-  async listCommands(): Promise<Array<{ name: string; description?: string; agent?: string; model?: string; source?: string }>> {
-    const response = await this.client.command.list(
-      this.currentDirectory ? { directory: this.currentDirectory } : undefined
-    );
-    const commands = unwrapSdkData(response, 'command.list');
-    // Return only lightweight info for autocomplete
-    return (commands || []).map((cmd: Record<string, unknown>) => ({
-      name: cmd.name as string,
-      description: cmd.description as string | undefined,
-      agent: cmd.agent as string | undefined,
-      model: cmd.model as string | undefined,
-      source: cmd.source as string | undefined,
-      // Intentionally excluding template to keep memory usage low
-    }));
-  }
-
   async listCommandsWithDetails(directory?: string | null): Promise<Array<{ name: string; description?: string; agent?: string; model?: string; source?: string; template?: string }>> {
     const requestDirectory = this.normalizeCandidatePath(directory ?? null) ?? this.currentDirectory;
     const response = await this.client.command.list(
@@ -1724,58 +1679,6 @@ class OpencodeService {
       source: cmd.source as string | undefined,
       template: cmd.template as string | undefined,
     }));
-  }
-
-  async listSkillsWithDetails(): Promise<Array<{ name: string; description?: string; location: string; content?: string }>> {
-    try {
-      const response = await this.client.app.skills(
-        this.currentDirectory ? { directory: this.currentDirectory } : undefined,
-      );
-      const data = response.data;
-      if (!Array.isArray(data)) {
-        return [];
-      }
-
-      const skills: Array<{ name: string; description?: string; location: string; content?: string }> = [];
-      for (const item of data as Array<Record<string, unknown>>) {
-          const name = typeof item.name === 'string' ? item.name.trim() : '';
-          const location = typeof item.location === 'string' ? item.location : '';
-          if (!name || !location) {
-            continue;
-          }
-          const skill: { name: string; description?: string; location: string; content?: string } = { name, location };
-          if (typeof item.description === 'string') skill.description = item.description;
-          if (typeof item.content === 'string') skill.content = item.content;
-          skills.push(skill);
-      }
-      return skills;
-    } catch {
-      return [];
-    }
-  }
-
-  async getCommandDetails(name: string): Promise<{ name: string; template: string; description?: string; agent?: string; model?: string } | null> {
-    try {
-      const response = await this.client.command.list(
-        this.currentDirectory ? { directory: this.currentDirectory } : undefined
-      );
-
-      if (response.data) {
-        const command = response.data.find((cmd: Record<string, unknown>) => cmd.name === name);
-        if (command) {
-          return {
-            name: command.name as string,
-            template: command.template as string,
-            description: command.description as string | undefined,
-            agent: command.agent as string | undefined,
-            model: command.model as string | undefined
-          };
-        }
-      }
-      return null;
-    } catch {
-      return null;
-    }
   }
 
   // Lightweight readiness check. Full diagnostics still live at /health.


### PR DESCRIPTION
## Architecture status

> Shared-correctness / dead-code cleanup. Independent of the #3259 dual-runtime architecture.
>
> **Fresh zero-caller audit (2026-09-03, against current `main` @ `504fd8532` and current #3007 @ `5a424cf7`):** `OpencodeService.readFile`, `listFiles`, `listCommands`, `listSkillsWithDetails`, and `getCommandDetails` still have zero production consumers repo-wide (direct calls, `getSdkClient()` chains, dynamic/bracket access, all packages checked). #3007 implements the underlying capabilities (`file.read`, `file.list`, `app.skills`, `command.list`) inside its adapter, but no caller reaches them through these wrapper methods. Deletion remains valid and unaffected by the V1/V2 architecture.

---

## Intent

Migration unit #6 (tracking #3259): remove dead legacy wrappers from `OpencodeService` and eliminate a data-fabrication hazard, per the program's §67 incremental-cleanup rule.

Five `OpencodeService` methods had zero production callers (repo-wide grep across all packages, including dynamic imports and `getSdkClient()` chains) and were removed:

- `readFile(path)` — on any error returned a **fabricated placeholder** (`// Content of ...\n// This would be loaded from the server`), violating the repository invariant *"never let fetch failure masquerade as success"*. No caller existed to observe the fabrication, so the correct fix is removal of the hazard, not a behavior patch.
- `listFiles(directory)` — swallowed errors into `[]`.
- `listCommands()` — superseded by `listCommandsWithDetails` (kept; used by `useCommandsStore` and `session-ui-store`).
- `listSkillsWithDetails()` — silently returned `[]` on failure. (Adjacent same-kind dead code, included beyond the three originally named methods.)
- `getCommandDetails(name)` — silently returned `null` on failure.

## Non-goals

- No behavior change anywhere: deletion-only (97 lines removed, 0 added).
- Live methods with the same swallow-into-`[]`/`null` shape (`getSessionTodos`, `listToolIds`) are **out of scope** — they have callers, so changing them is a behavior change for a follow-up unit.
- The `listAgents` `/api/agent` fallback branch is untouched (separate policy decision, recorded in #3259).

## Affected surfaces

- `packages/ui/src/lib/opencode/client.ts` only (the `OpencodeService` facade).
- No OpenCode API surface change: the wrappers were the only consumers of `file.read`/`file.list`/`app.skills` on this client, and no UI/server/VS Code/mobile code reached them (repo-wide grep incl. dynamic/string access).
- `RuntimeAPIs files.readFile/listDirectory` (used by FilesView/PlanView/mobile) are separate OpenChamber route contracts — untouched.
- No persisted contracts, no server routes, no UI components change. Deletion-only.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariants | Never let fetch failure masquerade as authoritative success | The fabrication hazard (`readFile` placeholder) is deleted outright; the same silent-empty pattern in three more dead wrappers goes with it |
| openchamber-change-discipline | Dead-code removal in the owning integration boundary | Deletion-only diff in `lib/opencode/client.ts`; no new abstractions, no behavior change; superseded code removed in the same unit (§67) |
| ui-api-decoupling | Shared UI data access boundaries | RuntimeAPIs `files.*` contract (the one the UI actually uses) untouched; only unused SDK-wrapper methods removed |
| Validation matrix | Executable source change | Focused tests + package type-check + lint + dead-code scan, all green |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` (packages/ui, `tsc --noEmit`) | 0 errors |
| Focused client suites (`client.test.ts`, `client.permission.test.ts`, `client-timeout.test.ts`, `client.questions-v2-helper.test.ts` — bun test) | 23 pass / 0 fail |
| Adjacent stores (`useCommandsStore`, `usePluginsStore`) | 27 pass / 0 fail |
| Full `src/sync` suite (57 files) | Failure set byte-identical to the clean-base run on the same tree (verified via stash-diff; all pre-existing cross-file mock-bleed, each file green in isolation) |
| `bunx oxlint src/lib/opencode/client.ts` | 135 vs 159 baseline — reduction only, no new rule kinds (removed code carried 24 pre-existing findings incl. the `skill` binding widening) |
| `bun run dead-code` | Output identical to clean base (removed methods were non-exported class methods, not scanner-tracked; no new findings) |

**Pre-change baseline (§40):** recorded on pristine `upstream/main` `85a95bb8e` before edits — client suites 11/0, tsc 0, oxlint 159, dead-code output captured.

**Caller verification:** zero production callers for all five methods across `packages/ui`, `packages/web` (src + server), `packages/vscode` (src + webview), `packages/electron`, `packages/mobile` — direct calls, `getSdkClient()` chains, and string/bracket access all checked. The plugins store's `readFile` is its own `runtimeFetch` implementation (OpenChamber route), unrelated. `RuntimeAPIs.files.*` used by the UI are separate contracts.

**Not runtime-verified:** no runtime behavior changes — deletion-only, all suites green; no runtime probe applicable.

## Visual evidence

No user-visible change possible: every removed method had zero callers, so no rendered output, request, or state could depend on them. Diff is deletion-only.

## Risks and failure behavior

- Failure mode: none new — the only behavior removed was unreachable (dead methods), including `readFile`'s error-path placeholder fabrication which no caller could observe.
- Rollback: revert one commit.
- Cross-runtime: shared `packages/ui` code only; runtime adapters untouched; the VS Code webview and web both import the same singleton and use none of the removed methods.
- `getSessionTodos()` / `listToolIds()` retain a swallow-into-`[]` pattern but have **live callers** — behavior-changing cleanup deliberately left out of this dead-code unit; noted in #3259 backlog.

---

### Migration tracking (#3259)

```text
Tracking: #3259

Depends on: none

Required merge order: standalone
```

Effective base:

```text
main (upstream): 85a95bb8e
SDK: @opencode-ai/sdk 1.18.25
```

Existing overlap:

```text
#3266 @ 09855ea1f — client.ts neighbor (V2 question read); deletion touches a different region (file/command wrappers); no conflict
#3267 @ 1156bb9b8 — unrelated (questions mutations/events)
#3288 @ 796d057f — sibling (bootstrap V2 read); touches client.ts imports only — trivial rebase after #3266
#3271 @ 18f7bf023 — unrelated
#3007 — unrelated (runtime detection infra)
```

Reuse strategy: `NONE` (deletion-only unit; no foreign code reused).

### V2 purity statement

Not a V2-adoption unit: pure §67 removal of dead legacy wrappers. No V1→V2 semantics claimed; OpenCode untouched (`OpenCode modifications: NONE`).

### Engineering delta

- 97 lines of unreachable/error-masking wrapper code removed from the integration facade.
- One data-fabrication hazard (`readFile` placeholder) eliminated at the source.
- Remaining command surface reduced to the single used accessor (`listCommandsWithDetails`).

### Program notes (from review pass)

- `getSessionTodos()` / `listToolIds()` share the swallow-into-`[]` pattern but have live callers — behavior-changing cleanup deferred to a follow-up unit (program backlog).
- `src/lib/i18n` locale-parity test fails identically on clean base — pre-existing, unrelated to this unit.
