### PR TITLE
feat(vscode): localize loading splash and dev-server status for Turkish

### DIFF
--- a/packages/vscode/src/webviewHtml.ts
+++ b/packages/vscode/src/webviewHtml.ts
@@ -202,31 +202,48 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
         var rawLocale = window.localStorage.getItem('openchamber.i18n.v1');
         if (rawLocale) {
           var parsedLocale = JSON.parse(rawLocale);
-          if (parsedLocale && typeof parsedLocale.locale === 'string' && parsedLocale.locale.toLowerCase().indexOf('fr') === 0) {
-            locale = 'fr';
+          if (parsedLocale && typeof parsedLocale.locale === 'string') {
+            var detected = parsedLocale.locale.toLowerCase();
+            if (detected.indexOf('fr') === 0) {
+              locale = 'fr';
+            } else if (detected.indexOf('tr') === 0) {
+              locale = 'tr';
+            }
           }
         }
       } catch {}
 
-      return locale === 'fr'
-        ? {
-            startingApi: 'Démarrage de l’API OpenCode…',
-            initializing: 'Initialisation…',
-            connecting: 'Connexion…',
-            connected: 'Connecté !',
-            connectionError: 'Erreur de connexion',
-            reconnecting: 'Reconnexion…',
-            cliNotFound: 'L’interface en ligne de commande OpenCode est introuvable. Veuillez l’installer d’abord.',
-          }
-        : {
-            startingApi: 'Starting OpenCode API…',
-            initializing: 'Initializing…',
-            connecting: 'Connecting…',
-            connected: 'Connected!',
-            connectionError: 'Connection error',
-            reconnecting: 'Reconnecting…',
-            cliNotFound: 'OpenCode CLI not found. Please install it first.',
-          };
+      if (locale === 'fr') {
+        return {
+          startingApi: 'Démarrage de l’API OpenCode…',
+          initializing: 'Initialisation…',
+          connecting: 'Connexion…',
+          connected: 'Connecté !',
+          connectionError: 'Erreur de connexion',
+          reconnecting: 'Reconnexion…',
+          cliNotFound: 'L’interface en ligne de commande OpenCode est introuvable. Veuillez l’installer d’abord.',
+        };
+      }
+      if (locale === 'tr') {
+        return {
+          startingApi: 'OpenCode API başlatılıyor…',
+          initializing: 'Başlatılıyor…',
+          connecting: 'Bağlanılıyor…',
+          connected: 'Bağlandı!',
+          connectionError: 'Bağlantı hatası',
+          reconnecting: 'Yeniden bağlanılıyor…',
+          cliNotFound: 'OpenCode CLI bulunamadı. Lütfen önce yükleyin.',
+        };
+      }
+      return {
+        startingApi: 'Starting OpenCode API…',
+        initializing: 'Initializing…',
+        connecting: 'Connecting…',
+        connected: 'Connected!',
+        connectionError: 'Connection error',
+        reconnecting: 'Reconnecting…',
+        cliNotFound: 'OpenCode CLI not found. Please install it first.',
+      };
     }
 
     (function applyBootstrapLocale() {
@@ -283,11 +300,20 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
           const rawLocale = window.localStorage.getItem('openchamber.i18n.v1');
           if (rawLocale) {
             const parsedLocale = JSON.parse(rawLocale);
-            if (parsedLocale && typeof parsedLocale.locale === 'string' && parsedLocale.locale.toLowerCase().indexOf('fr') === 0) {
-              return {
-                startingDevServer: (host) => 'Démarrage du serveur de développement de la webview (' + host + ')...',
-                waitingDevServer: (host, attempt) => 'En attente du serveur de développement de la webview (' + host + ')... tentative ' + attempt,
-              };
+            if (parsedLocale && typeof parsedLocale.locale === 'string') {
+              const detected = parsedLocale.locale.toLowerCase();
+              if (detected.indexOf('fr') === 0) {
+                return {
+                  startingDevServer: (host) => 'Démarrage du serveur de développement de la webview (' + host + ')...',
+                  waitingDevServer: (host, attempt) => 'En attente du serveur de développement de la webview (' + host + ')... tentative ' + attempt,
+                };
+              }
+              if (detected.indexOf('tr') === 0) {
+                return {
+                  startingDevServer: (host) => 'Webview geliştirme sunucusu başlatılıyor (' + host + ')...',
+                  waitingDevServer: (host, attempt) => 'Webview geliştirme sunucusu bekleniyor (' + host + ')... deneme ' + attempt,
+                };
+              }
             }
           }
         } catch {}


### PR DESCRIPTION
## Intent

Add Turkish CLI-missing, generic connection-error, and dev-server status text to the VS Code inline bootstrap maps. These messages use the locale saved by OpenChamber. English remains the fallback, and ordinary progress text remains intentionally hidden.

## Non-goals

- Refactoring the inline locale detection into a shared helper or moving these strings to `l10n` bundles — both blocks live inside generated HTML templates and follow the existing per-locale pattern; a refactor would widen the diff for no user-visible gain.
- Adding other locales.

## Affected surfaces

- `packages/vscode/src/webviewHtml.ts` — two embedded script blocks:
  - `getBootstrapMessages()`: locale detection now extracts the stored locale once and matches `fr` or `tr` prefixes; adds a 7-string Turkish branch (`startingApi`, `initializing`, `connecting`, `connected`, `connectionError`, `reconnecting`, `cliNotFound`). English remains the default fallback, French output is byte-identical to before.
  - `getDevMessages()` (dev server only): adds a Turkish branch for the two dev-server status strings. Production bundles are unaffected.

No persisted/external contract changes; the stored locale key (`openchamber.i18n.v1`) and detection semantics (case-insensitive prefix match) are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Locale contribution guidance (per #3064) | New user-facing translations must be complete and consistent with the shipped glossary | 7 + 2 strings translated consistently with the #3300 l10n files; product names (OpenCode, CLI) kept literal |
| Existing `fr` inline pattern in `webviewHtml.ts` | Only shipped reference for these embedded strings | Mirrors the French structure exactly; no new mechanism introduced |

## Validation

The PR's package type-check, lint, tests, and build completed successfully in GitHub CI at `81226404bb97061b9cbd0eba0e0ee12215574429`.

`packages/vscode/src/webviewHtml.test.ts` checks CSP tokens only. It does not validate bootstrap message translations. Maintainer review traced Turkish CLI-missing text, the generic connection-error fallback, and dev-server status text from the saved OpenChamber locale to their DOM consumers. No live Turkish VS Code run was performed by the maintainer.

## Visual evidence

Normal progress text is intentionally blank in `applyBootstrapLocale` and the `connectionStatus` listener. This PR translates CLI-missing text, the generic connection-error fallback, and dev-server status text using the saved OpenChamber locale. The earlier claimed progress-text transition was not supported by the code and has been removed. No screenshot is attached.
