### PR TITLE
fix(proxy): evict idle agent sockets before server timeout and silence client aborts

### DIFF
--- a/packages/web/server/lib/opencode/proxy-agent-wiring.test.js
+++ b/packages/web/server/lib/opencode/proxy-agent-wiring.test.js
@@ -76,6 +76,7 @@ describe('OpenCode API proxy agent wiring', () => {
       // request. See createOpenCodeProxyAgent in ./proxy.js.
       expect(agent).toBeTruthy();
       expect(agent.options?.keepAlive).toBe(true);
+      expect(agent.options?.timeout).toBe(4_000);
     }
   });
 

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -20,10 +20,11 @@ const OPENCODE_AGENT_KEEP_ALIVE_MS = 30_000;
 // exists to prevent (measured: at 64 concurrent requests, a cap of 32 left
 // 303 sockets in TIME_WAIT versus 0 at 256).
 const OPENCODE_AGENT_MAX_FREE_SOCKETS = 256;
-// Evicts idle free sockets from our side. Without it the only thing that
-// retires an idle pooled socket is the upstream closing it. Note this is
-// distinct from `keepAliveMsecs`, which is the TCP keep-alive probe delay.
-const OPENCODE_AGENT_IDLE_TIMEOUT_MS = 60_000;
+// Evicts idle free sockets from our side before upstream servers close them
+// (Node default keepAliveTimeout is 5s, Bun default idle timeout is 10s).
+// Setting this higher than upstream causes stale socket reuse where the
+// client writes into a dead socket and gets 'socket hang up' (ECONNRESET).
+const OPENCODE_AGENT_IDLE_TIMEOUT_MS = 4_000;
 
 const OPENCODE_AGENT_OPTIONS = {
   keepAlive: true,
@@ -919,6 +920,16 @@ export const registerOpenCodeProxy = (app, deps) => {
         }
       },
       error: (err, req, res) => {
+        if (
+          req?.aborted ||
+          req?.destroyed ||
+          res?.writableEnded ||
+          res?.destroyed ||
+          req?.socket?.destroyed ||
+          res?.socket?.destroyed
+        ) {
+          return;
+        }
         console.error('[proxy] OpenCode proxy error:', err.message);
         if (req?.[PROXY_TIMEOUT_MARKER]) {
           return;

--- a/packages/web/server/lib/opencode/proxy.js
+++ b/packages/web/server/lib/opencode/proxy.js
@@ -922,7 +922,6 @@ export const registerOpenCodeProxy = (app, deps) => {
       error: (err, req, res) => {
         if (
           req?.aborted ||
-          req?.destroyed ||
           res?.writableEnded ||
           res?.destroyed ||
           req?.socket?.destroyed ||

--- a/packages/web/server/lib/opencode/proxy.test.js
+++ b/packages/web/server/lib/opencode/proxy.test.js
@@ -188,6 +188,7 @@ describe('createOpenCodeProxyAgent', () => {
 
     expect(agent).toBeInstanceOf(https.Agent);
     expect(agent.options.keepAlive).toBe(true);
+    expect(agent.options.timeout).toBe(4_000);
   });
 
   it('returns a plain http agent for http targets', () => {
@@ -197,6 +198,7 @@ describe('createOpenCodeProxyAgent', () => {
     expect(agent).toBeInstanceOf(http.Agent);
     expect(agent).not.toBeInstanceOf(https.Agent);
     expect(agent.options.keepAlive).toBe(true);
+    expect(agent.options.timeout).toBe(4_000);
   });
 
   it('falls back to an http agent for missing or unparseable targets', () => {

--- a/packages/web/server/opencode-proxy.test.js
+++ b/packages/web/server/opencode-proxy.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import express from 'express';
 import path from 'path';
@@ -705,5 +705,53 @@ describe('OpenCode proxy SSE forwarding', () => {
     });
 
     expect(response.status).toBe(504);
+  });
+
+  it('does not log proxy error when the client aborts the request', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const upstream = express();
+    upstream.get('/hang', () => {});
+    upstreamServer = await listen(upstream);
+    const upstreamPort = upstreamServer.address().port;
+    const externalBaseUrl = `http://127.0.0.1:${upstreamPort}`;
+
+    const app = express();
+    registerOpenCodeProxy(app, {
+      fs: {},
+      os: {},
+      path,
+      OPEN_CODE_READY_GRACE_MS: 0,
+      LONG_REQUEST_TIMEOUT_MS: 5000,
+      getRuntime: () => ({
+        openCodePort: upstreamPort,
+        openCodeBaseUrl: externalBaseUrl,
+        isOpenCodeReady: true,
+        openCodeNotReadySince: 0,
+        isRestartingOpenCode: false,
+      }),
+      getOpenCodeAuthHeaders: () => ({}),
+      buildOpenCodeUrl: (requestPath) => `${externalBaseUrl}${requestPath}`,
+      ensureOpenCodeApiPrefix: () => {},
+    });
+    proxyServer = await listen(app);
+    const proxyPort = proxyServer.address().port;
+
+    const controller = new AbortController();
+    const fetchPromise = fetch(`http://127.0.0.1:${proxyPort}/api/hang`, {
+      signal: controller.signal,
+    }).catch(() => {});
+
+    // Abort after request has started
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    controller.abort();
+    await fetchPromise;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const proxyErrorLogs = errorSpy.mock.calls
+      .map((call) => call.join(' '))
+      .filter((msg) => msg.includes('[proxy] OpenCode proxy error:'));
+
+    expect(proxyErrorLogs).toHaveLength(0);
+    errorSpy.mockRestore();
   });
 });

--- a/packages/web/server/opencode-proxy.test.js
+++ b/packages/web/server/opencode-proxy.test.js
@@ -29,6 +29,7 @@ describe('OpenCode proxy SSE forwarding', () => {
   let proxyServer;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await closeServer(proxyServer);
     await closeServer(upstreamServer);
     proxyServer = undefined;
@@ -710,7 +711,13 @@ describe('OpenCode proxy SSE forwarding', () => {
   it('does not log proxy error when the client aborts the request', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const upstream = express();
-    upstream.get('/hang', () => {});
+    let markUpstreamReceived;
+    const upstreamReceived = new Promise((resolve) => {
+      markUpstreamReceived = resolve;
+    });
+    upstream.get('/hang', () => {
+      markUpstreamReceived();
+    });
     upstreamServer = await listen(upstream);
     const upstreamPort = upstreamServer.address().port;
     const externalBaseUrl = `http://127.0.0.1:${upstreamPort}`;
@@ -741,8 +748,7 @@ describe('OpenCode proxy SSE forwarding', () => {
       signal: controller.signal,
     }).catch(() => {});
 
-    // Abort after request has started
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await upstreamReceived;
     controller.abort();
     await fetchPromise;
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -752,6 +758,55 @@ describe('OpenCode proxy SSE forwarding', () => {
       .filter((msg) => msg.includes('[proxy] OpenCode proxy error:'));
 
     expect(proxyErrorLogs).toHaveLength(0);
-    errorSpy.mockRestore();
+  });
+
+  it('returns 503 when upstream resets after a parsed POST body is forwarded', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const upstream = express();
+    let upstreamBody;
+    upstream.use(express.json());
+    upstream.post('/reset', (req) => {
+      upstreamBody = req.body;
+      req.socket.destroy();
+    });
+    upstreamServer = await listen(upstream);
+    const upstreamPort = upstreamServer.address().port;
+    const externalBaseUrl = `http://127.0.0.1:${upstreamPort}`;
+
+    const app = express();
+    app.use(express.json());
+    registerOpenCodeProxy(app, {
+      fs: {},
+      os: {},
+      path,
+      OPEN_CODE_READY_GRACE_MS: 0,
+      LONG_REQUEST_TIMEOUT_MS: 5000,
+      getRuntime: () => ({
+        openCodePort: upstreamPort,
+        openCodeBaseUrl: externalBaseUrl,
+        isOpenCodeReady: true,
+        openCodeNotReadySince: 0,
+        isRestartingOpenCode: false,
+      }),
+      getOpenCodeAuthHeaders: () => ({}),
+      buildOpenCodeUrl: (requestPath) => `${externalBaseUrl}${requestPath}`,
+      ensureOpenCodeApiPrefix: () => {},
+    });
+    proxyServer = await listen(app);
+    const proxyPort = proxyServer.address().port;
+
+    const startedAt = Date.now();
+    const response = await fetch(`http://127.0.0.1:${proxyPort}/api/reset`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hello' }),
+      signal: AbortSignal.timeout(2000),
+    });
+
+    expect(response.status).toBe(503);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+    await expect(response.json()).resolves.toMatchObject({ error: 'OpenCode service unavailable' });
+    expect(upstreamBody).toEqual({ prompt: 'hello' });
+    expect(errorSpy).toHaveBeenCalledWith('[proxy] OpenCode proxy error:', 'socket hang up');
   });
 });


### PR DESCRIPTION
## Intent

Fixes frequent `[proxy] OpenCode proxy error: socket hang up` messages in server logs caused by two distinct issues:

1. **Keep-alive timeout race condition**: `http.Agent` pooled idle sockets for 60 seconds (`OPENCODE_AGENT_IDLE_TIMEOUT_MS = 60_000`). Upstream Node.js HTTP servers drop idle connections after 5 seconds (`server.keepAliveTimeout`), and Bun drops them after 10 seconds. When OpenChamber attempted to reuse a pooled socket after an idle pause of >5 seconds, the upstream server had already terminated the connection, causing the next write to fail with `ECONNRESET` (`socket hang up`). Lowering the agent idle timeout to 4 seconds ensures OpenChamber evicts idle sockets cleanly from the client side before upstream servers drop them.
2. **Spurious error logging on client cancellations**: When a browser client cancels an in-flight request (e.g. during page navigation, switching sessions, fast typing, or React hook unmounts), `http-proxy` aborts the upstream socket, which emits a `socket hang up`. The proxy error handler previously logged this unconditionally as `[proxy] OpenCode proxy error: socket hang up`. Suppressing error logs when the client request or response was already aborted or destroyed removes false-alarm log noise.

## Non-goals

- Modifying active request timeouts: In-flight requests (prompts, tool execution, model generations) remain governed by `PROXY_REQUEST_TIMEOUT_MS` (4 minutes) and `proxyTimeout`.
- Changing SSE streaming lifecycles or retry policies.
- Adding automatic request retries on socket reset.

## Affected surfaces

- Packages: `@openchamber/web`
- Runtimes: Web and Desktop (Electron runs the OpenChamber server in-process).
- User-visible states: Cleaner server console logs without false-alarm proxy error traces; no changes to UI rendered output or API contracts.
- Persisted/external contracts: None.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Modifying proxy server networking and error handling in `@openchamber/web` | Scoped strictly to `OPENCODE_AGENT_IDLE_TIMEOUT_MS` and client-abort detection in `proxy.js`. Validated with focused unit tests. |
| `communication-style` | PR description and documentation authoring | Concise, plain language, active voice, and no em dashes. |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run packages/web/server/lib/opencode/proxy-agent-wiring.test.js packages/web/server/lib/opencode/proxy.test.js packages/web/server/opencode-proxy.test.js` | 35 passed across 3 test files |
| `bun test` in `@openchamber/web` | 176 test files passed (1,836 tests passed) |
| Client abort test in `opencode-proxy.test.js` | Passed (verified `console.error` is not invoked on client abort) |
| Upstream timeout assertion tests | Passed (agent timeout verified for both HTTP and HTTPS targets) |

## Visual evidence

No user-visible UI change. This is a server-side reverse-proxy socket lifecycle and logging change; rendered DOM, styling, and UI components are unaffected.

## Risks and failure behavior

- **Idle timeout impact**: Sockets sitting idle in the pool for >4 seconds will close cleanly. When the user resumes activity, a new connection is established. On localhost, TCP handshake latency is ~0.1ms, which is imperceptible.
- **Active requests unaffected**: Active request duration is set by `proxyTimeout` (4 minutes) on the outgoing request, overriding the agent's idle timeout while requests are in flight.
- **Rollback**: Reverting involves restoring `OPENCODE_AGENT_IDLE_TIMEOUT_MS` and removing the abort check in `createApiProxy`.
