### PR TITLE
fix(vscode): normalize status path comparison

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { AgentManagerPanelProvider } from './AgentManagerPanelProvider';
 import { SessionEditorPanelProvider } from './SessionEditorPanelProvider';
 import { createOpenCodeManager, type OpenCodeManager } from './opencode';
 import { startGlobalEventWatcher, stopGlobalEventWatcher, setChatViewProvider } from './sessionActivityWatcher';
+import { pathsEqualWithNormalizedDriveLetter } from './pathUtils';
 import { resolveWorkspaceFolders } from './workspaceResolver';
 
 let chatViewProvider: ChatViewProvider | undefined;
@@ -537,7 +538,9 @@ export async function activate(context: vscode.ExtensionContext) {
       const debug = openCodeManager?.getDebugInfo();
       const resolvedApiUrl = openCodeManager?.getApiUrl();
       const workingDirectory = openCodeManager?.getWorkingDirectory() ?? '';
-      const workingDirectoryMatchesWorkspace = Boolean(primaryWorkspace && workingDirectory === primaryWorkspace);
+      const workingDirectoryMatchesWorkspace = Boolean(
+        primaryWorkspace && pathsEqualWithNormalizedDriveLetter(workingDirectory, primaryWorkspace)
+      );
       let resolvedApiPath = '';
       if (resolvedApiUrl) {
         try {

--- a/packages/vscode/src/pathUtils.test.ts
+++ b/packages/vscode/src/pathUtils.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { pathsEqualWithNormalizedDriveLetter } from './pathUtils';
+
+describe('pathsEqualWithNormalizedDriveLetter', () => {
+  test('matches Windows paths that differ only in drive-letter case', () => {
+    assert.equal(
+      pathsEqualWithNormalizedDriveLetter('C:\\Users\\user\\project', 'c:\\Users\\user\\project'),
+      true
+    );
+  });
+
+  test('does not ignore case outside the drive letter', () => {
+    assert.equal(
+      pathsEqualWithNormalizedDriveLetter('C:\\Users\\user\\project', 'C:\\Users\\User\\project'),
+      false
+    );
+  });
+
+  test('preserves exact comparison for paths without a Windows drive letter', () => {
+    assert.equal(pathsEqualWithNormalizedDriveLetter('/work/project', '/work/project'), true);
+    assert.equal(pathsEqualWithNormalizedDriveLetter('/work/project', '/work/other'), false);
+  });
+});

--- a/packages/vscode/src/pathUtils.ts
+++ b/packages/vscode/src/pathUtils.ts
@@ -7,3 +7,6 @@
  */
 export const normalizeWindowsDriveLetter = (p: string): string =>
   p.replace(/^([a-z]):/, (_, letter: string) => letter.toUpperCase() + ':');
+
+export const pathsEqualWithNormalizedDriveLetter = (left: string, right: string): boolean =>
+  normalizeWindowsDriveLetter(left) === normalizeWindowsDriveLetter(right);


### PR DESCRIPTION
## Intent

Fixes #3308.

The VS Code status command compared OpenCode's normalized working directory with the raw workspace path. On Windows, a drive-letter case difference could therefore report `Working dir matches workspace: no` for the same directory. This change normalizes the leading drive letter on both paths and adds a regression test for that case.

## Non-goals

- Do not make the full Windows path case-insensitive.
- Do not change shared UI, Electron, Web, session, or persistence behavior.
- Do not add dependencies or update maintainer-owned changelogs.

## Affected surfaces

This affects `@openchamber/vscode` only: the status diagnostic in `extension.ts` and the pure path helper used by that comparison. Other runtimes do not call this helper. No persisted data or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `CONTRIBUTING.md` | They define the repository workflow, Bun commands, validation expectations, and changelog ownership. | Used Bun 1.3.14, kept the change scoped, ran package and workspace checks, and left changelogs untouched. |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Source changes must follow the repository's change-discipline workflow. | Traced the caller and existing normalization helper, reproduced the bug before the fix, reviewed the final diff, and avoided dependency or generated-file changes. |
| `packages/vscode/README.md` and `packages/vscode/src/DOCUMENTATION.md` | These are the nearest package documents for the affected extension. | Kept the behavior inside the VS Code package and followed its existing colocated Bun test pattern. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/vscode/src/pathUtils.test.ts` | Pass, 3 tests. Before the fix, the new drive-letter case test failed while the other 2 passed. |
| `bun run --cwd packages/vscode test` | Pass, 29 test files. |
| `bun run --cwd packages/vscode type-check` | Pass. |
| `bun run --cwd packages/vscode lint` | Pass. |
| `bun run --cwd packages/vscode build` | Pass. Existing asset and chunk warnings remain. |
| `bun run type-check` | Pass for all workspaces. |
| `bun run lint` | Pass with one existing warning in `packages/ui/src/apps/MobileChangesSurface.tsx`. |
| `bun run build` | Pass for all workspaces with existing Vite warnings. |
| `bun run test` | The run stopped in the unchanged UI package on a locale-sensitive `AM|PM` assertion because the Windows host rendered `上午`. |
| `bun run --cwd packages/electron test` | Pass, 19 test files. |
| `bun run --cwd packages/web test` | 159/176 files passed. The 17 failing unchanged files depend on POSIX paths, permissions, symlinks, line endings, or shell commands on this Windows host. |

## Visual evidence

Not captured. I did not run an Extension Host reproduction; the local editor is VS Code 1.135 while the report uses 1.136. The visible effect is limited to the existing status line changing from an incorrect `no` to `yes`; the focused test covers the path comparison behind it.

## Risks and failure behavior

The helper changes only an ASCII drive letter at the start of a path before strict equality. Path segments, separators, trailing slashes, and non-Windows paths keep their prior behavior. The change does not touch stored data, network behavior, security boundaries, or cleanup. Reverting the single commit restores the prior comparison.