### PR TITLE
feat(session-assist): give the suggestion the whole session, and a way to say nothing

### DIFF
--- a/packages/web/server/lib/session-assist/DOCUMENTATION.md
+++ b/packages/web/server/lib/session-assist/DOCUMENTATION.md
@@ -1,9 +1,24 @@
 # Session Assist
 
 Server-side watcher that generates a short recap of the agent's last reply
-and one suggested user follow-up with the small model
+and the agent's own proposed next step with the small model
 (`lib/small-model`), storing both on the session's metadata under
 `metadata.openchamber.assist`.
+
+## What the suggestion is
+
+The suggestion is written **in the agent's voice** — "I would…" — and says what
+it would do next if told to keep going. It is explicitly **not** an order
+addressed to the agent in the user's voice.
+
+That distinction is the reason the whole conversation is sent. A suggestion
+generated from the last exchange alone cannot see the request the session
+started from, so it has no way to know the work is finished, and its prompt
+gives it no way to say so: it will always manufacture a next step, and the
+agent's own "I did not verify X" caveats become the next instruction. The
+system prompt therefore requires an **empty string** when the user's request is
+already satisfied or the session is waiting on a human decision, and an empty
+suggestion is a correct answer rather than a generation failure.
 
 ## Flow
 
@@ -15,8 +30,7 @@ and one suggested user follow-up with the small model
    `retry` status or a user `message.updated` clears it (the "1 minute of
    quiet" rule).
 3. On fire: fetch the session (skip sub-agent sessions with `parentID`),
-   take the LAST exchange only — the final assistant reply plus the user
-   message it answered (assistant `parentID` → user id) — and call
+   render the WHOLE conversation (`buildTranscript`) and call
    `generateSmallModelText` with the
    session's own provider/model taken from the last assistant message — so
    the utility call spends the same subscription as the conversation.
@@ -30,6 +44,59 @@ and one suggested user follow-up with the small model
    re-checked (a stale result is dropped) and the metadata is merged from a
    fresh session read so concurrent metadata writes made during generation are
    preserved.
+
+## Transcript shape and the prefix cache
+
+`buildTranscript` renders every message oldest-first as `#N Role:` blocks —
+text parts plus **tool names only**, never tool input or output (a session can
+be almost entirely tool calls, so omitting them renders it as an empty
+conversation; including their payloads would pipe file contents and command
+lines into a utility prompt).
+
+Everything that varies per call — the pointer to the last message, the
+requested fields, the language sample — goes **after** the transcript. The
+history is therefore an append-only prefix between consecutive assists on one
+session, which a backend that caches prefixes can serve without re-prefilling.
+That is an opportunity, not a guarantee: it depends entirely on the provider.
+An OpenAI-compatible backend in front of vLLM or sglang does it automatically,
+and there the effect is large (measured: 35s for the first assist on a
+154k-character transcript, 8s for each of the next two). Anthropic caching, by
+contrast, requires explicit `cache_control` breakpoints, which `callSmallModel`
+never sends, so this ordering buys nothing there and costs nothing either.
+Over budget the oldest messages are dropped, but only on
+a `TRANSCRIPT_DROP_CHUNK` boundary: dropping one message per turn would move the
+start of the transcript every time and re-prefill the whole session on every
+cycle.
+
+The budget is not a constant. It comes from `describeSmallModel().inputCharBudget`
+for the model that will actually answer, minus `PROMPT_SCAFFOLD_RESERVE_CHARS`:
+a local proxy model is absent from the models.dev catalog and falls back to a
+conservative 64k context, so a fixed budget would either waste a large window or
+overflow a small one.
+
+This buys latency, not spend — the provider still bills every input token, and
+assist cost is now proportional to session length rather than constant. Text
+parts and tool names alone stay far below what the conversation itself sends:
+measured on live sessions, 403 messages render to ~10k tokens, 1921 to ~56k.
+
+**The fetch scales too, and it is the larger number.** `fetchSessionMessages`
+without a `limit` pulls every message with its parts, tool inputs and outputs
+included, and the transcript then keeps only text and tool names. On a long
+session that is a transient multi-megabyte download and JSON parse in the
+server process once per assist cycle, far bigger than the prompt it produces.
+It is bounded (one in-flight assist per session, a 20s timeout) and OpenCode's
+message endpoint offers no field projection to narrow it, but anyone measuring
+this feature's cost should measure the fetch, not just the model call.
+
+The prefix cache is **assist-to-assist only**. This module calls the provider
+directly, with its own system prompt and no tool schemas, so it shares no
+prefix with the request OpenCode makes for the conversation itself.
+
+Because the clamp in `lib/small-model` truncates the **tail**, which here is the
+instruction, the call passes `onOverflow: 'error'`. A session larger than its
+own model's context (`context-too-small`) and a reasoning model that spends the
+output budget thinking (`output-exhausted`) are expected outcomes of a
+whole-session transcript, so both are skipped without a warning.
 
 ## Settings gate
 

--- a/packages/web/server/lib/session-assist/runtime.js
+++ b/packages/web/server/lib/session-assist/runtime.js
@@ -36,11 +36,28 @@ const getSessionAssistTargets = () => {
 };
 
 const IDLE_QUIET_MS = 60_000;
-const TRANSCRIPT_MESSAGE_LIMIT = 12;
 const TRANSCRIPT_PART_CHAR_LIMIT = 6_000;
+// Over the budget the transcript is trimmed from the OLDEST end, and only ever
+// on a TRANSCRIPT_DROP_CHUNK boundary: the prompt is sent to the session's own
+// model, so consecutive assists on one session share a token prefix and hit the
+// backend's prefix cache. Dropping one message per turn would shift the start of
+// the transcript every time and defeat that.
+const TRANSCRIPT_DROP_CHUNK = 16;
+// Room left for everything the prompt wraps around the transcript: the header,
+// the pointer to the last message, the requested fields and the language sample.
+// Generous on purpose — the budget it is subtracted from is itself an estimate.
+const PROMPT_SCAFFOLD_RESERVE_CHARS = 2_000;
 const RECAP_CHAR_LIMIT = 320;
 const SUGGESTION_CHAR_LIMIT = 500;
 const FETCH_TIMEOUT_MS = 5_000;
+// The transcript is the whole session, so the message list can be large.
+const HISTORY_FETCH_TIMEOUT_MS = 20_000;
+const ASSIST_TIMEOUT_MS = 120_000;
+const STALENESS_TAIL_LIMIT = 4;
+// Expected outcomes of a whole-session transcript, not failures: a session
+// longer than its own model's context, and a reasoning model that spends the
+// output budget thinking. Both mean "no suggestion this cycle".
+const QUIET_GENERATION_CODES = new Set(['context-too-small', 'output-exhausted']);
 
 const buildAssistSystemPrompt = ({ recap, suggestion }) => [
   'You assist a user who chats with a coding agent. Based on the conversation transcript, return exactly one JSON object and nothing else — no prose, no markdown, no code fences.',
@@ -48,44 +65,40 @@ const buildAssistSystemPrompt = ({ recap, suggestion }) => [
   recap
     ? 'recap: at most 20 words. State the substance directly — the facts, result, or conclusion, plus the next move if there is one. NEVER narrate ("The assistant explained…", "The agent did…") — write the content itself, like a note the user jotted down.'
     : '',
-  suggestion ? 'suggestion: write ONE immediately sendable next user message addressed TO the coding agent.' : '',
-  suggestion ? 'The suggestion should be the most useful next step after the assistant\'s latest reply. It should help the user continue productively, not inspect already-known details.' : '',
-  suggestion ? 'Prefer suggestions that ask the agent to make a concrete improvement, implement something specific, validate the latest change, explain tradeoffs, improve the current approach, or continue from the current result.' : '',
+  // Written in the USER's voice because the client pastes this exact string
+  // into the composer for the user to send. A suggestion phrased as the agent
+  // ("I would do X") reads as nonsense once it lands there.
+  suggestion ? 'suggestion: write ONE short message the user could send to the coding agent as-is, asking for the next step.' : '',
+  suggestion ? 'You are given the WHOLE conversation, not just the end. Judge the next step against what the user actually asked for at the start, not only against your latest reply.' : '',
   suggestion ? 'Rules for suggestion:' : '',
-  suggestion ? '- Output exactly one message the user could click and send without editing.' : '',
-  suggestion ? '- Pick one best next action yourself.' : '',
+  suggestion ? '- Return an EMPTY STRING when there is no honest next step: the request the user made is already satisfied, or the conversation is waiting on a decision only the user can make. An empty suggestion is a correct and expected answer, not a failure.' : '',
+  suggestion ? '- Never invent follow-up work to fill the field. Finishing a task is a valid end state.' : '',
+  suggestion ? '- Work you flagged as unverified, out of scope, or "not tested" in your own reply is NOT automatically the next step. It is only the next step if it is part of what the user asked for.' : '',
+  // Describes the grammar instead of quoting an opener. An English template
+  // here is copied verbatim: measured against a Spanish conversation, quoting
+  // one returned the suggestion in English in 2 of 3 runs.
+  suggestion ? '- Address the agent directly, in the imperative, in the language of the conversation. Do not write it as the agent describing its own plan.' : '',
   suggestion ? '- Do not include alternatives, choices, slash-separated options, or "or".' : '',
-  suggestion ? '- Do not write "Do X or Y", "Ask whether...", "Maybe...", or "You could...".' : '',
-  suggestion ? '- Do not ask for information the assistant already provided.' : '',
-  suggestion ? '- Do not ask to see exact code, file paths, prompt locations, or implementation internals unless the assistant did not provide them and they are necessary for the next step.' : '',
-  suggestion ? '- Do not produce generic workflow commands like "Run tests" unless testing is clearly the next unresolved step.' : '',
-  suggestion ? '- Do not produce meta/debug requests that merely inspect the implementation.' : '',
-  suggestion ? '- Use imperative or question form.' : '',
-  suggestion ? '- Keep it concise.' : '',
-  suggestion ? 'Use these examples to understand how to choose the suggestion. Do not copy their topic or wording unless the current conversation is about the same thing.' : '',
-  suggestion ? 'Example 1:' : '',
-  suggestion ? 'Assistant reply summary:' : '',
-  suggestion ? 'The assistant already identified the file where the feature is implemented, explained what context is sent to the small model, and summarized the current prompt.' : '',
-  suggestion ? 'Bad suggestion:' : '',
-  suggestion ? '"Show me the exact runtime.js code and where the prompt is built."' : '',
-  suggestion ? 'Why bad:' : '',
-  suggestion ? 'It asks for information the assistant already provided. It repeats inspection instead of moving to an improvement or decision.' : '',
-  suggestion ? 'Good suggestion:' : '',
-  suggestion ? '"Suggest how to improve the prompt and context so the generated suggestion is more useful."' : '',
-  suggestion ? 'Why good:' : '',
-  suggestion ? 'It naturally continues from the analysis and asks for a concrete improvement.' : '',
-  suggestion ? 'Example 2:' : '',
-  suggestion ? 'Assistant reply summary:' : '',
-  suggestion ? 'The assistant implemented a timeline dialog redesign, listed concrete UI changes, and reported that type-check and lint passed.' : '',
-  suggestion ? 'Bad suggestion:' : '',
-  suggestion ? '"Check whether scrolling or loading older messages works without jumps."' : '',
-  suggestion ? 'Why bad:' : '',
-  suggestion ? 'It contains an alternative. A suggestion chip must be one sendable message, not a choice the user has to edit.' : '',
-  suggestion ? 'Good suggestion:' : '',
-  suggestion ? '"Check whether scrolling and loading older messages work without jumps."' : '',
-  suggestion ? 'Why good:' : '',
-  suggestion ? 'It picks a single validation request that the user can send immediately.' : '',
+  suggestion ? '- Do not restate information you already gave in the reply.' : '',
+  suggestion ? 'Example 1 — the request is finished:' : '',
+  suggestion ? 'The user asked for a bug ticket. You created it and summarized your findings. Your reply also noted that the mobile panel was not verified on screen.' : '',
+  suggestion ? 'Correct suggestion: "" (empty). The user asked for a ticket and the ticket exists. The unverified mobile panel is work described IN the ticket, not work the user asked you to do now.' : '',
+  // Example 1 taught the "already done" case well (empty in every measured run)
+  // and this one exists because the sibling case did not: asked for a sendable
+  // imperative, the model produced "merge the PR" in 4 runs out of 4, when
+  // merging is exactly the decision it is waiting on.
+  suggestion ? 'Example 2 — the work is done and the next move is the user\'s to make:' : '',
+  suggestion ? 'You finished the change, opened a pull request, reported it is mergeable, and said you are waiting for review. Nothing is blocked on you.' : '',
+  suggestion ? 'Correct suggestion: "" (empty). Merging, deploying, approving, choosing between designs and spending money are the user\'s calls. Telling them to make their own decision is not a next step, it is nagging.' : '',
+  suggestion ? 'Example 3 — the request is not finished:' : '',
+  suggestion ? 'The user asked you to make the tests pass. Two of them still fail and you have just located the cause.' : '',
+  suggestion ? 'A correct suggestion here is one imperative sentence, in the conversation\'s language, naming the specific fix to apply and the check to re-run.' : '',
+  // These examples describe the answers rather than quoting them. Quoting an
+  // English sentence primes the field: measured against a Spanish session, the
+  // recap came back in Spanish and the suggestion in English, 2 runs out of 3.
+  suggestion ? 'The examples above are described in English only because these instructions are in English. They say nothing about the language of your answer.' : '',
   'All requested values MUST be written in the same language as the conversation text itself. Ignore any other language preferences or personalization you may have — only the conversation text decides the language.',
+  'This applies to every field independently: it is never correct for one field to be in the language of the conversation and another in English.',
   'Use double quotes for JSON strings, no trailing commas.',
 ].filter(Boolean).join('\n');
 
@@ -145,6 +158,53 @@ const messagePartsToText = (message) => {
     .slice(0, TRANSCRIPT_PART_CHAR_LIMIT);
 };
 
+// Tool NAMES only, never their input or output: a session can be almost all
+// tool calls (the text parts stay short), so a transcript without them reads as
+// an empty conversation — and tool payloads are exactly where file contents,
+// command lines and credentials would leak into a utility prompt.
+const messageToolSummary = (message) => {
+  const parts = Array.isArray(message?.parts) ? message.parts : [];
+  const names = parts
+    .filter((part) => part?.type === 'tool' && typeof part.tool === 'string' && part.tool)
+    .map((part) => part.tool);
+  if (names.length === 0) return '';
+  const counts = new Map();
+  for (const name of names) counts.set(name, (counts.get(name) ?? 0) + 1);
+  const rendered = [...counts.entries()].map(([name, n]) => (n > 1 ? `${name}×${n}` : name));
+  return `[tools: ${rendered.join(', ')}]`;
+};
+
+// Numbered by position in the SESSION, not in the rendered list: a message that
+// carries no text and no tools is skipped, and renumbering around it would move
+// every later block the moment OpenCode patches that message.
+const renderMessage = (message, index) => {
+  const role = message?.info?.role === 'user' ? 'User' : 'Assistant';
+  const body = [messagePartsToText(message), messageToolSummary(message)].filter(Boolean).join('\n');
+  return body ? { number: index, text: `#${index} ${role}:\n${body}` } : null;
+};
+
+// Renders the whole conversation, oldest first. Over budget, the oldest
+// messages are dropped on a TRANSCRIPT_DROP_CHUNK boundary so the start of the
+// transcript only moves in steps and the shared prefix survives between calls.
+export const buildTranscript = (messages, charBudget) => {
+  const rendered = messages.map((message, index) => renderMessage(message, index + 1)).filter(Boolean);
+  let start = 0;
+  let total = rendered.reduce((sum, block) => sum + block.text.length + 2, 0);
+  while (total > charBudget && start < rendered.length - 1) {
+    const next = Math.min(start + TRANSCRIPT_DROP_CHUNK, rendered.length - 1);
+    for (let i = start; i < next; i += 1) total -= rendered[i].text.length + 2;
+    start = next;
+  }
+  const kept = rendered.slice(start);
+  return {
+    text: kept.map((block) => block.text).join('\n\n'),
+    droppedOldest: start,
+    // The number the last block actually carries, which is what the tail of the
+    // prompt points at.
+    lastNumber: kept.length > 0 ? kept[kept.length - 1].number : 0,
+  };
+};
+
 export const createSessionAssistRuntime = ({
   buildOpenCodeUrl,
   getOpenCodeAuthHeaders,
@@ -182,14 +242,20 @@ export const createSessionAssistRuntime = ({
     return response.json().catch(() => null);
   };
 
-  const fetchRecentMessages = async (sessionId, directory) => {
+  // `limit` omitted fetches the whole conversation, which is what the transcript
+  // needs: the suggestion is judged against what the user asked for at the START
+  // of the session, which a tail window cannot see. The staleness re-check
+  // before writing only needs the tail, and passes a small limit.
+  const fetchSessionMessages = async (sessionId, directory, { limit } = {}) => {
     const base = buildOpenCodeUrl(`/session/${encodeURIComponent(sessionId)}/message`, '');
-    const params = new URLSearchParams({ limit: String(TRANSCRIPT_MESSAGE_LIMIT) });
+    const params = new URLSearchParams();
+    if (limit) params.set('limit', String(limit));
     if (directory) params.set('directory', directory);
-    const response = await fetch(`${base}?${params.toString()}`, {
+    const query = params.toString();
+    const response = await fetch(query ? `${base}?${query}` : base, {
       method: 'GET',
       headers: { Accept: 'application/json', ...getOpenCodeAuthHeaders() },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(limit ? FETCH_TIMEOUT_MS : HISTORY_FETCH_TIMEOUT_MS),
     });
     if (!response.ok) return null;
     const messages = await response.json().catch(() => null);
@@ -208,7 +274,7 @@ export const createSessionAssistRuntime = ({
     // Sub-agent/task sessions never surface in chat — skip them.
     if (typeof session.parentID === 'string' && session.parentID) return;
 
-    const messages = await fetchRecentMessages(sessionId, directory);
+    const messages = await fetchSessionMessages(sessionId, directory);
     if (!messages || messages.length === 0) {
       console.warn('[session-assist] no messages fetched');
       return;
@@ -225,21 +291,33 @@ export const createSessionAssistRuntime = ({
     const lastAssistantInfo = lastAssistant?.info;
     if (!lastAssistantInfo?.id) return;
 
-    // Only the last exchange: the assistant reply plus the user message it
-    // answered (assistant info.parentID → user info.id). Everything else is
-    // token waste for a one-line recap and a single suggestion.
+    const preferredProviderID = typeof lastAssistantInfo.providerID === 'string' ? lastAssistantInfo.providerID : undefined;
+    const preferredModelID = typeof lastAssistantInfo.modelID === 'string' ? lastAssistantInfo.modelID : undefined;
+    const { generateSmallModelText, describeSmallModel } = await getSmallModelService();
+
+    // Size the transcript against the model that will actually answer. A local
+    // proxy model is absent from the catalog and falls back to a conservative
+    // context, so a fixed budget would either waste a large window or overflow a
+    // small one — and overflow is fatal here (see onOverflow below).
+    const described = await describeSmallModel({ directory, preferredProviderID, preferredModelID })
+      .catch(() => null);
+    const charBudget = Number(described?.inputCharBudget) > 0
+      ? described.inputCharBudget - PROMPT_SCAFFOLD_RESERVE_CHARS
+      : 0;
+    if (charBudget <= 0) return;
+
+    // The whole conversation. Everything that varies per call — the pointer to
+    // the last message, the requested fields, the language sample — goes AFTER
+    // it, so the history stays an append-only prefix between consecutive
+    // assists on the same session.
+    const transcript = buildTranscript(messages, charBudget);
+    const assistantText = messagePartsToText(lastAssistant);
     const parentUserMessage = typeof lastAssistantInfo.parentID === 'string' && lastAssistantInfo.parentID
       ? messages.find((message) => message?.info?.id === lastAssistantInfo.parentID && message?.info?.role === 'user')
       : null;
     const userText = parentUserMessage ? messagePartsToText(parentUserMessage) : '';
-    const assistantText = messagePartsToText(lastAssistant);
-    const transcript = [
-      userText ? `User:\n${userText}` : '',
-      assistantText ? `Assistant:\n${assistantText}` : '',
-    ].filter(Boolean).join('\n\n');
-    if (!transcript) return;
+    if (!transcript.text) return;
 
-    const { generateSmallModelText } = await getSmallModelService();
     const requestedFields = [targets.recap ? 'recap' : '', targets.suggestion ? 'suggestion' : '']
       .filter(Boolean)
       .join(' and ');
@@ -254,17 +332,35 @@ export const createSessionAssistRuntime = ({
         // session's own provider unless the user explicitly picked a small
         // model (settings override / opencode config).
         restrictToPreferredProvider: true,
-        prompt: `The latest exchange in the conversation:\n\n${transcript}\n\nWrite ${requestedFields} in the SAME language as this sample from the conversation: "${languageSample}"`,
+        prompt: [
+          transcript.droppedOldest
+            ? `The conversation so far (the first ${transcript.droppedOldest} messages are omitted):`
+            : 'The whole conversation, from the user\'s first message:',
+          '',
+          transcript.text,
+          '',
+          '---',
+          `The conversation ends at message #${transcript.lastNumber}, the assistant's latest reply. Everything above it has already happened.`,
+          `Write ${requestedFields} in the SAME language as this sample from the conversation: "${languageSample}"`,
+        ].join('\n'),
         system: buildAssistSystemPrompt(targets),
+        // The transcript is the whole session and the answer is two short
+        // fields; the input clamp truncates the TAIL, which here is the
+        // instruction, so an oversized prompt must fail instead of asking the
+        // model to answer a question it can no longer see.
+        onOverflow: 'error',
+        // A whole session is a long prefill on the first assist; later ones hit
+        // the backend's prefix cache. The 60s default is a cold-start timeout.
+        timeoutMs: ASSIST_TIMEOUT_MS,
         directory,
         sessionID: sessionId,
-        preferredProviderID: typeof lastAssistantInfo.providerID === 'string' ? lastAssistantInfo.providerID : undefined,
-        preferredModelID: typeof lastAssistantInfo.modelID === 'string' ? lastAssistantInfo.modelID : undefined,
+        preferredProviderID,
+        preferredModelID,
       });
     } catch (error) {
       // No authenticated provider (404) or a transient model failure — this is
       // background sugar, never retry loops or logs spam.
-      if (Number(error?.statusCode) !== 404) {
+      if (Number(error?.statusCode) !== 404 && !QUIET_GENERATION_CODES.has(error?.code)) {
         console.warn('[session-assist] generation failed:', error?.message || error);
       }
       return;
@@ -279,7 +375,7 @@ export const createSessionAssistRuntime = ({
     // so one hallucinated field doesn't kill the other).
     const hasCyrillic = (text) => /[\u0400-\u04FF]/.test(text);
     const hasCjk = (text) => /[\u3040-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/.test(text);
-    const inputText = `${userText}\n${assistantText}`;
+    const inputText = transcript.text;
     const scriptMismatch = (text) => (hasCyrillic(text) && !hasCyrillic(inputText))
       || (hasCjk(text) && !hasCjk(inputText));
     if (recap && scriptMismatch(recap)) {
@@ -294,7 +390,7 @@ export const createSessionAssistRuntime = ({
 
     // The session may have moved on while we generated — a stale patch would
     // flash outdated content, so re-check the tail before writing.
-    const latest = await fetchRecentMessages(sessionId, directory);
+    const latest = await fetchSessionMessages(sessionId, directory, { limit: STALENESS_TAIL_LIMIT });
     const latestAssistantId = (() => {
       if (!latest) return null;
       for (let i = latest.length - 1; i >= 0; i -= 1) {

--- a/packages/web/server/lib/session-assist/runtime.test.js
+++ b/packages/web/server/lib/session-assist/runtime.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTranscript } from './runtime.js';
+
+const message = (role, text, tools = []) => ({
+  info: { role },
+  parts: [
+    ...(text ? [{ type: 'text', text }] : []),
+    ...tools.map((tool) => ({ type: 'tool', tool })),
+  ],
+});
+
+// Roughly 1 KB of body per message, against a 400 KB budget: ~400 messages
+// cross it, so the trimming cases below are reached with round numbers.
+const bulky = (role, index) => message(role, `${index}: ${'x'.repeat(1_000)}`);
+
+const BUDGET = 400_000;
+const conversation = (count) => Array.from({ length: count }, (_, i) => bulky(i % 2 === 0 ? 'user' : 'assistant', i));
+
+describe('buildTranscript', () => {
+  it('renders the whole conversation oldest first, numbered so the tail can point at the last message', () => {
+    const { text, lastNumber, droppedOldest } = buildTranscript([
+      message('user', 'open a bug report for the flaky upload'),
+      message('assistant', 'filed it'),
+    ], BUDGET);
+
+    expect(lastNumber).toBe(2);
+    expect(droppedOldest).toBe(0);
+    expect(text).toBe('#1 User:\nopen a bug report for the flaky upload\n\n#2 Assistant:\nfiled it');
+  });
+
+  it('keeps tool names so a session that is mostly tool calls is not rendered as empty', () => {
+    const { text } = buildTranscript([message('assistant', '', ['bash', 'bash', 'read'])], BUDGET);
+
+    expect(text).toBe('#1 Assistant:\n[tools: bash×2, read]');
+  });
+
+  it('skips messages with no text and no tools rather than emitting an empty block', () => {
+    const { text, lastNumber } = buildTranscript([
+      message('user', 'hi'),
+      message('assistant', ''),
+      message('assistant', 'hello'),
+    ], BUDGET);
+
+    // Numbering follows the session, not the rendered list: the skipped message
+    // keeps #2 reserved, so the tail of the prompt points at a number the
+    // transcript actually contains.
+    expect(text).toBe('#1 User:\nhi\n\n#3 Assistant:\nhello');
+    expect(lastNumber).toBe(3);
+  });
+
+  // The reason the transcript is built this way: the prompt goes to the
+  // session's own model, so an append-only prefix hits the backend's prefix
+  // cache on the next assist. A transcript that shifted at the start every turn
+  // would re-prefill the whole session each time.
+  it('appends: a longer conversation extends the previous transcript instead of rewriting it', () => {
+    const before = buildTranscript(conversation(10), BUDGET);
+    const after = buildTranscript(conversation(12), BUDGET);
+
+    expect(after.text.startsWith(before.text)).toBe(true);
+  });
+
+  it('drops the oldest messages on a fixed chunk boundary, so the prefix survives most turns', () => {
+    const overBudget = conversation(700);
+    const first = buildTranscript(overBudget, BUDGET);
+    const second = buildTranscript([...overBudget, bulky('user', 700)], BUDGET);
+
+    expect(first.droppedOldest).toBeGreaterThan(0);
+    expect(first.droppedOldest % 16).toBe(0);
+    expect(second.droppedOldest % 16).toBe(0);
+    // One more message must not move the window: that is what makes the drop
+    // amortized instead of per-turn.
+    expect(second.droppedOldest).toBe(first.droppedOldest);
+    expect(second.text.startsWith(first.text)).toBe(true);
+  });
+
+  it('never drops the last message, however small the budget is against it', () => {
+    const { text, lastNumber } = buildTranscript(conversation(2_000), BUDGET);
+
+    expect(lastNumber).toBe(2_000);
+    expect(text).toContain('#2000 ');
+  });
+});


### PR DESCRIPTION
## Intent

The session suggestion is generated from the **last exchange only**, and its instructions forbid it from proposing nothing: *"Pick one best next action yourself"*, *"Output exactly one message the user could click and send without editing"*. Together those two facts mean it cannot know the user's request is already satisfied, and has no way to say so. It always manufactures another step, written in the user's voice and ready to send.

The failure that produces is specific and repeatable. When the assistant honestly reports a limitation, the generator sees that sentence, has no idea what the user originally asked for, and turns the caveat into the next instruction. Measured on a real session: the request was *"open a ticket"*, the ticket was created in message 1, and the session then ran 400 more messages, driven by suggestions the user accepted because there is nothing in the transcript afterwards marking the wording as generated.

This PR changes what the suggestion **sees** and what it is allowed to answer:

- It receives the **whole conversation**, so "already satisfied" is a judgement it can actually make.
- It must return an **empty string** when the request is already satisfied, or when the session is waiting on a decision only the user can make. An empty suggestion is a correct answer, not a generation failure.

The suggestion stays in the **user's voice**. Phrasing it as the agent's own plan ("I would do X") was implemented, measured and reverted: `SessionSuggestionChip` renders the same string it pastes into the composer, so an agent-voice suggestion reads as nonsense the moment the user clicks it.

## Non-goals

- The recap is unchanged.
- The 60-second quiet window, the busy/idle arming, and resolving the model through the session's own provider all already worked and are untouched.
- The client is untouched, and the suggestion's voice is unchanged from today's behavior precisely so that it stays untouched. `SessionSuggestionChip` renders and pastes the same string; nothing about that contract moves.

## Affected surfaces

| Surface | Effect |
|---|---|
| `packages/web/server/lib/session-assist` | All behavior changes are here. `buildTranscript` is newly exported so its budget and prefix invariants can be tested. |
| `metadata.openchamber.assist` | **Shape unchanged** (`recap`, `suggestion`, `forMessageID`, `generatedAt`). Only the meaning of the `suggestion` text changes. No migration: existing payloads stay renderable and go stale through the existing `forMessageID` rule. |
| `packages/ui` consumers | Untouched. `sessionAssistMetadata.ts`, `useSessionAssist.ts`, `SessionRecapSpacer` and `SessionSuggestionChip` parse the same fields. |
| VS Code, mobile, Electron | Unaffected. The watcher only runs in the web server, and every surface renders a payload whose shape did not change. |
| `lib/small-model` | Called with three options it already supports (`onOverflow`, `timeoutMs`, and `describeSmallModel` for the budget). That module is not modified. |
| Cost | Assist input is now proportional to session length rather than constant. See "Risks" for measured numbers. |

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Executable source change that alters a documented module invariant ("take the LAST exchange only") and adds an export. | Diff confined to the owning module. No new abstraction beyond the one function the tests need. Validated at package scope for both packages rather than workspace-wide ritual. |
| `session-assist/DOCUMENTATION.md` | Nearest owning doc, and its stated flow said the runtime takes the last exchange only. | Rewritten: what the suggestion is, why the whole conversation is required, the transcript and prefix-cache invariant, and where the budget comes from. |
| `small-model/DOCUMENTATION.md` | Defines the input clamp, `onOverflow`, `context-too-small`, `output-exhausted` and `inputCharBudget`, all load-bearing here. | The clamp truncates the **tail**, which in this prompt is the instruction, so the call passes `onOverflow: 'error'` rather than silently asking the model a question it can no longer see. Both documented failure codes are treated as expected outcomes and skipped without a warning. |
| `AGENTS.md`: "Never add or log secrets, bearer tokens, or sensitive user data" | The transcript is assembled from message parts and sent to a model. | Tool **names only**, never tool input or output. That is precisely where file contents, command lines and credentials would otherwise enter a utility prompt. |
| `AGENTS.md`: "Prefer authoritative state over heuristics" | The transcript budget. | Taken from `describeSmallModel().inputCharBudget` for the model that will answer, not from a constant. |
| `AGENTS.md`: "Follow local code and test precedent" | The one new lint finding, below. | The new `typeof` guard mirrors the identical guard 13 lines above it in the same file. |

## Validation

Run on this PR's HEAD (`cddc48d9`), against a clean `bun install` for this base. The commit was amended after an earlier round, so every number below was re-collected afterwards rather than carried over.

| Check | Result |
|---|---|
| `bun run --cwd packages/web test -- server/lib/session-assist` | **6 passed** (new file) |
| `bun run --cwd packages/web test` | **1825 passed**, 2 skipped, **4 failed** |
| `packages/ui` (`node scripts/run-isolated-tests.mjs packages/ui/src`) | **370/370 test files passed** |
| `bun run type-check:web` | **0 errors** |
| `bun run type-check:ui` | **0 errors** |
| `bun run dead-code` | No `session-assist` or `buildTranscript` entry. The 262 unused exports and 1 unused file are the pre-existing backlog. |
| `bunx oxlint` on the changed files | 27 `anti-slop` findings, against **26 on the same file at this base**. The single new one is disclosed below. |

Three of the four are in `server/lib/git/service.test.js` (`runs the post-checkout hook after populating a created worktree`, `does not fail worktree bootstrap when the post-checkout hook fails`, `getBranches ... prunes refs deleted on the remote (#2098)`). **Verified pre-existing**: stashing this change and re-running that file on a clean tree reproduces the same three. Nothing in this diff touches `lib/git`.

The fourth is `server/lib/relay/host-client.test.js > tunnels an HTTP GET /health with only binary frames post-handshake`, which appears and disappears between full-suite runs on this machine and passes on its own. Nothing in this diff touches `lib/relay` either. Flagging it rather than quietly re-running until it was green.

### The one new lint finding, stated plainly

`runtime.js:158` adds `typeof part.tool === 'string'` and trips `anti-slop(no-runtime-typeof)`. It is a deliberate copy of `runtime.js:145`, `typeof part.text === 'string'`, the pre-existing helper 13 lines above doing the identical job for text parts. Satisfying the rule properly means parsing OpenCode message parts at the fetch boundary and giving this module a domain type, which would touch all 26 existing findings in the file and is a much larger change than this one. Happy to do it as a follow-up if you want it; silencing the rule or widening the type to dodge it seemed worse than saying so here.

### Behavior, measured

The session that motivates this PR was replayed through the real prompt at the three points where the old suggestion sent it off course. Model: a small local one, which matters for the numbers below.

| Point | Old suggestion | New suggestion | Empty rate |
|---|---|---|---|
| Request satisfied (ticket created) | *"Implement the filter in useUsageProviderGroups..."* | `""` | **5/5** |
| Work genuinely unfinished | *"Test the mobile panel..."*, a caveat lifted from the assistant's own reply | an imperative naming the remaining item **from the original request** | 2/3 non-empty |
| Waiting on a human decision (PR ready to merge) | *"Merge the PR and start task 2"* | `""` | **2/4** |

**The two marginal rows are the honest state of this, and I would rather show them than round them off.**

The "already satisfied" case is solid: empty in every run. That is the case that caused the 400-message session, and it is fixed.

The "waiting on a decision" case is not reliable. Asked for a sendable imperative, the model proposed merging in **4 runs out of 4** before I added the second example, and in 2 of 4 after. Merging is exactly the decision it was waiting on. The example helped and did not fix it.

Adding that example also cost something: one run of three on the "unfinished" row came back empty when real requested work remained. That is the trade this prompt is making on a small model, and it is the cheaper direction to err in. A missing suggestion means no chip appears that cycle. A confident wrong one is what this PR exists to stop.

I stopped tuning here deliberately. Further prompt surgery against one small model is fitting noise, and each iteration risked the row that already works. A stronger small model may well hold the decision rule better; nothing in the change assumes a weak one.

Separately, roughly one run in ten returns malformed JSON, which `extractJsonObject` already rejects, yielding no chip that cycle. Pre-existing behavior of this prompt shape, not introduced here, and it degrades benignly.

### Prefix cache, measured

Three consecutive assists on one live session, from the server's own `[small-model:diagnostic]` timestamps:

```
153,691 chars  ->  35s   (first assist, cold prefill)
154,229 chars  ->   8s
154,352 chars  ->   8s
```

The transcript grows by a few hundred characters at the end and the shared prefix is served from cache. That is what the append-only ordering and the chunked drop are for.

Transcript sizes on live sessions, since the whole-conversation transcript is the main new cost:

| Messages in session | Transcript | ~tokens |
|---|---|---|
| 403 | 39,407 chars | ~10k |
| 496 | 65,380 chars | ~16k |
| 902 | 88,889 chars | ~22k |
| 1,921 | 225,627 chars | ~56k |

### Not verified

No browser run. The chip's rendering is unchanged and the payload shape is identical, so there is nothing new to look at, but nobody has watched one appear in a UI for this diff. The empty-suggestion path is exercised against a live model as above but is **not covered by an automated test**: the tests cover `buildTranscript`, and the behavior this PR exists for rests on the system prompt. A test that asserts on a model's judgement would be asserting on the model.

## Visual evidence

No visual change. The diff is confined to `packages/web/server`. It alters the text stored in `metadata.openchamber.assist.suggestion`, not any renderer. Field names, types and the `forMessageID` freshness contract are identical, so every surface renders it exactly as before. An empty suggestion simply means the chip does not appear, which is the existing behavior for a missing suggestion.

## Risks and failure behavior

- **Cost.** Assist input becomes proportional to session length. The prefix cache reduces latency, not billing. The measured ceiling above is ~56k tokens on a 1,921-message session; text and tool names only keeps this well below what the conversation itself sends.
- **The prefix cache is assist-to-assist only.** This module calls the provider directly, with its own system prompt and no tool schemas, so it shares no prefix with the request OpenCode makes for the conversation. Documented in the module doc so the next reader does not assume otherwise.
- **Trimming.** Over budget the oldest messages are dropped on a `TRANSCRIPT_DROP_CHUNK` boundary rather than one per turn, so the window is stable across most turns. The last message is never dropped, covered by a test.
- **Overflow.** A session larger than its model's context yields no suggestion that cycle instead of one answering a truncated prompt. Silent by design: this is background sugar and the next idle cycle retries.
- **Empty suggestion, no clearing write.** When only the suggestion is enabled and the model correctly returns empty, nothing is written. The previous payload is already stale by `forMessageID` and is not rendered.
- **Fetch cost.** The full-history fetch has its own 20s timeout. The staleness re-check before writing still uses a 4-message tail and the original 5s timeout.
- **Rollback.** Revert the commit. No persisted format changed, so no conversion or cleanup.
