### PR TITLE
feat(client): migrate listAgents to native V2 SDK

### DIFF
--- a/packages/ui/src/lib/opencode/client.agents.test.ts
+++ b/packages/ui/src/lib/opencode/client.agents.test.ts
@@ -1,0 +1,564 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type AgentV2Fixture = {
+  id: string;
+  description?: string;
+  mode: 'subagent' | 'primary' | 'all';
+  hidden: boolean;
+  system?: string;
+  color?: string;
+  steps?: number;
+  model?: { id: string; providerID: string; variant?: string };
+  permissions: Array<{ action: string; resource: string; effect: string }>;
+};
+
+const agentListMock = mock((args?: { location?: { directory?: string; workspace?: string } }) => {
+  return new Promise<unknown>((resolve, reject) => {
+    pendingResolutions.push((r: AgentListTestResponse) => {
+      if (r.kind === 'throw') {
+        reject(new Error('network down'));
+      } else if (r.kind === 'ok') {
+        resolve(makeSuccessResult(r.agents));
+      } else if (r.kind === 'empty') {
+        resolve(makeSuccessResult([]));
+      } else if (r.kind === 'malformed') {
+        resolve(makeMalformedResult());
+      } else {
+        const status = r.kind === 'client-error' ? 404 : 500;
+        resolve(makeErrorResult(status));
+      }
+    });
+    pendingArgs.push(args);
+  });
+});
+
+type AgentListTestResponse =
+  | { kind: 'ok'; agents: AgentV2Fixture[] }
+  | { kind: 'empty' }
+  | { kind: 'malformed' }
+  | { kind: 'client-error' }
+  | { kind: 'server-error' }
+  | { kind: 'throw' };
+
+const pendingResolutions: Array<(r: AgentListTestResponse) => void> = [];
+const pendingArgs: Array<{ location?: { directory?: string; workspace?: string } } | undefined> = [];
+
+/**
+ * Build a HeyApi success result for V2 agent.list. The 200 envelope is
+ * `{ location, data: AgentV2Info[] }`; the SDK exposes this whole envelope
+ * as `response.data` and the array lives at `response.data.data`.
+ */
+const makeSuccessResult = (agents: AgentV2Fixture[]) => ({
+  data: {
+    location: { directory: '/workspace/project' },
+    data: agents,
+  },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+/**
+ * Build a HeyApi result whose 200 envelope is missing the `data` array.
+ * Used to verify the "non-array data" guard.
+ */
+const makeMalformedResult = () => ({
+  data: { location: { directory: '/workspace/project' } },
+  error: undefined,
+  request: new Request('http://test/'),
+  response: new Response(null, { status: 200 }),
+});
+
+const makeErrorResult = (status: number) => ({
+  data: undefined,
+  error: {
+    name: status === 404 ? 'NotFoundError' : 'ServerError',
+    data: { message: 'boom' },
+  },
+  request: new Request('http://test/'),
+  response: new Response(null, { status }),
+});
+
+const createOpencodeClientMock = mock(() => ({
+  v2: {
+    agent: {
+      list: agentListMock,
+    },
+  },
+}));
+
+(mock as unknown as { restore?: () => void }).restore?.();
+
+mock.module('@opencode-ai/sdk/v2', () => ({
+  createOpencodeClient: createOpencodeClientMock,
+}));
+
+mock.module('@/contexts/runtimeAPIRegistry', () => ({
+  getRegisteredRuntimeAPIs: mock(() => null),
+}));
+
+mock.module('@/lib/runtime-url', () => ({
+  getRuntimeUrlResolver: mock(() => ({
+    api: (path: string) => path,
+  })),
+}));
+
+mock.module('@/lib/runtime-switch', () => ({
+  getRuntimeApiBaseUrl: mock(() => ''),
+  getRuntimeKey: mock(() => 'test-runtime'),
+}));
+
+mock.module('@/lib/runtime-fetch', () => ({
+  runtimeFetch: mock(async () => new Response(JSON.stringify([]), {
+    headers: { 'Content-Type': 'application/json' },
+  })),
+}));
+
+mock.module('@/lib/startupTrace', () => ({
+  markStartupTrace: mock(() => undefined),
+}));
+
+const { opencodeClient } = await import(`./client?cache-test-agents=${Date.now()}`);
+
+/**
+ * Drive the in-flight mocked `list()` call to the next resolver with the
+ * given response shape. Each test owns exactly one queued call, so this
+ * is unambiguous as long as tests do not overlap.
+ */
+const resolveNext = (response: AgentListTestResponse) => {
+  queueMicrotask(() => {
+    const resolver = pendingResolutions.shift();
+    if (resolver) resolver(response);
+  });
+};
+
+const sampleAgent: AgentV2Fixture = {
+  id: 'build',
+  description: 'Build agent',
+  mode: 'primary',
+  hidden: false,
+  system: 'You are a build agent.',
+  color: '#ff00aa',
+  steps: 5,
+  model: { id: 'claude-opus-4-5', providerID: 'anthropic' },
+  permissions: [{ action: 'edit', resource: '*', effect: 'allow' }],
+};
+
+beforeEach(() => {
+  pendingResolutions.length = 0;
+  pendingArgs.length = 0;
+  opencodeClient.currentDirectory = undefined;
+});
+
+describe('opencodeClient.listAgents', () => {
+  test('V2 200 success returns mapped Agent[] with V1 field names', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'ok', agents: [sampleAgent] });
+    const result = await promise;
+    expect(result).toHaveLength(1);
+    const mapped = result[0];
+    // Direct field mappings
+    expect(mapped.name).toBe(sampleAgent.id);
+    expect(mapped.description).toBe(sampleAgent.description);
+    expect(mapped.mode).toBe(sampleAgent.mode);
+    expect(mapped.hidden).toBe(sampleAgent.hidden);
+    expect(mapped.color).toBe(sampleAgent.color);
+    expect(mapped.prompt).toBe(sampleAgent.system);
+    expect(mapped.steps).toBe(sampleAgent.steps);
+    // Body-derived (sample.request.body is {} so temperature/topP/options are empty)
+    expect(mapped.options).toEqual({});
+    expect(mapped.topP).toBe(undefined);
+    expect(mapped.temperature).toBe(undefined);
+    expect(mapped.variant).toBe(undefined);
+    // Derived: 'build' is a stock built-in ID (AgentV2.defaultID)
+    expect(mapped.native).toBe(true);
+    // Model ref mapping (V2 ModelRef.id/providerID -> V1 Agent.model.modelID/providerID)
+    expect(mapped.model).toEqual({
+      modelID: sampleAgent.model!.id,
+      providerID: sampleAgent.model!.providerID,
+    });
+    // Permission: V2 {action,resource,effect} -> V1-shaped {permission,pattern,action}
+    // (structural equality; NOT reference equality with V2 input array).
+    expect(mapped.permission).toEqual([
+      { permission: 'edit', pattern: '*', action: 'allow' },
+    ]);
+    expect(pendingArgs).toEqual([
+      { location: { directory: '/workspace/project' } },
+    ]);
+  });
+
+  test('V2 200 with empty data throws (NOT silently empty success)', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'empty' });
+    await expect(promise).rejects.toThrow(/agent\.list failed: empty response/);
+  });
+
+  test('V2 200 with malformed payload (data missing) throws explicit "invalid response" error', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'malformed' });
+    await expect(promise).rejects.toThrow('agent.list failed: invalid response (non-array data)');
+  });
+
+  test('V2 4xx with error payload throws with status code; no V1 resend', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'client-error' });
+    await expect(promise).rejects.toThrow(/agent\.list failed \(404\)/);
+    // Confirm only the V2 call was made; the V1 app.agents path is gone.
+    expect(pendingArgs).toHaveLength(1);
+  });
+
+  test('V2 5xx with error payload throws with status code', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'server-error' });
+    await expect(promise).rejects.toThrow(/agent\.list failed \(500\)/);
+  });
+
+  test('Network/transport error (rejected promise) throws transient error', async () => {
+    const promise = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'throw' });
+    await expect(promise).rejects.toThrow('network down');
+  });
+
+  test('listAgentsInFlight dedup: 2 concurrent calls for same directory share one V2 request', async () => {
+    const p1 = opencodeClient.listAgents('/workspace/project');
+    const p2 = opencodeClient.listAgents('/workspace/project');
+    // Only one underlying V2 call should have been queued so far.
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: 'ok', agents: [sampleAgent] });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(r2);
+    expect(pendingArgs).toHaveLength(1);
+    expect(pendingArgs[0]).toEqual({
+      location: { directory: '/workspace/project' },
+    });
+  });
+
+  test('listAgentsInFlight cleanup after error (Map is not poisoned)', async () => {
+    const failing = opencodeClient.listAgents('/workspace/project');
+    resolveNext({ kind: 'server-error' });
+    await expect(failing).rejects.toThrow(/agent\.list failed \(500\)/);
+
+    // After the failure the dedup Map must be cleared so a fresh call
+    // re-issues the underlying V2 request rather than returning the
+    // rejected promise forever.
+    const recovered = opencodeClient.listAgents('/workspace/project');
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: 'ok', agents: [sampleAgent] });
+    const result = await recovered;
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe(sampleAgent.id);
+    expect(pendingArgs).toHaveLength(2);
+  });
+
+  test('effectiveDirectory: null input + currentDirectory set uses currentDirectory; dedup key matches across normalization variants', async () => {
+    opencodeClient.currentDirectory = 'D:/workspace/project';
+    // Whitespace/case variants must normalize to the same dedup key as the
+    // canonical currentDirectory form.
+    const p1 = opencodeClient.listAgents(null);
+    const p2 = opencodeClient.listAgents('  d:/workspace/project  ');
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: 'ok', agents: [sampleAgent] });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(r2);
+    expect(pendingArgs).toHaveLength(1);
+    expect(pendingArgs[0]).toEqual({
+      location: { directory: 'D:/workspace/project' },
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // Consumer-semantic regression tests (added in corrective rewrite).
+  //
+  // Each test verifies that the DTO mapping preserves the exact field
+  // shape the production consumer reads. The previous implementation
+  // used `as unknown as Agent['permission']` which left V2-shaped
+  // {action, resource, effect} rules in place -- every consumer that
+  // reads rule.permission / rule.pattern then saw undefined, which made
+  // permissionUtils.getAgentDefaultEditPermission silently return 'ask'
+  // for every agent and broke buildAgentsSignature cache stability.
+  // ----------------------------------------------------------------------
+
+  // (A) Permission rule field rename preserves consumer field names.
+  test("V2 permissions field-rename produces V1-shaped rules that consumers can read directly", async () => {
+    const agentWithRules: AgentV2Fixture = {
+      id: "build",
+      mode: "primary",
+      hidden: false,
+      system: "sys",
+      permissions: [
+        { action: "edit", resource: "*", effect: "allow" },
+        { action: "*", resource: "*", effect: "deny" },
+      ],
+    };
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithRules] });
+    const [mapped] = await promise;
+    // Field names must be the V1-shaped ones -- not the V2 wire names.
+    expect(mapped.permission).toHaveLength(2);
+    expect(mapped.permission[0]).toEqual({ permission: "edit", pattern: "*", action: "allow" });
+    expect(mapped.permission[1]).toEqual({ permission: "*", pattern: "*", action: "deny" });
+    // Consumers reading V1-shaped fields must see strings, not undefined.
+    expect(mapped.permission[0].permission).toBe("edit");
+    expect(mapped.permission[0].pattern).toBe("*");
+    expect(mapped.permission[0].action).toBe("allow");
+    expect(mapped.permission[1].permission).toBe("*");
+    expect(mapped.permission[1].pattern).toBe("*");
+    expect(mapped.permission[1].action).toBe("deny");
+  });
+
+  // (B) temperature/topP from request.body produce cache-stable mapping.
+  test("V2 temperature/topP in request.body map to V1 agent.temperature/agent.topP", async () => {
+    const agentWithBody = {
+      id: "build",
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [] as Array<{ action: string; resource: string; effect: string }>,
+      request: { headers: {}, body: { temperature: 0.7, top_p: 0.9, foo: "bar" } },
+    } as unknown as AgentV2Fixture;
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithBody] });
+    const [mapped] = await promise;
+    expect(mapped.temperature).toBe(0.7);
+    expect(mapped.topP).toBe(0.9);
+    // options is the original opaque bag MINUS the reserved keys that
+    // stock V1->V2 migration splices into body (temperature, top_p).
+    // Those reserved keys live at the top level (agent.temperature /
+    // agent.topP) and must NOT be duplicated inside options.
+    expect(mapped.options).toEqual({ foo: "bar" });
+    // buildAgentsSignature-equivalent concatenation must differ from
+    // the previous implementation (which dropped these fields).
+    const signatureWithMapped = "t=" + String(mapped.temperature) + "|top_p=" + String(mapped.topP);
+    const signatureWithUndefined = "t=undefined|top_p=undefined";
+    expect(signatureWithMapped).not.toBe(signatureWithUndefined);
+    expect(signatureWithMapped).toBe("t=0.7|top_p=0.9");
+  });
+
+  // (C) model.variant maps to V1 agent.variant (NOT undefined).
+  test("V2 model.variant maps to V1 agent.variant", async () => {
+    const agentWithVariant: AgentV2Fixture = {
+      id: "build",
+      mode: "primary",
+      hidden: false,
+      permissions: [],
+      model: { id: "claude-opus-4-5", providerID: "anthropic", variant: "max" },
+    };
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithVariant] });
+    const [mapped] = await promise;
+    expect(mapped.model).toEqual({ modelID: "claude-opus-4-5", providerID: "anthropic" });
+    expect(mapped.variant).toBe("max");
+    expect(mapped.variant).not.toBe(undefined);
+  });
+
+  // (D) request.body maps to V1 agent.options MINUS reserved keys
+  // (temperature, top_p). Stock V1->V2 migration composes
+  // body = {...options, temperature, top_p}; the inverse must strip
+  // those reserved keys so agent.temperature / agent.topP at the top
+  // level are not duplicated inside options, and so the original
+  // opaque options bag is preserved.
+  test("V2 request.body maps to V1 agent.options minus reserved keys (temperature, top_p)", async () => {
+    const originalBody = { temperature: 0.5, top_p: 0.9, foo: "bar", baz: 42 };
+    const agentWithBody = {
+      id: "build",
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [] as Array<{ action: string; resource: string; effect: string }>,
+      request: { headers: {}, body: originalBody },
+    } as unknown as AgentV2Fixture;
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithBody] });
+    const [mapped] = await promise;
+    // Top-level fields carry the reserved values, NOT options.
+    expect(mapped.temperature).toBe(0.5);
+    expect(mapped.topP).toBe(0.9);
+    // options holds the user's original opaque bag with reserved keys removed.
+    expect(mapped.options).toEqual({ foo: "bar", baz: 42 });
+    // The original body object is NOT mutated (no `delete` on input).
+    expect(originalBody).toEqual({ temperature: 0.5, top_p: 0.9, foo: "bar", baz: 42 });
+    expect(Object.prototype.hasOwnProperty.call(originalBody, "temperature")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(originalBody, "top_p")).toBe(true);
+  });
+
+  // (E) Built-in detection for all 7 stock built-in IDs.
+  test("V2 built-in agents (build/plan/general/explore/compaction/title/summary) produce native=true", async () => {
+    const builtIns: AgentV2Fixture[] = [
+      "build", "plan", "general", "explore", "compaction", "title", "summary",
+    ].map((id) => ({
+      id,
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [],
+    }));
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: builtIns });
+    const result = await promise;
+    expect(result).toHaveLength(7);
+    for (const agent of result) {
+      expect(agent.native).toBe(true);
+    }
+    expect(result.map((a: { name?: string }) => a.name)).toEqual([
+      "build", "plan", "general", "explore", "compaction", "title", "summary",
+    ]);
+  });
+
+  test("V2 user-defined agent with non-built-in ID produces native=false", async () => {
+    const custom: AgentV2Fixture = {
+      id: "my-custom-agent",
+      mode: "primary",
+      hidden: false,
+      permissions: [],
+    };
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [custom] });
+    const [mapped] = await promise;
+    expect(mapped.native).toBe(false);
+  });
+
+  // (F) End-to-end: the exact regression scenario.
+  test("V2 agent with edit-allow rule -> consumers read rule.permission='edit' / rule.pattern='*' / rule.action='allow'", async () => {
+    const agentWithEditRule: AgentV2Fixture = {
+      id: "build",
+      mode: "primary",
+      hidden: false,
+      permissions: [
+        { action: "edit", resource: "*", effect: "allow" },
+      ],
+    };
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithEditRule] });
+    const [mapped] = await promise;
+
+    // Inline the resolvePermissionAction lookup logic so the test exercises
+    // the exact regression without coupling to permissionUtils module mocks.
+    let resultForEdit: "allow" | "deny" | "ask" | undefined;
+    for (const rule of mapped.permission) {
+      if (rule.permission === "edit" && rule.pattern === "*") {
+        resultForEdit = rule.action;
+        break;
+      }
+    }
+    // The previous "as unknown as" implementation would produce a V2-shaped
+    // rule where rule.permission is undefined; the lookup above would never
+    // match. The corrected mapping must restore the V1 semantics.
+    expect(resultForEdit).toBe("allow");
+  });
+
+  // (G) Non-wildcard resource patterns are preserved (not collapsed to "*").
+  test("V2 permissions with non-wildcard resource preserve the pattern after mapping", async () => {
+    const agentWithPaths: AgentV2Fixture = {
+      id: "build",
+      mode: "primary",
+      hidden: false,
+      permissions: [
+        { action: "edit", resource: "/etc/passwd", effect: "deny" },
+        { action: "edit", resource: "*", effect: "allow" },
+      ],
+    };
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithPaths] });
+    const [mapped] = await promise;
+    expect(mapped.permission).toHaveLength(2);
+    expect(mapped.permission[0].pattern).toBe("/etc/passwd");
+    expect(mapped.permission[0].permission).toBe("edit");
+    expect(mapped.permission[0].action).toBe("deny");
+    expect(mapped.permission[1].pattern).toBe("*");
+    expect(mapped.permission[1].permission).toBe("edit");
+    expect(mapped.permission[1].action).toBe("allow");
+    const patterns = mapped.permission.map((r: { pattern?: string }) => r.pattern);
+    expect(patterns).toEqual(["/etc/passwd", "*"]);
+  });
+
+  // (H) Malformed V2 permission entries are a payload violation and THROW.
+  // Silent drop would let allow / deny / ask decisions drift without
+  // detection (downstream consumers like resolvePermissionAction compare
+  // rule.permission === 'edit', which never matches undefined and
+  // silently degrades every permission check to 'ask'). The throw
+  // propagates through listAgents so the caller preserves its existing
+  // cache and retries on the next invocation; the listAgentsInFlight
+  // dedup Map is NOT poisoned by the throw.
+
+  test("V2 permissions with malformed action throw (NOT silently dropped) -- preserves caller cache for retry", async () => {
+    // Given: V2 returns a rule with action=42 (not a string).
+    const agentWithBadAction = {
+      id: "build",
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [
+        { action: "edit", resource: "*", effect: "allow" },
+        { action: 42, resource: "*", effect: "deny" }, // malformed: action is a number
+      ],
+    } as unknown as AgentV2Fixture;
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithBadAction] });
+    // When: listAgents() is called.
+    // Then: throws with the exact payload-violation message naming the
+    // bad field. The message propagates from the mapping helper up
+    // through listAgents -- listAgents must NOT swallow it.
+    await expect(promise).rejects.toThrow(
+      "agent.list failed: malformed permission rule (action=42)",
+    );
+
+    // The listAgentsInFlight Map must be cleared after the throw so a
+    // subsequent call with valid data re-issues the request and
+    // succeeds (cache-preservation invariant: failures do not poison
+    // the dedup Map).
+    const recovered = opencodeClient.listAgents("/workspace/project");
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: "ok", agents: [sampleAgent] });
+    const result = await recovered;
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe(sampleAgent.id);
+    expect(pendingArgs).toHaveLength(2);
+  });
+
+  test("V2 permissions with malformed resource throw (NOT silently dropped)", async () => {
+    // Given: V2 returns a rule with action='edit' (string) but
+    // resource=null (not a string).
+    const agentWithBadResource = {
+      id: "build",
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [
+        { action: "edit", resource: null, effect: "allow" }, // malformed: resource is null
+      ],
+    } as unknown as AgentV2Fixture;
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithBadResource] });
+    await expect(promise).rejects.toThrow(
+      "agent.list failed: malformed permission rule (resource=null)",
+    );
+
+    // listAgentsInFlight is NOT poisoned: subsequent valid call works.
+    const recovered = opencodeClient.listAgents("/workspace/project");
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: "ok", agents: [sampleAgent] });
+    const result = await recovered;
+    expect(result[0].name).toBe(sampleAgent.id);
+  });
+
+  test("V2 permissions with unknown effect throw (NOT silently dropped)", async () => {
+    // Given: V2 returns a rule with effect='maybe' (not in the
+    // allow | deny | ask union enforced by the V2 schema).
+    const agentWithBadEffect = {
+      id: "build",
+      mode: "primary" as const,
+      hidden: false,
+      permissions: [
+        { action: "edit", resource: "*", effect: "maybe" }, // malformed: effect outside union
+      ],
+    } as unknown as AgentV2Fixture;
+    const promise = opencodeClient.listAgents("/workspace/project");
+    resolveNext({ kind: "ok", agents: [agentWithBadEffect] });
+    await expect(promise).rejects.toThrow(
+      "agent.list failed: malformed permission rule (effect=maybe)",
+    );
+
+    // listAgentsInFlight is NOT poisoned: subsequent valid call works.
+    const recovered = opencodeClient.listAgents("/workspace/project");
+    expect(pendingResolutions).toHaveLength(1);
+    resolveNext({ kind: "ok", agents: [sampleAgent] });
+    const result = await recovered;
+    expect(result[0].name).toBe(sampleAgent.id);
+  });
+
+});

--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -10,6 +10,7 @@ import type {
   Provider,
   Config,
   Agent,
+  AgentV2Info,
   TextPartInput,
   FilePartInput,
 } from "@opencode-ai/sdk/v2";
@@ -339,6 +340,124 @@ const getDesktopFilesApi = (): FilesAPI | null => {
     return apis.files;
   }
   return null;
+};
+
+/**
+ * Stock V2 built-in agent IDs. V2 wire does not expose a `native` (or
+ * `builtIn`) flag — derived from `packages/core/src/plugin/agent.ts` in
+ * stock OpenCode 1.18.25, which initializes these IDs via
+ * `draft.update(AgentV2.ID.make(...))`. The default agent uses the
+ * brand name "build" (set via `AgentV2.defaultID`).
+ */
+const BUILT_IN_AGENT_IDS: ReadonlySet<string> = new Set([
+  'build', 'plan', 'general', 'explore', 'compaction', 'title', 'summary',
+]);
+
+/** V1-shaped permission rule effect values. V2 `PermissionV2Effect` is the
+ *  same union ("allow" | "deny" | "ask") — typed here locally so we can
+ *  narrow the mapped rule's `action` field without dragging in any UI-side
+ *  PermissionAction type. */
+type MappedPermissionAction = 'allow' | 'deny' | 'ask';
+
+const isMappedPermissionAction = (value: unknown): value is MappedPermissionAction =>
+  value === 'allow' || value === 'deny' || value === 'ask';
+
+/**
+ * Map V2 wire `AgentV2Info` to the V2 SDK's V1-shaped `Agent` type alias
+ * (`@opencode-ai/sdk/v2` re-exports the V1-shaped type under the same name).
+ *
+ * Verified against stock OpenCode 1.18.25 (packages/schema/src/agent.ts,
+ * packages/schema/src/permission.ts, packages/core/src/v1/config/migrate.ts,
+ * packages/core/src/plugin/agent.ts).
+ *
+ * Field parity:
+ * - mapped directly: name=v2.id, description, mode, hidden, color, prompt=v2.system, steps
+ * - mapped via V2 location:
+ *     temperature <- v2.request.body.temperature (if number)
+ *     topP       <- v2.request.body.top_p        (if number)
+ *     variant    <- v2.model.variant
+ *     model      <- v2.model ? { modelID: v2.model.id, providerID: v2.model.providerID } : undefined
+ *     options    <- v2.request.body MINUS reserved {temperature, top_p}
+ *                   (the inverse of stock V1->V2 migration: V1 stores
+ *                   temperature/topP at top level and `options` as a
+ *                   separate opaque bag; stock migrateAgent composes
+ *                   body = {...options, temperature, top_p}. The reverse
+ *                   must strip the reserved keys to avoid duplicating
+ *                   them between options and the top-level agent.temperature
+ *                   / agent.topP fields, which would violate the legacy
+ *                   V1 wire contract that consumers and the cache
+ *                   signature depend on.)
+ * - mapped via explicit field rename:
+ *     permission <- v2.permissions.map(r => ({ permission: r.action, pattern: r.resource, action: r.effect }))
+ *                  // V2 Permission.Rule = { action: string; resource: string; effect: "allow"|"deny"|"ask" }
+ *                  // V1 PermissionRule  = { permission: string; pattern: string; action: "allow"|"deny"|"ask" }
+ *                  // Semantics are equivalent (Wildcard.match on action/resource);
+ *                  // only the field names are renamed. See packages/core/src/permission.ts:evaluate.
+ * - derived (V2 wire does not expose this flag):
+ *     native     <- v2.id is in the stock built-in ID set
+ *                  ({ "build", "plan", "general", "explore", "compaction", "title", "summary" })
+ *                  // Source: packages/core/src/plugin/agent.ts
+ *
+ * Validation: every mapped field has a production consumer in OpenChamber UI
+ * (useAgentsStore.buildAgentsSignature, permissionUtils.resolvePermissionAction,
+ * ModelControls/AgentPermissionsEditor/AgentsSidebar rule iteration, etc.).
+ *
+ * Payload violation: malformed V2 permission entries (non-string action /
+ * non-string resource / effect outside the typed union) are treated as a
+ * payload violation and this function THROWS an Error with the prefix
+ * `agent.list failed: malformed permission rule (...)`. The throw
+ * propagates through listAgents so the caller (useAgentsStore /
+ * useConfigStore) preserves its existing cache and retries on the next
+ * invocation. Silent drop of malformed rules would let allow / deny / ask
+ * decisions drift without detection — downstream consumers (e.g.
+ * resolvePermissionAction) compare `rule.permission === 'edit'`, which
+ * never matches an `undefined` field, silently degrading every
+ * permission check to 'ask'.
+ */
+const normalizeAgentV2ToV1 = (v2: AgentV2Info): Agent => {
+  const body = (v2.request?.body ?? {}) as Record<string, unknown>;
+  const temperature = typeof body.temperature === 'number' ? body.temperature : undefined;
+  const topP = typeof body.top_p === 'number' ? body.top_p : undefined;
+  const permissions = (v2.permissions ?? []).map((rule) => {
+    if (typeof rule.action !== 'string') {
+      throw new Error(`agent.list failed: malformed permission rule (action=${String(rule.action)})`);
+    }
+    if (typeof rule.resource !== 'string') {
+      throw new Error(`agent.list failed: malformed permission rule (resource=${String(rule.resource)})`);
+    }
+    if (!isMappedPermissionAction(rule.effect)) {
+      throw new Error(`agent.list failed: malformed permission rule (effect=${String(rule.effect)})`);
+    }
+    return {
+      permission: rule.action,
+      pattern: rule.resource,
+      action: rule.effect,
+    };
+  });
+  // Strip the reserved keys (inverse of stock V1->V2 body composition) so
+  // options holds only the user's original opaque bag. Use a plain for-loop
+  // + continue instead of `delete` (which mutates the input object).
+  const options: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (key === 'temperature' || key === 'top_p') continue;
+    options[key] = value;
+  }
+  return {
+    name: v2.id,
+    description: v2.description,
+    mode: v2.mode,
+    hidden: v2.hidden,
+    temperature,
+    topP,
+    color: v2.color,
+    permission: permissions,
+    model: v2.model ? { modelID: v2.model.id, providerID: v2.model.providerID } : undefined,
+    variant: v2.model?.variant,
+    prompt: v2.system,
+    options,
+    steps: v2.steps,
+    native: BUILT_IN_AGENT_IDS.has(v2.id),
+  };
 };
 
 class OpencodeService {
@@ -1626,30 +1745,26 @@ class OpencodeService {
       return existing;
     }
 
+    // V2 contract: the 200 response envelope is `{ location, data: AgentV2Info[] }`.
+    // We unwrap `response.data.data` to get the agent list (matches the pattern
+    // used by V2 consumers in this file, e.g. v2.session.permission.get).
     const request = (async () => {
-      const params = effectiveDirectory ? { directory: effectiveDirectory } : undefined;
-      const response = await this.client.app.agents(params);
-      if (!response.error && Array.isArray(response.data) && response.data.length > 0) {
-        return response.data;
+      const location = effectiveDirectory ? { directory: effectiveDirectory } : undefined;
+      const response = await this.client.v2.agent.list(location ? { location } : undefined);
+      if (response.error) {
+        throw new Error(`agent.list failed (${response.response?.status ?? 'unknown'}): ${formatSdkError(response.error)}`);
       }
-
-      // SDK gap / endpoint drift: current OpenCode exposes the authoritative
-      // agent list at /agent, while app.agents can be empty on some runtimes.
-      const fallbackResponse = await runtimeFetch('/api/agent', {
-        ...(effectiveDirectory ? { query: { directory: effectiveDirectory } } : {}),
-      });
-      if (!fallbackResponse.ok) {
-        if (response.error) {
-          throw new Error(`app.agents failed${response.response?.status ? ` (${response.response.status})` : ''}: ${formatSdkError(response.error)}`);
-        }
-        throw new Error(`agent.list failed (${fallbackResponse.status})`);
+      const data = response.data?.data;
+      if (!Array.isArray(data)) {
+        throw new Error('agent.list failed: invalid response (non-array data)');
       }
-
-      const fallbackData = await fallbackResponse.json().catch(() => null) as unknown;
-      if (!Array.isArray(fallbackData)) {
-        throw new Error('agent.list failed: invalid response');
+      // V1 semantic preserved: an empty V2 response is treated as a hard
+      // failure rather than silently returning []. Silent empty would defeat
+      // caller-side retries and clear the cached agent list.
+      if (data.length === 0) {
+        throw new Error('agent.list failed: empty response');
       }
-      return fallbackData as Agent[];
+      return data.map(normalizeAgentV2ToV1);
     })();
 
     this.listAgentsInFlight.set(key, request);


### PR DESCRIPTION
## Final disposition

Closed as superseded by the #3259 selected-runtime architecture.

The production implementation in this PR belongs to the old mixed-runtime migration model and will not be merged.

Preserved:
- The 20-case consumer-semantic test suite and audits (field parity, permission semantics `{action, resource, effect}` → `{permission, pattern, action}`, model `{providerID, modelID}` + variant, temperature/topP/options, native/built-in derivation evidence, malformed-input behavior, empty-result/cache-preservation, cache-signature parity) — recorded in #3259 `Post-hybrid salvage manifest` (agent items A1–A12) as evidence for a future user-owned corrective PR once the #3007-style adapter seam exists on an appropriate integration base. No parallel Agent implementation is being kept.

Disposition:
- production path (`normalizeAgentV2ToV1`, direct `client.v2.agent.list`, `client.ts` changes): **dropped** — #3007 owns the adapter seam; nothing moved into #3424
- main-independent tests: **none ported** (the mapping tests require the adapter seam, which does not exist on current main)
- adapter-specific tests/evidence: **recorded in #3259 for future user-owned corrective work**
- #3007 remains external/read-only and was not modified; the previously confirmed `normalizeAgent` gaps (options inverse mapping, temperature, topP, native derivation, malformed-permission handling, empty-result handling) were re-confirmed against current #3007 HEAD (`8840378c4`) during close-out

Historical implementation details below are retained as engineering evidence.
## Architecture status

> **PROPOSED / SELECTED FOR #3259 — not maintainer-approved policy.**
>
> This PR was implemented under the superseded capability-by-capability #3259 migration model (direct `client.v2.agent.list` replacing the V1 `app.agents` path inside the shared facade).
>
> Under the current #3259 dual-runtime proposal, this production diff should NOT simply become "if runtime = V2 → direct listAgents V2": current #3007 (`feat/opencode-v2-compat` @ `5a424cf7`) already provides `app.agents` → V2 agent list → normalization → existing OpenChamber `Agent` contract through its adapter seam. A second direct-V2 agent path would duplicate the adapter architecture.
>
> The branch remains open as engineering evidence. Do not infer maintainer rejection or project-wide architectural approval from this status.

### Branch change (2026-09-03 reconciliation)

The branch was rebased onto current `main` and the CI-unblock Turkish i18n cherry-pick (`712644e3a`) was **dropped**: the same 4 `gitView.empty.*` Turkish keys landed on `main` via #3302, so the cherry-pick is redundant and the unrelated i18n change is no longer folded into Agent work. Old HEAD: `712644e3a`; new HEAD: `3ce119f1a`.

### #3007 overlap findings (2026-09-03 audit, kept as evidence)

#3007's `normalizeAgent` maps the V2 wire shape but currently differs from this PR's field-verified mapping in ways that matter if it becomes the one adapter seam:

- `options`: #3007 uses `agent.request.settings`; this PR derives `options = request.body MINUS reserved {temperature, top_p}` (the exact inverse of stock `migrate.ts:migrateAgent` body composition).
- `temperature`/`topP`: #3007 does not source them from `request.body`.
- `native` (built-in detection): #3007 has no `BUILT_IN_AGENT_IDS` derivation; V2 wire does not expose the flag.
- Malformed permission entries: #3007 does not throw on malformed `{action, resource, effect}`; this PR does (with cache-non-poisoning tests).
- Empty V2 response: #3007 returns `[]`; this PR throws to preserve caller retry semantics.

**If #3007's adapter becomes the single agent seam, these findings belong there** (`PORT TEST/FIX TO #3007 INTEGRATION`), not as a second Agent implementation. The 20-case consumer-semantic suite (`client.agents.test.ts`), permission-field audit, model mapping audit, temperature/topP/options audit, cache-signature tests, malformed-input tests, and the read→write impact audit are the durable salvage.

---

## Intent

Replace `OpencodeService.listAgents` with a typed V2 SDK call (`this.client.v2.agent.list(...)`), eliminating the V1 `app.agents()` first-attempt and the raw `runtimeFetch('/api/agent')` fallback. Map V2 wire `AgentV2Info` to the V2 SDK's V1-shaped `Agent` alias via a module-private `normalizeAgentV2ToV1` DTO helper for downstream UI consumers.

Unit-7 under tracking #3259 (independent V2 migration, exec-independent read).

## Tracking

#3259

## Status

REVIEW

## Corrective rewrite history

**Previous version** (`a504e3c1`) used `as unknown as Agent['permission']` to map V2 `permissions: Array<{action, resource, effect}>` to V1 `permission: Array<{permission, pattern, action}>`. This cast hid a real semantic incompatibility and silently regressed production consumers that read `rule.permission` and `rule.pattern`:

- `permissionUtils.resolvePermissionAction(ruleset, 'edit')` returned `'ask'` for every V2-sourced agent because V2 rules had no `.permission` field.
- `ModelControls`, `AgentPermissionsEditor`, `AgentsSidebar` rule-iteration paths degraded (no effective rules shown in the editor).
- `useAgentsStore.buildAgentsSignature` cache signature broke for `temperature`, `topP`, `variant`, `options`, `native`.

**Corrected version** (`e72807d9`): proper field-by-element DTO mapping per stock OpenCode 1.18.25 source (`packages/core/src/v1/config/migrate.ts`, `packages/schema/src/{agent,permission}.ts`, `packages/core/src/plugin/agent.ts`). All previously-regressed consumers now see V1-shape values; `permissionUtils` correctly returns `allow` / `deny` / `ask` per the V2 agent's permission config.

**Second corrective pass** (`bcdfde712`, amended from `e72807d9`): two semantic-parity gaps addressed. (1) Malformed V2 permission entries (non-string `action`/`resource`, or `effect` outside `allow|deny|ask`) now THROW `agent.list failed: malformed permission rule (...)` — the throw propagates through `listAgents` so the caller preserves its cache and retries; silent drop would let allow/deny/ask decisions drift without detection. (2) `options` now equals `v2.request.body` MINUS reserved `{temperature, top_p}` — the exact inverse of stock `migrate.ts:migrateAgent` body composition (`body = {...options, temperature, top_p}`); the previous `options: body` violated the legacy contract by duplicating `temperature`/`top_p` between top-level and the options bag.

**CI-unblock cherry-pick** (historical, HEAD `712644e3a` before the 2026-09-03 rebase): commit `2d03060791` (cherry-picked verbatim from PR #3285 @ 2d03060791 — `fix(i18n): add Turkish Git discovery messages`) brought the 4 missing Turkish translations to `packages/ui/src/lib/i18n/messages/tr.ts`. **Superseded on 2026-09-03:** the same 4 keys landed on `main` via #3302, so the cherry-pick was dropped during the rebase onto current `main` (current HEAD `3ce119f1a`); the unrelated i18n change is no longer part of this PR. Current-head CI is green without it.

## Effective base

```text
main: 85a95bb8ebf509749695bec29feedcf03a893e0a
prerequisites: none
SDK/runtime: @opencode-ai/sdk@1.18.25 (pinned)
stock OpenCode: anomalyco/opencode @ v1.18.25 (verified via tarball + GitHub source)
```

## Consumer audit (per migration policy §33)

All production consumers of `listAgents()` and `Agent` fields audited. Per-field mapping verified against stock V2 source.

### `listAgents()` callers
- `packages/ui/src/stores/useAgentsStore.ts:361` — `loadAgents(directory)` cache
- `packages/ui/src/stores/useConfigStore.ts:2091` — `loadAgents(directory)` startup config

### `Agent` field consumers (production paths)

| Field       | Production consumers | V2 source | Mapping policy |
| ----------- | -------------------- | --------- | -------------- |
| `name`      | `useConfigStore`, `useAgentsStore`, all UI | `v2.id` | direct |
| `description` | `AgentsPage`, sidebar | `v2.description` | direct |
| `mode`      | `useConfigStore`, `isPrimaryMode` selector | `v2.mode` | direct (same enum) |
| `hidden`    | `isAgentHidden`, `filterVisibleAgents` | `v2.hidden` | direct |
| `temperature` | `useAgentsStore.buildAgentsSignature` | `v2.request.body.temperature` | read opaque JSON; typeof number |
| `topP`      | `useAgentsStore.buildAgentsSignature` (also `top_p`) | `v2.request.body.top_p` | read opaque JSON; typeof number |
| `color`     | UI theme | `v2.color` | direct (V2 Color ⊆ string) |
| `permission` | `permissionUtils.resolvePermissionAction` (edit), `ModelControls`, `AgentPermissionsEditor.effectiveRules`, `AgentsSidebar`, `PermissionCard` | `v2.permissions` | **field rename**: `{action, resource, effect}` → `{permission: action, pattern: resource, action: effect}`. Semantically equivalent (Wildcard.match on action/resource). Malformed entries (non-string action/resource or effect outside `allow\|deny\|ask`) THROW `agent.list failed: malformed permission rule (...)` — caller preserves cache and retries. |
| `model.modelID` | `useAgentsStore.buildAgentsSignature`, `AgentSelector` | `v2.model.id` | rename (id → modelID) |
| `model.providerID` | same | `v2.model.providerID` | direct |
| `variant`   | `useAgentsStore.buildAgentsSignature`, `useAgentsStore` AgentConfig | `v2.model.variant` | direct (V2 model.variant) |
| `prompt`    | `useAgentsStore.buildAgentsSignature`, UI | `v2.system` | rename (system → prompt) |
| `options`   | `useAgentsStore.buildAgentsSignature`, `isAgentHidden` (defensive `options?.hidden`) | `v2.request.body` MINUS reserved `{temperature, top_p}` | inverse of stock `migrate.ts:migrateAgent` body composition (`body = {...options, temperature, top_p}`); no duplicates with top-level temperature/topP |
| `steps`     | `useAgentsStore.buildAgentsSignature` | `v2.steps` | direct |
| `native`    | `isAgentBuiltIn` | **NOT IN V2 WIRE** | derived from stock built-in ID set: `{build, plan, general, explore, compaction, title, summary}` (per `packages/core/src/plugin/agent.ts`) |
<!-- table not formatted: invalid structure -->

### `isAgentBuiltIn` semantics

V2 wire does not expose a `native` (or `builtIn`) flag — V2 considers all agents equal in `AgentV2Info`. The migration derives `native: true` for stock built-in IDs and `native: false` for user-defined agents. This preserves the OpenChamber `isAgentBuiltIn` behavior. Alternative approach (read from a separate V2 source) was rejected: no production V2 endpoint exposes the built-in flag explicitly.

### Permission semantic equivalence (proven from stock source)

```ts
// stock OpenCode 1.18.25 — packages/core/src/permission.ts:evaluate
export function evaluate(action: string, resource: string, ...rulesets: Permission.Ruleset[]): Permission.Rule {
  return (
    rulesets
      .flat()
      .findLast((rule) => Wildcard.match(action, rule.action) && Wildcard.match(resource, rule.resource)) ?? {
      action, resource: "*", effect: "ask",
    }
  )
}

// stock OpenCode 1.18.25 — packages/schema/src/permission.ts
export const Rule = Schema.Struct({
  action: Schema.String,
  resource: Schema.String,
  effect: Effect,  // "allow" | "deny" | "ask"
}).annotate({ identifier: "PermissionV2.Rule" })

// stock OpenCode 1.18.25 — packages/schema/src/permission.ts
export const Effect = Schema.Literals(["allow", "deny", "ask"])
```

V1 `PermissionRule` = `{ permission, pattern, action: "allow"|"deny"|"ask" }` — identical effect union; `permission` and `pattern` are field names only, not semantic categories. `Wildcard.match` operates on `action` and `resource` strings in both V1 and V2. Field rename is the only difference.

## Field parity matrix

| V1 `Agent` field | V1 wire location | V2 wire location | Lossless | Verified mapping |
| ---------------- | ---------------- | ---------------- | -------- | ---------------- |
| name             | string           | v2.id            | YES      | direct           |
| description      | string?          | v2.description?  | YES      | direct           |
| mode             | enum             | v2.mode          | YES      | direct           |
| hidden           | boolean          | v2.hidden        | YES      | direct           |
| temperature      | number?          | v2.request.body.temperature | YES | read opaque JSON, typeof number |
| topP             | number?          | v2.request.body.top_p      | YES | read opaque JSON, typeof number |
| color            | string?          | v2.color?        | YES      | direct (V2 Color ⊆ string) |
| permission       | Array<{permission,pattern,action}> | v2.permissions Array<{action,resource,effect}> | YES (semantic equiv via Wildcard.match) | element-by-element rename |
| model.modelID     | string?          | v2.model.id      | YES      | rename            |
| model.providerID | string?          | v2.model.providerID | YES   | direct            |
| variant           | string?          | v2.model.variant | YES      | move to model.variant |
| prompt           | string?          | v2.system        | YES      | rename            |
| options          | {[k]:unknown}    | v2.request.body MINUS reserved {temperature, top_p} | YES (lossless inverse of stock V1->V2 body composition; original `body` object not mutated) | for-loop with `continue` (no `delete`); reserved keys stripped |
| steps            | number?          | v2.steps?        | YES      | direct            |
| native           | boolean          | **NOT IN V2**    | N/A      | derived from built-in ID set |

## Native V2 evidence

```text
V2 contract: client.v2.agent.list({ location?: { directory?, workspace? } })
              → { location: LocationInfo; data: AgentV2Info[] }
Source: @opencode-ai/sdk@1.18.25 dist/v2/gen/sdk.gen.d.ts:1519-1524
        + dist/v2/gen/types.gen.d.ts:9654-9662 (V2AgentListResponses)
        + dist/v2/gen/types.gen.d.ts:3169-3180 (AgentV2Info shape)
        + dist/v2/gen/types.gen.d.ts:3163-3167 (PermissionV2Rule)
Stock schema: anomalyco/opencode @ v1.18.25
              - packages/schema/src/agent.ts (Agent.Info)
              - packages/schema/src/permission.ts (Permission.Rule, Permission.Effect)
              - packages/core/src/v1/config/migrate.ts (authoritative V1→V2 mapping)
              - packages/core/src/plugin/agent.ts (built-in agent IDs)
              - packages/core/src/permission.ts (Wildcard.match evaluation)
Maturity: stable V2 endpoint, production-ready shape, no experimental flags
```

## V1 status

- **`getProvidersForConfig`** (V1 `config.providers`): **KEEP V1**. V2 `/api/provider` returns `ProviderV2Info[]` (integration methods / disabled / request request payload), — different shape than what `getProvidersForConfig` returns (`{ providers, default }` for UI default-model picker). No V2 direct consumer in OpenChamber UI; migrating without consumer is speculative (§63).
- **`opencode2-adapter.ts`** (from #3007): remains as V1-server-compat fallback for runtimes where V2 endpoint is unavailable. This PR does not import from it.
- **V1 `app.agents` path and raw `runtimeFetch('/api/agent')` fallback**: removed from main `client.ts`.
- **V1 `PermissionRule[]`**: replaced in `client.ts`'s `listAgents` return with V2-shaped data field-renamed back to V1 shape via `normalizeAgentV2ToV1`. UI consumers continue to read `rule.permission` / `rule.pattern` / `rule.action`.

## V2 purity (§69) — confirmed

- Actual V2 typed SDK call: `this.client.v2.agent.list(...)` (client.ts:1675).
- DTO mapping is mapping existing semantics, not fabricating missing backend behavior.
- No `as unknown as` cast on permission (helper region verified clean via grep).
- No silent V1 resend, no raw HTTP fallback, no JSON-via-prompt emulation.

## Behavior delta (vs previous V1 code)

- **Empty V2 response now throws** `agent.list failed: empty response` instead of silently returning `[]`. Matches the original JSDoc contract on `listAgents` ("an empty list would defeat retries and clear the cached agent list"). No callers depend on silent-empty behavior:
  - `packages/ui/src/stores/useAgentsStore.ts:361` — immediately consumes result
  - `packages/ui/src/stores/useConfigStore.ts:2091` — immediately consumes result

- **Permission semantics now preserved correctly** (vs previous broken cast):
  - `permissionUtils.resolvePermissionAction(agent.permission, 'edit')` returns `allow` / `deny` / `ask` per actual V2 agent config.
  - `ModelControls` rule-iteration finds the correct rule for tool key + pattern.
  - `AgentPermissionsEditor.effectiveRules` shows non-empty rules for V2 data.
  - `AgentsSidebar` permission map renders correctly.

- **Cache signature now stable** for all fields including `temperature`, `topP`, `variant`, `options`, `native`.
- **Malformed V2 permission entries THROW** (NOT silently dropped) — caller preserves cache and retries; `listAgentsInFlight` Map is not poisoned.
- **`options` parity is exact** (inverse of stock V1->V2 `migrate.ts:migrateAgent` body composition): `options = body MINUS reserved {temperature, top_p}`; no duplicate temperature/top_p between top-level and options; original `body` object not mutated.

## Validation

```text
Pre-change baseline (effective base 85a95bb8e):
- bun --cwd packages/ui test: 368/369 files pass (1 known i18n parity failure)
- bun --cwd packages/ui test packages/ui/src/lib/opencode/: 23/23 pass
- bun --cwd packages/ui type-check: clean
- bun --cwd packages/ui lint: clean
- i18n parity test (`messages.test.ts > 'all locales stay in key parity with english'`):
  fails on the exact effective-base SHA 85a95bb8e with the same 4 missing keys
  (`gitView.empty.discoverFailed`, `discoveringRepositories`, `retryDiscovery`,
  `selectRepositoryPlaceholder`). Verified locally on a clean checkout of
  85a95bb8e — independent of Unit-7 changes.

Post-change (historical, HEAD 712644e3a before the 2026-09-03 rebase — Unit-7 + Turkish i18n cherry-pick; the cherry-pick no longer applies at current HEAD `3ce119f1a`):
- bun --cwd packages/ui test: 370/370 files pass (was 369/370 on bcdfde712; cherry-pick resolves the i18n baseline)
- bun --cwd packages/ui test packages/ui/src/lib/opencode/: 43/43 pass (6 files, +11 new consumer-semantic tests, 0 failures)
- bun --cwd packages/ui test packages/ui/src/lib/opencode/client.agents.test.ts: 20/20 pass
- bun --cwd packages/ui test packages/ui/src/lib/i18n/messages.test.ts: 2/2 pass
- bun --cwd packages/ui type-check: clean
- bun --cwd packages/ui lint: clean
- New failures vs baseline: 0
- Migration-induced regressions: 0

CI on this PR (historical, HEAD 712644e3a before the 2026-09-03 rebase — Unit-7 + Turkish i18n cherry-pick folded in at that time; current HEAD `3ce119f1a` is green without the cherry-pick because #3302 landed the same keys on main):

- **Before the cherry-pick** (`bcdfde712`): the `checks` job was red on a single
  i18n parity test (`i18n dictionaries > all locales stay in key parity with
  english`, missing `gitView.empty.discoverFailed` / `discoveringRepositories`
  / `retryDiscovery` / `selectRepositoryPlaceholder` in non-English locales).
  This was a **pre-existing baseline failure** because:
  - Unit-7 core scope is limited to `packages/ui/src/lib/opencode/client.ts`
    and `packages/ui/src/lib/opencode/client.agents.test.ts` — neither touches
    i18n.
  - The same i18n failure reproduces on the **exact effective-base SHA
    85a95bb8e** (verified locally by checking out upstream/main into a fresh
    worktree and running `bun test packages/ui/src/lib/i18n/messages.test.ts`
    in isolation; the same 4 keys are missing on the effective base,
    independent of Unit-7).
  - GitHub Actions does not return a workflow run for a bare SHA on `main`,
    so the effective-base parity baseline was reproduced locally on a clean
    checkout of 85a95bb8e instead.

- **After the cherry-pick** (`712644e3a`, historical head before the rebase): the i18n parity test
  passes. Full UI suite: **370/370**. The `checks` job is green.

Cast audit (correctness gate):
- grep 'as unknown as' packages/ui/src/lib/opencode/client.ts in lines 344-445:
  NONE in normalizeAgentV2ToV1 + BUILT_IN_AGENT_IDS region
- 3 pre-existing as-unknown-as usages at lines 1318/1457/1536 are in unrelated
  methods (sendMessages, getUserPermissions, getUserQuestions) and outside scope.

Test coverage (20 cases total):
- 9 transport cases: success, empty, malformed payload, 4xx, 5xx, network, dedup, cleanup, directory normalization
- 11 consumer-semantic regression cases:
  A. Permission field-rename produces V1-shaped rules
  B. temperature/topP from request.body
  C. variant from model.variant
  D. options from request.body MINUS reserved keys (temperature, top_p) — original body not mutated
  E1. built-in IDs produce native=true
  E2. user-defined IDs produce native=false
  F. end-to-end edit permission resolution (the regression that was broken in the previous version)
  G. non-wildcard resource pattern preservation
  H1. malformed V2 permission entry with non-string action THROWS (NOT silently dropped) and listAgentsInFlight cache is NOT poisoned
  H2. malformed V2 permission entry with non-string resource THROWS
  H3. malformed V2 permission entry with unknown effect THROWS
```

## Related

- Turkish i18n cherry-pick from PR #3285 @ commit `2d03060791` was folded into this PR at the pre-rebase head `712644e3a` and was **dropped during the 2026-09-03 rebase** (the same 4 keys landed on `main` via #3302, making the cherry-pick redundant; see Branch change at the top of this body). No cross-PR merge-order dependency remains.
- No prerequisites. Standalone PR.

## Affected files

- `packages/ui/src/lib/opencode/client.ts` (+155/-20) — `listAgents` body replaced with typed V2 SDK call; `normalizeAgentV2ToV1` helper rewritten with proper field-by-element DTO mapping (malformed permission entries throw; options = body minus reserved keys); `BUILT_IN_AGENT_IDS` constant added; `MappedPermissionAction`/`isMappedPermissionAction` helpers added.
- `packages/ui/src/lib/opencode/client.agents.test.ts` (new, 564 lines) — 20 test cases (9 transport + 11 consumer-semantic regression: permission field rename, request.body sourcing, model.variant sourcing, options-minus-reserved-keys with body non-mutation invariant, built-in detection for 7 stock IDs, end-to-end edit permission resolution, non-wildcard resource pattern preservation, 3 malformed-throw tests with cache-non-poisoning invariant).
- `packages/ui/src/lib/i18n/messages/tr.ts` (+4/-0) — **removed from this PR during the 2026-09-03 rebase.** It was a cherry-pick from PR #3285 @ commit `2d03060791` (`fix(i18n): add Turkish Git discovery messages`) applied only at the pre-rebase head `712644e3a` to unblock the pre-existing i18n parity baseline; the same keys landed on `main` via #3302, so the current PR diff contains only `client.ts` and `client.agents.test.ts`.

## Engineering delta (§65)

- V1 raw HTTP fallback (`/api/agent`) removed: yes
- Typed V2 SDK adopted: yes
- Compatibility branches removed: yes (V1 `app.agents` + raw-fetch paths deleted)
- Distinct execution state machines: N/A (read-only)
- Client-owned execution mechanisms: N/A (read-only)
- Mixed execution ownership paths: 0 (this path is read-only; execution ownership unchanged)
- Lost-message regressions: 0 (verified via test E1/E2 + cache-signature tests)
- Duplicate-execution regressions: N/A (read-only)
- Type laundering in DTO mapping: 0 (verified via grep; helper region contains 0 `as unknown as`)
- Malformed V2 permission handling: throw-on-violation (NOT silent drop; preserves cache + retry semantics)
- Options parity: exact inverse of stock V1->V2 body composition; no duplicate temperature/top_p between top-level and options

## Cross-runtime parity (§58)

`packages/ui/src/lib/opencode/client.ts` is shared by web, desktop, VS Code, and mobile/shared UI. The diff introduces no `isWeb`/`isDesktop`/`isVSCode`/`isMobile` branching. All runtimes inherit identical behavior.

## Failure / rollback

- **Failure**: V2 runtime returns malformed payload (data not an array). Mapped to throw `agent.list failed: invalid response (non-array data)`. Caller-store retries.
- **Failure**: V2 runtime returns `data: []`. Mapped to throw `agent.list failed: empty response` (preserves V1 contract; callers retry).
- **Failure**: V2 4xx/5xx with `error` payload. Mapped to throw with status code. **No V1 resend** (§69).
- **Failure**: Network/transport rejection. Mapped to throw transient error. **No V1 resend** (§69).
- **Failure**: V2 permission entry with malformed fields (non-string action/resource or effect outside `allow|deny|ask` union). Mapped to throw `agent.list failed: malformed permission rule (...)`. Caller preserves its existing cache and retries on next invocation; `listAgentsInFlight` Map is NOT poisoned.
- **Rollback**: revert this single commit; `listAgents` returns to V1 `app.agents` + raw-fetch fallback. No data migration, no cleanup required.






