### PR TITLE
fix(docker): apply patch-package in the builder stage and set a UTF-8 locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN bun install --frozen-lockfile --ignore-scripts
 FROM deps AS builder
 WORKDIR /app
 COPY . .
+# `deps` installs with --ignore-scripts, so the root postinstall never runs there
+# and the patches/ directory is not present yet. Apply patch-package here, after
+# the full source copy, so the web bundle ships the patched ghostty-web.
+RUN bunx patch-package
 RUN bun run build:web
 
 FROM oven/bun:1.3.14 AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ RUN npm config set prefix /home/openchamber/.npm-global && mkdir -p /home/opench
 COPY --from=cloudflare/cloudflared@sha256:6d91c121b803126f7a5344005d17a9324788fc09d305b6e2560ec6040a7ae283 /usr/local/bin/cloudflared /usr/local/bin/cloudflared
 
 ENV NODE_ENV=production
+# The base image ships with the POSIX locale, which makes bash readline treat
+# every byte of a multibyte character separately in the built-in terminal.
+ENV LANG=C.UTF-8
 
 COPY scripts/docker-entrypoint.sh /home/openchamber/openchamber-entrypoint.sh
 


### PR DESCRIPTION
Fixes #3284

## Intent

The Docker image shipped an unpatched terminal renderer. The `deps` stage installs with `--ignore-scripts`, so the root `postinstall` never runs there and `patches/ghostty-web+0.4.0.patch` is never applied. The `builder` stage copies the full source but does not install again, so the web bundle built there and copied into `runtime` contained the upstream `ghostty-web`. Docker users got block characters drawn as font glyphs with seams between cells, and none of the invalid-codepoint guard the patch adds.

The issue proposes copying the three postinstall inputs into `deps` and dropping `--ignore-scripts`. I took the narrower path instead: keep `deps` as it is and run `patch-package` explicitly in `builder`, after `COPY . .` and before `bun run build:web`. That applies the only postinstall step the container needs. `fix-deprecation.js` only silences a warning and `ensure-electron.mjs` has no job in a container.

While testing the terminal in the image I also found the runtime stage has no UTF-8 locale (`locale charmap` prints `ANSI_X3.4-1968`). Bash readline then treats each byte of a multibyte character as its own column, so pasting Cyrillic or box-drawing characters into the built-in terminal garbles the echoed line. `ENV LANG=C.UTF-8` fixes that, in a separate commit.

## Non-goals

- Removing `--ignore-scripts` from `deps`. Bun only runs lifecycle scripts for trusted packages anyway, and the container's terminal backend (`bun-pty`) ships prebuilt binaries, so nothing else in the image depends on those scripts.
- Making the root `postinstall` tolerant of a manifest-only checkout.
- Anything about the terminal dock's initial height, which I noticed during testing but which is UI behaviour, not the image.

## Affected surfaces

- `Dockerfile` only. Both changes land in the image that `docker compose` and the published container use.
- Web runtime inside the container: the terminal renderer in `packages/web/dist` now matches what desktop, VS Code, and a plain `openchamber` install already get, because those run the root `postinstall`.
- Desktop, VS Code, mobile, and non-Docker web installs are unaffected. They never used this Dockerfile.
- No persisted data, routes, or API contracts change. `LANG` is new in the container environment and is inherited by the terminal PTY through `process.env`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` always-on constraints | Build configuration change | Two focused commits, no new dependencies, no changelog edits, no unrelated changes |
| `openchamber-change-discipline` | Build/generated-asset change in a platform image | Smallest complete change (one `RUN`, one `ENV`); validated with a real image build rather than static checks; alternative from the issue considered and rejected with a reason |
| `communication-style` | PR text | Applied to this description |

## Validation

| Check | Result |
|---|---|
| `docker build --target builder .` on this branch | Builds. Build log shows `patch-package 8.0.1` then `ghostty-web@0.4.0 ✔` |
| `docker build .` (full image) | Builds. `docker history` lists the `bunx patch-package` layer |
| `grep -c renderBlockChar packages/web/dist/assets/vendor-ghostty-web-*.js` inside the built image | `1` on this branch, `0` on the `main` image built the same way. `renderBlockChar` only exists in the patched renderer |
| `patch-package` against an unpatched copy of `ghostty-web@0.4.0` outside Docker | Applies cleanly, re-running on an already patched tree also exits 0, output identical byte for byte to a local `bun install` |
| Container started, project added, terminal opened, `ls`, `pwd`, `echo`, `printf` with block characters | Commands run and output renders. Before/after screenshots below |
| `locale charmap` and `printf %s "привіт" \| wc -m` inside the built image | `UTF-8` and `6`. The `main` image printed `ANSI_X3.4-1968` for the same charmap check |

Not verified: pasting multibyte text into the built-in terminal after the locale change (only checked from a shell in the image, not through the UI), the published multi-arch image pipeline, and Compose with persisted volumes. Both only consume this Dockerfile and nothing in the change is architecture-specific.

## Visual evidence

Maintainer-captured screenshots of the built-in terminal inside the container after running:

```sh
printf '\n████████████░░░░░░░░ 60%%\n▁▂▃▄▅▆▇█ ▏▎▍▌▋▊▉█\n▀▀▀▀ ▄▄▄▄ ▌▌▌▌ ▐▐▐▐\n▖▗▘▝ ▚▞ ▙▟▛▜\n\n'
```

Before (image from `main`): the progress bar and the `▁▂▃▄▅▆▇█` ramp draw as separate cells with visible seams.
<img width="1430" height="590" alt="image" src="https://github.com/user-attachments/assets/0e2fc0a3-8ad6-4ef3-ba10-0192c83706af" />


After (this branch): solid rectangles, adjacent cells touch.

<img width="1430" height="590" alt="image" src="https://github.com/user-attachments/assets/c22bb75d-4164-4f95-8169-442b29e8f2bc" />

The locale change has no rendering component. It changes how bash echoes multibyte input. The garbled command line above the output in both screenshots shows the before state; the after state through the UI is not captured yet.

## Risks and failure behavior

- If a patch stops applying, `patch-package` exits non-zero and the image build fails at that step. That is intended: the previous behaviour was to silently ship the unpatched dependency.
- The `RUN bunx patch-package` layer invalidates only when `builder` inputs change, which `COPY . .` already does on every source change. No effect on `deps` caching.
- `LANG=C.UTF-8` is built into glibc in the base image, no locale package is installed. Processes that read `LANG` (bash, `ls`, OpenCode's own child processes) now see UTF-8 instead of POSIX. I could not find anything in the image that depends on the POSIX default.
- Rollback is reverting the Dockerfile. No persisted state is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

