### PR TITLE
feat(vscode): add Turkish localization for extension strings

### DIFF
--- a/packages/vscode/l10n/bundle.l10n.tr.json
+++ b/packages/vscode/l10n/bundle.l10n.tr.json
@@ -1,0 +1,23 @@
+{
+  "OpenChamber: Failed to open sidebar - {0}": "OpenChamber: Kenar çubuğu açılamadı - {0}",
+  "OpenChamber: Chat sidebar is not ready": "OpenChamber: Chat kenar çubuğu hazır değil",
+  "OpenChamber: No active session": "OpenChamber: Aktif oturum yok",
+  "OpenChamber: API connection restarted": "OpenChamber: API bağlantısı yeniden başlatıldı",
+  "OpenChamber: Failed to restart API - {0}": "OpenChamber: API yeniden başlatılamadı - {0}",
+  "OpenChamber [Add to Context]: No active editor": "OpenChamber [Bağlama Ekle]: Aktif düzenleyici yok",
+  "OpenChamber [Add to Context]: No text selected": "OpenChamber [Bağlama Ekle]: Metin seçilmedi",
+  "OpenChamber: No file selected to mention": "OpenChamber: Bahsetmek için dosya seçilmedi",
+  "OpenChamber: Some selected entries were skipped (folders or unsupported resources)": "OpenChamber: Seçilen bazı öğeler atlandı (klasörler veya desteklenmeyen kaynaklar)",
+  "OpenChamber [Explain]: No active editor": "OpenChamber [Açıkla]: Aktif düzenleyici yok",
+  "Explain the following Code / Text:": "Aşağıdaki Kodu / Metni açıkla:",
+  "OpenChamber [Improve Code]: No active editor": "OpenChamber [Kodu İyileştir]: Aktif düzenleyici yok",
+  "OpenChamber [Improve Code]: No text selected": "OpenChamber [Kodu İyileştir]: Metin seçilmedi",
+  "Improve the following Code:": "Aşağıdaki Kodu iyileştir:",
+  "OpenCode CLI not found. Install it and ensure it's in PATH.": "OpenCode CLI bulunamadı. Yükleyin ve PATH içinde olduğundan emin olun.",
+  "OpenCode CLI not found. Please install it and ensure it's in PATH.": "OpenCode CLI bulunamadı. Lütfen yükleyin ve PATH içinde olduğundan emin olun.",
+  "More Info": "Daha fazla bilgi",
+  "Failed to start OpenCode: {0}": "OpenCode başlatılamadı: {0}",
+  "New Session": "Yeni Oturum",
+  "Session": "Oturum",
+  "Agent Manager": "Agent Yöneticisi"
+}

--- a/packages/vscode/package.nls.tr.json
+++ b/packages/vscode/package.nls.tr.json
@@ -1,0 +1,20 @@
+{
+  "extension.description": "OpenCode destekli AI kodlama asistanı",
+  "views.chat.name": "Chat",
+  "command.openSidebar.title": "Kenar çubuğunu aç",
+  "command.focusChat.title": "Chat'e odaklan",
+  "command.restartApi.title": "API bağlantısını yeniden başlat",
+  "command.showOpenCodeStatus.title": "OpenCode durumunu göster",
+  "command.openAgentManager.title": "Agent yöneticisini aç",
+  "command.openActiveSessionInEditor.title": "Aktif oturumu düzenleyicide aç",
+  "command.openNewSessionInEditor.title": "Düzenleyicide yeni oturum aç",
+  "command.openCurrentOrNewSessionInEditor.title": "Oturumu düzenleyicide aç",
+  "command.addToContext.title": "Bağlama ekle",
+  "command.explain.title": "Açıkla",
+  "command.improveCode.title": "Kodu iyileştir",
+  "command.newSession.title": "Yeni oturum",
+  "command.showSettings.title": "Ayarlar",
+  "command.attachExplorerToChat.title": "OpenChamber Chat'ine ekle",
+  "configuration.apiUrl.description": "Harici bir OpenCode API sunucusunun URL'si. Yerel bir örneğin otomatik başlatılması için boş bırakın.",
+  "configuration.opencodeBinary.description": "opencode CLI ikili dosyasının (binary) isteğe bağlı mutlak yolu. PATH araması başarısız olduğunda faydalıdır. Uygulanması için pencere yeniden yükleme veya API yeniden başlatma gerekir."
+}


### PR DESCRIPTION
## Intent

The VS Code extension ships localized strings for French (`package.nls.fr.json` + `l10n/bundle.l10n.fr.json`) but has no Turkish, even though the OpenChamber UI has had a full Turkish translation since #3064 (shipped in v1.21.1). A Turkish user gets Turkish UI in the panel but English commands, menus, and notifications from the extension itself. This PR adds the two missing Turkish l10n files so the extension surface matches the UI locale.

## Non-goals

- Adding Turkish to the pre-bundle loading splash in `webviewHtml.ts` (`getBootstrapMessages()` only special-cases `fr` today) — planned as a separate follow-up to keep this PR to pure l10n files.
- Localizing other locales or touching the French files.

## Affected surfaces

- `packages/vscode/package.nls.tr.json` (new) — 18 manifest strings: command titles, view name, configuration descriptions. VS Code resolves these by file convention (`package.nls.<lang>.json`), same as the existing French file; no `package.json` change needed.
- `packages/vscode/l10n/bundle.l10n.tr.json` (new) — 21 runtime strings covering the `t(...)` call sites in `extension.ts`, `opencode.ts`, `SessionEditorPanelProvider.ts`, `AgentManagerPanelProvider.ts`. `l10n` is already declared in `package.json` (`"l10n": "./l10n"`) and the files are not excluded by `.vscodeignore`, so they ship in the .vsix like the French ones.

No webview/UI/server behavior changes; when the host locale is not Turkish, VS Code falls back to the English default exactly as before.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Locale contribution guidance (as applied in #3064 for the UI) | New user-facing translations must be complete and consistent | All 18 + 21 strings translated; product names (OpenChamber, OpenCode, CLI, PATH) kept literal; `{0}` placeholders preserved |
| French files as the structural reference | Only shipped locale to mirror | Same key sets (18/21), same file locations, no registry changes required |

## Validation

| Check | Result |
|---|---|
| Key parity vs English sources (programmatic, sorted key diff) | 18/18 nls, 21/21 bundle — empty diff |
| `{0}` placeholder parity across bundle strings | 0 differences |
| JSON parse of both new files | Valid |
| Note: the failing `checks` job on this PR is the pre-existing i18n parity failure on `main` (the 4 `gitView.empty.*` keys missing from `tr.ts`); #3251 fixes exactly that. Not caused by this diff — no UI dictionary files are touched here. | Explained |

## Visual evidence

Not a UI-layout change; extension command palette/menus will render the new titles only when VS Code display language is Turkish (`tr`/tr-*), otherwise behavior is unchanged.