### PR TITLE
feat(ui): add OpenCode CLI theme (dark and light presets)

### DIFF
--- a/packages/ui/src/lib/theme/themes/opencode-dark.json
+++ b/packages/ui/src/lib/theme/themes/opencode-dark.json
@@ -1,0 +1,180 @@
+{
+  "metadata": {
+    "id": "opencode-dark",
+    "name": "OpenCode",
+    "description": "The OpenCode CLI default theme: near-black grayscale surfaces, peach primary, One Dark-style syntax accents",
+    "author": "OpenCode",
+    "version": "1.0.0",
+    "variant": "dark",
+    "tags": [
+      "dark",
+      "opencode",
+      "ported"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#fab283",
+      "hover": "#d7996d",
+      "active": "#ffc09f",
+      "foreground": "#0a0a0a",
+      "muted": "#fab28380",
+      "emphasis": "#ffc09f"
+    },
+    "surface": {
+      "background": "#0a0a0a",
+      "foreground": "#eeeeee",
+      "muted": "#14141490",
+      "mutedForeground": "#808080",
+      "elevated": "#1e1e1e90",
+      "elevatedForeground": "#eeeeee",
+      "overlay": "#00000080",
+      "subtle": "#282828"
+    },
+    "interactive": {
+      "border": "#484848",
+      "borderHover": "#606060",
+      "borderFocus": "#fab283",
+      "selection": "#eeeeee1f",
+      "selectionForeground": "#eeeeee",
+      "focus": "#fab283",
+      "focusRing": "#fab28361",
+      "cursor": "#eeeeee",
+      "hover": "#eeeeee17",
+      "active": "#eeeeee1f"
+    },
+    "status": {
+      "error": "#e06c75",
+      "errorForeground": "#0a0a0a",
+      "errorBackground": "#e06c7529",
+      "errorBorder": "#e06c7573",
+      "warning": "#f5a742",
+      "warningForeground": "#0a0a0a",
+      "warningBackground": "#f5a74229",
+      "warningBorder": "#f5a74273",
+      "success": "#7fd88f",
+      "successForeground": "#0a0a0a",
+      "successBackground": "#7fd88f29",
+      "successBorder": "#7fd88f73",
+      "info": "#56b6c2",
+      "infoForeground": "#0a0a0a",
+      "infoBackground": "#56b6c229",
+      "infoBorder": "#56b6c273"
+    },
+    "pr": {
+      "open": "#7fd88f",
+      "draft": "#808080",
+      "blocked": "#f5a742",
+      "merged": "#9d7cd8",
+      "closed": "#e06c75"
+    },
+    "syntax": {
+      "base": {
+        "background": "#141414",
+        "foreground": "#eeeeee",
+        "comment": "#808080",
+        "keyword": "#9d7cd8",
+        "string": "#7fd88f",
+        "number": "#f5a742",
+        "function": "#fab283",
+        "variable": "#e06c75",
+        "type": "#e5c07b",
+        "operator": "#56b6c2"
+      },
+      "tokens": {
+        "commentDoc": "#606060",
+        "stringEscape": "#e5c07b",
+        "keywordImport": "#9d7cd8",
+        "storageModifier": "#9d7cd8",
+        "functionCall": "#fab283",
+        "method": "#fab283",
+        "variableProperty": "#56b6c2",
+        "variableOther": "#e06c75",
+        "variableGlobal": "#f5a742",
+        "variableLocal": "#e06c75",
+        "parameter": "#e06c75",
+        "constant": "#f5a742",
+        "class": "#e5c07b",
+        "className": "#e5c07b",
+        "interface": "#e5c07b",
+        "struct": "#e5c07b",
+        "enum": "#e5c07b",
+        "typeParameter": "#e5c07b",
+        "namespace": "#e5c07b",
+        "module": "#e06c75",
+        "tag": "#e06c75",
+        "jsxTag": "#e5c07b",
+        "tagAttribute": "#e5c07b",
+        "tagAttributeValue": "#7fd88f",
+        "boolean": "#f5a742",
+        "decorator": "#f5a742",
+        "label": "#9d7cd8",
+        "punctuation": "#eeeeee",
+        "macro": "#56b6c2",
+        "preprocessor": "#56b6c2",
+        "regex": "#7fd88f",
+        "url": "#56b6c2",
+        "key": "#fab283",
+        "exception": "#e06c75"
+      },
+      "highlights": {
+        "diffAdded": "#4fd6be",
+        "diffAddedBackground": "#20303b",
+        "diffRemoved": "#c53b53",
+        "diffRemovedBackground": "#37222c",
+        "diffModified": "#828bb8",
+        "diffModifiedBackground": "#141414",
+        "lineNumber": "#8f8f8f",
+        "lineNumberActive": "#eeeeee"
+      }
+    },
+    "markdown": {
+      "heading1": "#b39de4",
+      "heading2": "#a58ae0",
+      "heading3": "#9d7cd8",
+      "heading4": "#8a6ec9",
+      "link": "#fab283",
+      "linkHover": "#ffc09f",
+      "inlineCode": "#7fd88f",
+      "inlineCodeBackground": "#141414",
+      "blockquote": "#e5c07b",
+      "blockquoteBorder": "#484848",
+      "listMarker": "#fab28399"
+    },
+    "chat": {
+      "userMessage": "#eeeeee",
+      "userMessageBackground": "#141414",
+      "assistantMessage": "#eeeeee",
+      "assistantMessageBackground": "#0a0a0a",
+      "timestamp": "#808080",
+      "divider": "#484848"
+    },
+    "tools": {
+      "background": "#14141450",
+      "border": "#484848",
+      "headerHover": "#1e1e1e",
+      "icon": "#808080",
+      "title": "#fab283",
+      "description": "#808080",
+      "edit": {
+        "added": "#4fd6be",
+        "addedBackground": "#20303b",
+        "removed": "#c53b53",
+        "removedBackground": "#37222c",
+        "lineNumber": "#8f8f8f"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace",
+      "mono": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace",
+      "heading": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/opencode-light.json
+++ b/packages/ui/src/lib/theme/themes/opencode-light.json
@@ -1,0 +1,180 @@
+{
+  "metadata": {
+    "id": "opencode-light",
+    "name": "OpenCode",
+    "description": "The OpenCode CLI default theme (light variant): white grayscale surfaces, blue primary, warm accent highlighting",
+    "author": "OpenCode",
+    "version": "1.0.0",
+    "variant": "light",
+    "tags": [
+      "light",
+      "opencode",
+      "ported"
+    ]
+  },
+  "colors": {
+    "primary": {
+      "base": "#3b7dd8",
+      "hover": "#2968c3",
+      "active": "#5c9cf5",
+      "foreground": "#ffffff",
+      "muted": "#3b7dd880",
+      "emphasis": "#5c9cf5"
+    },
+    "surface": {
+      "background": "#ffffff",
+      "foreground": "#1a1a1a",
+      "muted": "#fafafa90",
+      "mutedForeground": "#8a8a8a",
+      "elevated": "#f5f5f590",
+      "elevatedForeground": "#1a1a1a",
+      "overlay": "#ffffff33",
+      "subtle": "#ebebeb"
+    },
+    "interactive": {
+      "border": "#b8b8b8",
+      "borderHover": "#a0a0a0",
+      "borderFocus": "#3b7dd8",
+      "selection": "#1a1a1a16",
+      "selectionForeground": "#1a1a1a",
+      "focus": "#3b7dd8",
+      "focusRing": "#3b7dd847",
+      "cursor": "#1a1a1a",
+      "hover": "#1a1a1a0e",
+      "active": "#1a1a1a16"
+    },
+    "status": {
+      "error": "#d1383d",
+      "errorForeground": "#ffffff",
+      "errorBackground": "#d1383d1f",
+      "errorBorder": "#d1383d59",
+      "warning": "#d68c27",
+      "warningForeground": "#ffffff",
+      "warningBackground": "#d68c271f",
+      "warningBorder": "#d68c2759",
+      "success": "#3d9a57",
+      "successForeground": "#ffffff",
+      "successBackground": "#3d9a571f",
+      "successBorder": "#3d9a5759",
+      "info": "#318795",
+      "infoForeground": "#ffffff",
+      "infoBackground": "#3187951f",
+      "infoBorder": "#31879559"
+    },
+    "pr": {
+      "open": "#3d9a57",
+      "draft": "#8a8a8a",
+      "blocked": "#d68c27",
+      "merged": "#7b5bb6",
+      "closed": "#d1383d"
+    },
+    "syntax": {
+      "base": {
+        "background": "#fafafa",
+        "foreground": "#1a1a1a",
+        "comment": "#8a8a8a",
+        "keyword": "#d68c27",
+        "string": "#3d9a57",
+        "number": "#d68c27",
+        "function": "#3b7dd8",
+        "variable": "#d1383d",
+        "type": "#b0851f",
+        "operator": "#318795"
+      },
+      "tokens": {
+        "commentDoc": "#a0a0a0",
+        "stringEscape": "#b0851f",
+        "keywordImport": "#d68c27",
+        "storageModifier": "#d68c27",
+        "functionCall": "#3b7dd8",
+        "method": "#3b7dd8",
+        "variableProperty": "#318795",
+        "variableOther": "#d1383d",
+        "variableGlobal": "#d68c27",
+        "variableLocal": "#d1383d",
+        "parameter": "#d1383d",
+        "constant": "#d68c27",
+        "class": "#b0851f",
+        "className": "#b0851f",
+        "interface": "#b0851f",
+        "struct": "#b0851f",
+        "enum": "#b0851f",
+        "typeParameter": "#b0851f",
+        "namespace": "#b0851f",
+        "module": "#d1383d",
+        "tag": "#d1383d",
+        "jsxTag": "#b0851f",
+        "tagAttribute": "#b0851f",
+        "tagAttributeValue": "#3d9a57",
+        "boolean": "#d68c27",
+        "decorator": "#d68c27",
+        "label": "#7b5bb6",
+        "punctuation": "#1a1a1a",
+        "macro": "#318795",
+        "preprocessor": "#318795",
+        "regex": "#3d9a57",
+        "url": "#318795",
+        "key": "#3b7dd8",
+        "exception": "#d1383d"
+      },
+      "highlights": {
+        "diffAdded": "#1e725c",
+        "diffAddedBackground": "#d5e5d5",
+        "diffRemoved": "#c53b53",
+        "diffRemovedBackground": "#f7d8db",
+        "diffModified": "#7086b5",
+        "diffModifiedBackground": "#fafafa",
+        "lineNumber": "#595959",
+        "lineNumberActive": "#1a1a1a"
+      }
+    },
+    "markdown": {
+      "heading1": "#d68c27",
+      "heading2": "#c67c1f",
+      "heading3": "#b0851f",
+      "heading4": "#8a8a8a",
+      "link": "#3b7dd8",
+      "linkHover": "#2968c3",
+      "inlineCode": "#3d9a57",
+      "inlineCodeBackground": "#fafafa",
+      "blockquote": "#b0851f",
+      "blockquoteBorder": "#b8b8b8",
+      "listMarker": "#3b7dd899"
+    },
+    "chat": {
+      "userMessage": "#1a1a1a",
+      "userMessageBackground": "#fafafa",
+      "assistantMessage": "#1a1a1a",
+      "assistantMessageBackground": "#ffffff",
+      "timestamp": "#8a8a8a",
+      "divider": "#b8b8b8"
+    },
+    "tools": {
+      "background": "#fafafa50",
+      "border": "#b8b8b8",
+      "headerHover": "#f5f5f5",
+      "icon": "#8a8a8a",
+      "title": "#3b7dd8",
+      "description": "#8a8a8a",
+      "edit": {
+        "added": "#1e725c",
+        "addedBackground": "#d5e5d5",
+        "removed": "#c53b53",
+        "removedBackground": "#f7d8db",
+        "lineNumber": "#595959"
+      }
+    }
+  },
+  "config": {
+    "fonts": {
+      "sans": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace",
+      "mono": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace",
+      "heading": "ui-monospace, \"SFMono-Regular\", \"Cascadia Mono\", \"Segoe UI Mono\", monospace"
+    },
+    "transitions": {
+      "fast": "150ms ease",
+      "normal": "250ms ease",
+      "slow": "350ms ease"
+    }
+  }
+}

--- a/packages/ui/src/lib/theme/themes/presets.ts
+++ b/packages/ui/src/lib/theme/themes/presets.ts
@@ -27,6 +27,8 @@ import fields_of_the_shire_dark_Raw from './fields-of-the-shire-dark.json';
 import fields_of_the_shire_light_Raw from './fields-of-the-shire-light.json';
 import onedarkpro_dark_Raw from './onedarkpro-dark.json';
 import onedarkpro_light_Raw from './onedarkpro-light.json';
+import opencode_dark_Raw from './opencode-dark.json';
+import opencode_light_Raw from './opencode-light.json';
 import solarized_dark_Raw from './solarized-dark.json';
 import solarized_light_Raw from './solarized-light.json';
 import tokyonight_dark_Raw from './tokyonight-dark.json';
@@ -67,6 +69,8 @@ export const presetThemes: Theme[] = [
   nord_light_Raw as Theme,
   onedarkpro_dark_Raw as Theme,
   onedarkpro_light_Raw as Theme,
+  opencode_dark_Raw as Theme,
+  opencode_light_Raw as Theme,
   solarized_dark_Raw as Theme,
   solarized_light_Raw as Theme,
   tokyonight_dark_Raw as Theme,


### PR DESCRIPTION
## Intent

OpenChamber runs on top of the OpenCode CLI, and many OpenChamber users are OpenCode CLI users first. This PR ports the **OpenCode CLI default theme** (the [`opencode` TUI theme from sst/opencode](https://github.com/sst/opencode/blob/dev/packages/tui/src/theme/assets/opencode.json)) as a built-in preset pair, so the desktop/web/VS Code UI can match the terminal look users stare at all day: near-black grayscale surfaces, warm peach primary, One Dark-style syntax accents, and monospace typography.

Color mapping: surfaces come from the TUI theme's grayscale steps (`#0a0a0a`/`#141414`/`#1e1e1a`→`#1e1e1e`/`#282828`), syntax/diff colors are taken verbatim from the upstream theme, and status backgrounds/borders follow the alpha conventions used by `scripts/port-opencode-theme.ts` (16%/45% alpha for dark, 12%/35% for light).

## Non-goals

- No changes to the theme system, the default theme, or any component styling — purely two new preset JSON files plus registration.
- No OpenCode-side changes; colors are ported one-way from the upstream TUI theme.
- Square-corner support: the example in `docs/CUSTOM_THEMES.md` shows a `config.radius` section, but it is not part of the `Theme` type (`packages/ui/src/types/theme.ts`) and `cssGenerator.ts` does not consume it, so the CLI's square-corner aesthetic is not expressible today. Left out intentionally; happy to split a separate change if maintainers want to wire `radius` up.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/ui` | Two new theme JSONs + 4 lines in `presets.ts` |
| Settings → Appearance | Two new dropdown entries ("OpenCode", light + dark variants) |
| Web / Desktop / VS Code | All inherit the new presets through the shared UI package; no per-runtime work needed |
| Persisted contracts | None — existing theme ids untouched; new ids (`opencode-dark`/`opencode-light`) are purely additive |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `theme-system` skill → `references/adding-themes.md` | Adding built-in themes | JSON pair `opencode-dark.json`/`opencode-light.json` in `packages/ui/src/lib/theme/themes/`, registered in `presets.ts` following the existing import/array conventions |
| `docs/CUSTOM_THEMES.md` | Theme format reference | Full schema coverage: all load-time required fields, `surface.muted`/`surface.elevated` with 90 alpha, well under the 512KB limit, unique ids |
| `CONTRIBUTING.md` PR contract | This PR | Template sections filled; light + dark visual evidence attached; validation reported honestly below |

## Validation

| Check | Result |
|---|---|
| Structural validation against the load-time validator (`packages/ui/src/contexts/theme-validation.ts`: required paths, variant, hex formats, 90-alpha rule, size limit) | **PASS** for both files — replicated the validator's required-path list in a standalone Node script and ran it against both JSONs |
| Manual load in OpenChamber desktop v1.22.0 (Windows) | Both variants load via Settings → Appearance → theme dropdowns and apply live, no app restart |
| Pixel-level check of the captured screenshots | Dark: 92.2% of sampled pixels at `#0a0a0a` background with the ported syntax palette present (green/peach/yellow/red/orange). Light: 91.6% white background + `#fafafa` panels with blue/orange/green/red syntax colors present |
| `bun run type-check / lint / test / build` | **Not run** — no Bun toolchain available on the contributor machine. CI is expected to cover these. The change is additive JSON plus four import/array lines mirroring existing entries, so the compile/lint surface is minimal |

## Visual evidence

OpenChamber desktop v1.22.0 on Windows, same session with code blocks in both states (loaded via the custom-themes directory, byte-identical colors to the built-in files in this PR):

| Dark | Light |
|---|---|
| ![OpenCode theme — dark](https://raw.githubusercontent.com/amuer/openchamber/opencode-theme-evidence/evidence/opencode-dark.png) | ![OpenCode theme — light](https://raw.githubusercontent.com/amuer/openchamber/opencode-theme-evidence/evidence/opencode-light.png) |

## Risks and failure behavior

- **Additive only**: worst case a theme fails validation and the loader skips it with a console warning (existing behavior); no other surface can regress.
- **Rollback**: revert the single commit.
- **No font dependency**: `config.fonts` uses the system monospace stack (same approach as the built-in `mono` themes), so nothing is bundled.
- **Naming**: `metadata.name` is "OpenCode" for both variants with ids `opencode-dark`/`opencode-light`, following the existing `vesper`/`vesper-dark` convention; happy to rename if maintainers prefer something else.
