### PR TITLE
fix(ui): derive a non-transient runtime key for same-origin web pages

### DIFF
--- a/packages/ui/src/lib/runtime-switch-same-origin.test.ts
+++ b/packages/ui/src/lib/runtime-switch-same-origin.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import { getRuntimeKey, isTransientRuntimeKey, resetRuntimeEndpointForTesting } from './runtime-switch';
+
+// Same-origin web pages are served by the instance itself: no API base URL is
+// injected, so the runtime key must fall back to the page origin. Without the
+// fallback the key is the transient `url:default` and per-instance consumers
+// (once-per-instance quota load, scoped theme entry, per-instance UI state)
+// silently skip their work — usage stayed missing from the work-status panel
+// until Settings -> Usage forced a fetch.
+//
+// Runs in its own file with an explicit reset: the endpoint-switching tests in
+// runtime-switch.test.ts leave `activeRuntimeKey` behind, and bun:test shares
+// module state across test files in a run.
+
+interface FakeLocation {
+  protocol: string;
+  origin: string;
+}
+
+const withBrowserWindow = (
+  location: FakeLocation | null,
+  injected: Record<string, string> = {},
+  run: () => void,
+): void => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  try {
+    if (location === null) {
+      Reflect.deleteProperty(globalThis, 'window');
+    } else {
+      const runtimeWindow: Record<string, unknown> = { location };
+      for (const [key, value] of Object.entries(injected)) {
+        runtimeWindow[key] = value;
+      }
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: runtimeWindow,
+      });
+    }
+    run();
+  } finally {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  }
+};
+
+describe('getRuntimeKey same-origin browser fallback', () => {
+  test('derives a non-transient key from the page origin when no API base URL is injected', () => {
+    resetRuntimeEndpointForTesting();
+    withBrowserWindow(
+      { protocol: 'https:', origin: 'https://openchamber.example' },
+      undefined,
+      () => {
+        const key = getRuntimeKey();
+        expect(key).toBe('url:https://openchamber.example');
+        expect(isTransientRuntimeKey(key)).toBe(false);
+      },
+    );
+  });
+
+  test('treats the page as local when the injected local origin matches it', () => {
+    resetRuntimeEndpointForTesting();
+    withBrowserWindow(
+      { protocol: 'https:', origin: 'https://openchamber.example' },
+      { __OPENCHAMBER_LOCAL_ORIGIN__: 'https://openchamber.example' },
+      () => {
+        expect(getRuntimeKey()).toBe('local');
+      },
+    );
+  });
+
+  test('keeps an injected API base URL ahead of the page origin', () => {
+    resetRuntimeEndpointForTesting();
+    withBrowserWindow(
+      { protocol: 'https:', origin: 'https://openchamber.example' },
+      { __OPENCHAMBER_API_BASE_URL__: 'https://api.example' },
+      () => {
+        const key = getRuntimeKey();
+        expect(key).toBe('url:https://api.example');
+        expect(isTransientRuntimeKey(key)).toBe(false);
+      },
+    );
+  });
+
+  test('stays transient on non-http(s) pages', () => {
+    resetRuntimeEndpointForTesting();
+    withBrowserWindow({ protocol: 'file:', origin: 'null' }, undefined, () => {
+      const key = getRuntimeKey();
+      expect(key).toBe('url:default');
+      expect(isTransientRuntimeKey(key)).toBe(true);
+    });
+  });
+
+  test('stays transient outside the browser', () => {
+    resetRuntimeEndpointForTesting();
+    withBrowserWindow(null, undefined, () => {
+      const key = getRuntimeKey();
+      expect(key).toBe('url:default');
+      expect(isTransientRuntimeKey(key)).toBe(true);
+    });
+  });
+});

--- a/packages/ui/src/lib/runtime-switch.ts
+++ b/packages/ui/src/lib/runtime-switch.ts
@@ -56,6 +56,13 @@ const normalizeRuntimeUrlKey = (value: string): string => {
 // disconnect state (`MobileApp` switches to it when the connection drops).
 // Per-instance client state (e.g. the scoped theme entry) must not be read
 // from or written under them.
+//
+// A browser page served by the instance itself is NOT uninitialised: its
+// origin is the instance. The web server does not inject an API base URL for
+// same-origin pages (fetches resolve relative to the page), so without a
+// fallback the derived key is `url:default` and every transient-key consumer
+// — the once-per-instance quota load, the scoped theme entry, per-instance UI
+// state — silently skips work. See `getRuntimeKey`.
 export const MOBILE_DISCONNECTED_RUNTIME_KEY = 'mobile-disconnected';
 const UNINITIALIZED_RUNTIME_KEY = 'url:default';
 
@@ -91,7 +98,8 @@ export const getRuntimeApiBaseUrl = (): string => activeApiBaseUrl || readInject
 // trimming two injected globals and constructing three `URL` objects, which
 // made this one of the most expensive functions during streaming.
 //
-// The result depends only on `activeApiBaseUrl` and the two injected globals,
+// The result depends only on `activeApiBaseUrl`, the two injected globals
+// and the same-origin browser fallback,
 // and `switchRuntimeEndpoint` writes the injected API base URL at runtime, so
 // the cache is validated against the raw, untrimmed values. That comparison
 // allocates nothing and still recomputes the moment any input changes.
@@ -99,6 +107,7 @@ let cachedRuntimeKey = '';
 let cachedActiveApiBaseUrl: string | null = null;
 let cachedRawApiBaseUrl: string | undefined;
 let cachedRawLocalOrigin: string | undefined;
+let cachedRawBrowserOrigin: string | undefined;
 
 const readRawRuntimeGlobal = (key: '__OPENCHAMBER_API_BASE_URL__' | '__OPENCHAMBER_LOCAL_ORIGIN__'): string | undefined => {
   if (typeof window === 'undefined') return undefined;
@@ -109,26 +118,42 @@ const readRawRuntimeGlobal = (key: '__OPENCHAMBER_API_BASE_URL__' | '__OPENCHAMB
   return typeof value === 'string' ? value : undefined;
 };
 
+// Same-origin web pages fetch instance APIs with relative URLs, so no API
+// base URL is injected for them. The serving origin is nevertheless a real
+// instance identity: fall back to it so the derived key is `url:<origin>`
+// instead of the transient `url:default`. Restricted to http(s) pages — other
+// contexts (SSR, file://, custom protocols) have no origin that names an
+// instance and stay transient.
+const readBrowserOriginFallback = (): string => {
+  if (typeof window === 'undefined') return '';
+  const { location } = window;
+  if (!location) return '';
+  return location.protocol === 'http:' || location.protocol === 'https:' ? location.origin : '';
+};
+
 export const getRuntimeKey = (): string => {
   if (activeRuntimeKey) return activeRuntimeKey;
 
   const rawApiBaseUrl = readRawRuntimeGlobal('__OPENCHAMBER_API_BASE_URL__');
   const rawLocalOrigin = readRawRuntimeGlobal('__OPENCHAMBER_LOCAL_ORIGIN__');
+  const rawBrowserOrigin = readBrowserOriginFallback();
   if (
     cachedActiveApiBaseUrl === activeApiBaseUrl
     && cachedRawApiBaseUrl === rawApiBaseUrl
     && cachedRawLocalOrigin === rawLocalOrigin
+    && cachedRawBrowserOrigin === rawBrowserOrigin
   ) {
     return cachedRuntimeKey;
   }
 
-  const apiBaseUrl = getRuntimeApiBaseUrl();
+  const apiBaseUrl = getRuntimeApiBaseUrl() || rawBrowserOrigin;
   cachedRuntimeKey = sameOrigin(apiBaseUrl, readInjectedLocalOrigin())
     ? 'local'
     : normalizeRuntimeUrlKey(apiBaseUrl);
   cachedActiveApiBaseUrl = activeApiBaseUrl;
   cachedRawApiBaseUrl = rawApiBaseUrl;
   cachedRawLocalOrigin = rawLocalOrigin;
+  cachedRawBrowserOrigin = rawBrowserOrigin;
   return cachedRuntimeKey;
 };
 
@@ -202,4 +227,18 @@ export const subscribeRuntimeEndpointChanged = (callback: (detail: RuntimeEndpoi
   };
   window.addEventListener(RUNTIME_ENDPOINT_CHANGED_EVENT, listener);
   return () => window.removeEventListener(RUNTIME_ENDPOINT_CHANGED_EVENT, listener);
+};
+
+// Test-only: `switchRuntimeEndpoint` mutates module-level state that no other
+// endpoint switch can clear, and bun:test shares module state across test
+// files in a run. Tests that assert on the derived fallback path need the
+// module back at "never initialised" first.
+export const resetRuntimeEndpointForTesting = (): void => {
+  activeApiBaseUrl = '';
+  activeRuntimeKey = '';
+  cachedRuntimeKey = '';
+  cachedActiveApiBaseUrl = null;
+  cachedRawApiBaseUrl = undefined;
+  cachedRawLocalOrigin = undefined;
+  cachedRawBrowserOrigin = undefined;
 };


### PR DESCRIPTION
## Intent

When the web UI is served by the OpenChamber instance itself (plain browser access), the server does not inject `__OPENCHAMBER_API_BASE_URL__` — same-origin pages fetch instance APIs with relative URLs. `initializeRuntimeEndpoint` therefore no-ops, and `getRuntimeKey()` derives `url:default` for the whole session, which `isTransientRuntimeKey` classifies as "no instance connected".

Every transient-key consumer then silently skips work for the entire web session:

- the once-per-instance quota load (`ensureLoadedForRuntime`, introduced in d8621eac) never fires — usage stays missing from the work-status panel until Settings → Usage forces a fetch, and no `/api/quota/*` request is issued at all;
- the scoped theme entry (`theme-storage.ts`) is never read or written;
- per-instance UI state entries (`useUIStore`) are dropped.

Reproduce on 1.22.1: open the web UI in a browser served by the instance, reload on a chat view with the work-status panel visible — the network tab shows zero `/api/quota/*` requests and the usage section stays empty until Settings → Usage is opened.

Fix: when no API base URL is configured, derive the runtime key from the page origin (http/https only), so same-origin web resolves to `url:<origin>` — a real instance identity — instead of the transient `url:default`.

## Non-goals

- Changing `initializeRuntimeEndpoint` / `switchRuntimeEndpoint` semantics for desktop, VS Code, or Capacitor mobile — they inject the base URL or switch explicitly and short-circuit before the fallback.
- The three-minute quota auto-refresh interval (already unguarded; not the broken path).
- Fixing the pre-existing cross-file module-state pollution in the ui package test suite (present on `main`; see Validation).

## Affected surfaces

- **web (plain browser, same-origin)**: runtime key changes from transient `url:default` to `url:<origin>`; quota auto-load, scoped theme, and per-instance UI state start working.
- **desktop (Electron) / VS Code / Capacitor mobile**: unaffected — they inject `__OPENCHAMBER_API_BASE_URL__` or call `switchRuntimeEndpoint`, so `activeRuntimeKey` short-circuits before the fallback is consulted.
- **hosted mobile page (`mobile-main.tsx`)**: goes through the same `createConfiguredWebAPIs`; served same-origin it now derives `url:<origin>`. The explicit `mobile-disconnected` state is set via `switchRuntimeEndpoint` and short-circuits earlier, so disconnect handling is unchanged.
- **SSR / `file://` / custom protocols**: the fallback returns `''` → key stays `url:default` (transient), unchanged.
- **Persisted state**: transient keys are never persisted (per the rule in `runtime-switch.ts`), so there is no legacy `url:default` data to migrate; origin-keyed state starts fresh.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root AGENTS.md — "Shared contracts must define intentional behavior for every applicable runtime" | `getRuntimeKey` is a shared UI contract consumed by web, desktop, VS Code, and mobile | The fallback defines behavior per runtime: http(s) browser pages resolve to `url:<origin>`; injected/switched runtimes short-circuit before it; non-http(s) contexts stay transient |
| Root AGENTS.md — follow local code and test precedent | `runtime-switch.ts` guards hot-path cost with an input-validated key cache | The page origin joins the cache validation inputs (`cachedRawBrowserOrigin`); reading `window.location.origin` is a single property read, keeping the derivation allocation-free |
| Root AGENTS.md — runtime boundaries (`packages/ui` = shared runtime contracts) | The defect is in the shared contract, not in any surface package | Change lives in `packages/ui/src/lib/runtime-switch.ts` with unit tests co-located |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/lib/runtime-switch-same-origin.test.ts` | 5 pass — new file: origin fallback; local-origin match resolves `local`; injected base URL wins; `file://` stays transient; no-window stays transient |
| `bun test packages/ui/src/lib/runtime-switch.test.ts` | 3 pass — existing switching tests unaffected (the fallback also tolerates their `window` mock without `location`) |
| `bun test packages/ui/src/lib/` | 59 fail / 833 pass with the change vs 64 fail / 823 pass on clean `origin/main` — zero new failures; the 5-test delta is the new file, and its `resetRuntimeEndpointForTesting` also clears pre-existing cross-file pollution for later suites |
| `bun run type-check:ui` | clean |
| `bun run lint:ui` | 0 errors; 1 pre-existing unrelated warning (`MobileChangesSurface.tsx`) |
| Full `bun test` in `packages/ui` | Suite is flaky on `main` (same-code runs vary in test/error counts due to the pre-existing cross-file module-state pollution noted above); no failure references `runtime-switch` beyond that noise |
| Manual browser check (web UI built from this branch, server 1.22.1) | Reload on a chat view: `/api/quota/*` requests now fire and the work-status usage section populates without visiting Settings → Usage; before the patch zero quota requests were issued until the settings page was opened |

## Visual evidence

The diff does not change any rendering by itself — it decides whether existing components receive data. Before the fix the work-status usage section renders `null` (no groups loaded) after reload; after it, the section populates within the initial load. Since the populated section looks identical whether it was filled automatically or via Settings → Usage, a screenshot pair would not carry information beyond the network-behavior table above.

## Risks and failure behavior

- Per-origin identity change: features keying per-instance state now see `url:<origin>` where they previously saw a transient key that was never persisted — no data migration needed; per-origin namespaces start empty.
- Non-browser and non-http(s) contexts keep the previous behavior (`url:default`), including partial `window` mocks without `location` (guarded).
- Hot-path cost: one `window.location` property read plus one cache comparison per derived call; runtimes with `activeRuntimeKey` set short-circuit before it.
- Rollback: revert the single commit; no persisted, server-side, or external effects.
