### PR TITLE
feat: add Charm Hyper quota provider

### DIFF
--- a/packages/ui/src/lib/quota/providers/index.ts
+++ b/packages/ui/src/lib/quota/providers/index.ts
@@ -24,6 +24,7 @@ export const QUOTA_PROVIDERS: QuotaProviderMeta[] = [
   { id: 'crof', name: 'CrofAI' },
   { id: 'deepseek', name: 'DeepSeek' },
   { id: 'exe-dev', name: 'exe.dev' },
+  { id: 'hyper', name: 'Charm Hyper' },
   { id: 'neuralwatt', name: 'NeuralWatt' },
   { id: 'xai', name: 'xAI' },
 ];

--- a/packages/ui/src/types/quota.ts
+++ b/packages/ui/src/types/quota.ts
@@ -19,6 +19,7 @@ export type QuotaProviderId =
   | 'crof'
   | 'deepseek'
   | 'exe-dev'
+  | 'hyper'
   | 'neuralwatt'
   | 'xai';
 

--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -19,6 +19,7 @@ const AUTH = JSON.stringify({
   'opencode-go': { key: 'test-token' },
   'zai-coding-plan': { key: 'test-token' },
   deepseek: { key: 'test-token' },
+  hyper: { key: 'test-token' },
   'github-copilot': { access: 'test-token' },
   anthropic: { access: 'test-token', refresh: 'test-refresh' },
 });
@@ -705,6 +706,90 @@ describe('DeepSeek quota provider (VS Code parity)', () => {
     const result = await fetchQuotaForProvider('deepseek');
 
     assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$0.00');
+  });
+
+  test('teardown: restore fs', () => {
+    const fsMock = fs as unknown as { existsSync: unknown; readFileSync: unknown };
+    fsMock.existsSync = ORIGINAL_FS.existsSync;
+    fsMock.readFileSync = ORIGINAL_FS.readFileSync;
+  });
+});
+
+describe('Charm Hyper quota provider (VS Code parity)', () => {
+  beforeEach(() => {
+    const fsMock = fs as unknown as { existsSync: () => boolean; readFileSync: () => string };
+    fsMock.existsSync = () => true;
+    fsMock.readFileSync = () => AUTH;
+  });
+
+  test('builds credits and credits_balance windows from documented payload (numeric balance)', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({ balance: 100 })));
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.providerId, 'hyper');
+
+    const balanceWindow = result.usage!.windows.credits_balance!;
+    assert.equal(balanceWindow.valueLabel, '$5.00');
+    assert.equal(balanceWindow.usedPercent, null);
+    assert.equal(balanceWindow.windowSeconds, null);
+    assert.equal(balanceWindow.resetAt, null);
+
+    const creditsWindow = result.usage!.windows.credits!;
+    assert.equal(creditsWindow.valueLabel, '100 credits');
+    assert.equal(creditsWindow.usedPercent, null);
+    assert.equal(creditsWindow.windowSeconds, null);
+    assert.equal(creditsWindow.resetAt, null);
+  });
+
+  test('tolerates a string balance', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({ balance: '50' })));
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows.credits!.valueLabel, '50 credits');
+    assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$2.50');
+  });
+
+  test('maps 401 to session-expired', async () => {
+    stubFetchFailing(async () => ({}), { ok: false, status: 401 });
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Session expired — please re-authenticate with Charm Hyper');
+  });
+
+  test('reports a normalized timeout error', async () => {
+    stubFetchReturning(() => Promise.reject(new DOMException('The operation timed out.', 'TimeoutError')));
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Request timed out');
+  });
+
+  test('returns no-quota-data on a 200 payload with no balance', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({})));
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.error, 'No quota data in response');
+    assert.equal(result.usage, null);
+  });
+
+  test('keeps a literal zero balance as a valid valueLabel', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({ balance: 0 })));
+
+    const result = await fetchQuotaForProvider('hyper');
+
+    assert.equal(result.ok, true);
+    assert.equal(result.usage!.windows.credits!.valueLabel, '0 credits');
     assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$0.00');
   });
 

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -155,6 +155,10 @@ type DeepseekPayload = {
   }>;
 };
 
+type HyperPayload = {
+  balance?: number | string;
+};
+
 type NeuralwattPayload = {
   balance?: {
     credits_remaining_usd?: number | string;
@@ -851,6 +855,11 @@ export const listConfiguredQuotaProviders = () => {
   const deepseekAuth = normalizeAuthEntry(getAuthEntry(auth, ['deepseek']));
   if (deepseekAuth && ((deepseekAuth as Record<string, unknown>).key || (deepseekAuth as Record<string, unknown>).token)) {
     configured.add('deepseek');
+  }
+
+  const hyperAuth = normalizeAuthEntry(getAuthEntry(auth, ['hyper']));
+  if (hyperAuth && ((hyperAuth as Record<string, unknown>).key || (hyperAuth as Record<string, unknown>).token)) {
+    configured.add('hyper');
   }
 
   let xaiAuth: XaiAuthEntry | null = null;
@@ -2786,6 +2795,106 @@ const fetchDeepseekQuota = async (): Promise<ProviderResult> => {
   }
 };
 
+const HYPER_QUOTA_URL = 'https://hyper.charm.land/v1/credits';
+const HYPER_CREDIT_TO_USD = 0.05;
+
+const fetchHyperQuota = async (): Promise<ProviderResult> => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, ['hyper'])) as Record<string, unknown> | null;
+  const apiKey = (entry?.key as string | undefined) ?? (entry?.token as string | undefined);
+
+  if (!apiKey) {
+    return buildResult({
+      providerId: 'hyper',
+      providerName: 'Charm Hyper',
+      ok: false,
+      configured: false,
+      error: 'Not configured',
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
+  try {
+    const response = await fetch(HYPER_QUOTA_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Accept-Encoding': 'identity',
+      },
+      signal: timeoutSignal,
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId: 'hyper',
+        providerName: 'Charm Hyper',
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with Charm Hyper'
+          : `API error: ${response.status}`,
+      });
+    }
+
+    const payload = await response.json() as HyperPayload;
+    const rawBalance = payload?.balance;
+    const balance = (typeof rawBalance === 'number' || (typeof rawBalance === 'string' && rawBalance.trim() !== ''))
+      ? toNumber(rawBalance)
+      : null;
+
+    if (balance === null) {
+      return buildResult({
+        providerId: 'hyper',
+        providerName: 'Charm Hyper',
+        ok: false,
+        configured: true,
+        error: 'No quota data in response',
+      });
+    }
+
+    const creditsLabel = Number.isInteger(balance) ? String(balance) : formatMoney(balance);
+    const windows: Record<string, UsageWindow> = {
+      credits_balance: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `$${formatMoney(balance * HYPER_CREDIT_TO_USD)}`,
+      }),
+      credits: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `${creditsLabel} credits`,
+      }),
+    };
+
+    return buildResult({
+      providerId: 'hyper',
+      providerName: 'Charm Hyper',
+      ok: true,
+      configured: true,
+      usage: { windows },
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && (
+      error.name === 'TimeoutError' || (error.name === 'AbortError' && timeoutSignal.aborted)
+    );
+    const isParseError = error instanceof SyntaxError;
+    return buildResult({
+      providerId: 'hyper',
+      providerName: 'Charm Hyper',
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : (error instanceof Error ? error.message : 'Request failed'),
+    });
+  }
+};
+
 const fetchXaiQuota = async (): Promise<ProviderResult> => {
   try {
     const entry = resolveXaiAuth();
@@ -2907,6 +3016,8 @@ const fetchQuotaForProviderUncoalesced = async (providerId: string): Promise<Pro
       return fetchCrofQuota();
     case 'deepseek':
       return fetchDeepseekQuota();
+    case 'hyper':
+      return fetchHyperQuota();
     case 'neuralwatt':
       return fetchNeuralwattQuota();
     case 'xai':

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -25,6 +25,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `deepseek` | DeepSeek | `providers/deepseek.js` | `deepseek` (API key under `key` or `token`) |
 | `exe-dev` | exe.dev | `providers/exe-dev.js` | Usage API token stored under `~/.config/openchamber/quota/` |
 | `google` | Google | `providers/google/index.js` | `google`, `google.oauth`, Antigravity accounts file |
+| `hyper` | Charm Hyper | `providers/hyper.js` | `hyper` (API key under `key` or `token`) |
 | `github-copilot` | GitHub Copilot | `providers/copilot.js` | `github-copilot`, `copilot` |
 | `github-copilot-addon` | GitHub Copilot Add-on | `providers/copilot.js` | `github-copilot`, `copilot` |
 | `kimi-for-coding` | Kimi for Coding | `providers/kimi.js` | `kimi-for-coding`, `kimi` |

--- a/packages/web/server/lib/quota/index.js
+++ b/packages/web/server/lib/quota/index.js
@@ -14,6 +14,7 @@ export {
   fetchCodexQuota,
   fetchCursorQuota,
   fetchDeepseekQuota,
+  fetchHyperQuota,
   fetchCopilotQuota,
   fetchCopilotAddonQuota,
   fetchKimiQuota,

--- a/packages/web/server/lib/quota/providers/hyper.js
+++ b/packages/web/server/lib/quota/providers/hyper.js
@@ -1,0 +1,118 @@
+import { readAuthFile } from '../../opencode/auth.js';
+import {
+  getAuthEntry,
+  normalizeAuthEntry,
+  buildResult,
+  toUsageWindow,
+  toNumber,
+  formatMoney
+} from '../utils/index.js';
+
+export const providerId = 'hyper';
+export const providerName = 'Charm Hyper';
+const aliases = ['hyper'];
+const HYPER_QUOTA_URL = 'https://hyper.charm.land/v1/credits';
+const CREDIT_TO_USD = 0.05;
+
+export const isConfigured = () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  return Boolean(entry?.key || entry?.token);
+};
+
+export const fetchQuota = async () => {
+  const auth = readAuthFile();
+  const entry = normalizeAuthEntry(getAuthEntry(auth, aliases));
+  const apiKey = entry?.key ?? entry?.token;
+
+  if (!apiKey) {
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: false,
+      error: 'Not configured'
+    });
+  }
+
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
+  try {
+    const response = await fetch(HYPER_QUOTA_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Accept-Encoding': 'identity'
+      },
+      signal: timeoutSignal
+    });
+
+    if (!response.ok) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with Charm Hyper'
+          : `API error: ${response.status}`
+      });
+    }
+
+    const payload = await response.json();
+    const rawBalance = payload?.balance;
+    const balance = (typeof rawBalance === 'number' || (typeof rawBalance === 'string' && rawBalance.trim() !== ''))
+      ? toNumber(rawBalance)
+      : null;
+
+    if (balance === null) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No quota data in response'
+      });
+    }
+
+    const creditsLabel = Number.isInteger(balance) ? String(balance) : formatMoney(balance);
+    const windows = {
+      credits_balance: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `$${formatMoney(balance * CREDIT_TO_USD)}`
+      }),
+      credits: toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `${creditsLabel} credits`
+      })
+    };
+
+    return buildResult({
+      providerId,
+      providerName,
+      ok: true,
+      configured: true,
+      usage: { windows }
+    });
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && (
+      error.name === 'TimeoutError' || (error.name === 'AbortError' && timeoutSignal.aborted)
+    );
+    const isParseError = error instanceof SyntaxError;
+    return buildResult({
+      providerId,
+      providerName,
+      ok: false,
+      configured: true,
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : (error instanceof Error ? error.message : 'Request failed')
+    });
+  }
+};

--- a/packages/web/server/lib/quota/providers/hyper.test.js
+++ b/packages/web/server/lib/quota/providers/hyper.test.js
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({ hyper: { key: 'test-token' } }),
+}));
+
+import { fetchQuota } from './hyper.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body, init = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  ...init,
+});
+
+// Documented payload shape from https://hyper.charm.land/docs/api/credits.html
+// The balance is denominated in Hypercredits; 1 credit = $0.05.
+describe('Charm Hyper quota provider', () => {
+  it('builds credits and credits_balance windows from documented payload (numeric balance)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ balance: 100 })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.providerId).toBe('hyper');
+
+    const balanceWindow = result.usage.windows.credits_balance;
+    expect(balanceWindow).toBeDefined();
+    expect(balanceWindow.valueLabel).toBe('$5.00');
+    expect(balanceWindow.usedPercent).toBeNull();
+    expect(balanceWindow.windowSeconds).toBeNull();
+    expect(balanceWindow.resetAt).toBeNull();
+
+    const creditsWindow = result.usage.windows.credits;
+    expect(creditsWindow).toBeDefined();
+    expect(creditsWindow.valueLabel).toBe('100 credits');
+    expect(creditsWindow.usedPercent).toBeNull();
+    expect(creditsWindow.windowSeconds).toBeNull();
+    expect(creditsWindow.resetAt).toBeNull();
+  });
+
+  it('tolerates a string balance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ balance: '50' })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits.valueLabel).toBe('50 credits');
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$2.50');
+  });
+
+  it('formats a fractional balance in both windows', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ balance: 25.5 })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits.valueLabel).toBe('25.50 credits');
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$1.28');
+  });
+
+  it('maps 401 to session-expired error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with Charm Hyper');
+  });
+
+  it('maps 403 to session-expired error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403, json: async () => ({}) }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with Charm Hyper');
+  });
+
+  it('reports invalid-response on JSON parse failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Invalid response from provider');
+  });
+
+  it('returns no-quota-data on a 200 payload with no balance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({})));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('No quota data in response');
+    expect(result.usage).toBeNull();
+  });
+
+  it('returns no-quota-data on an empty-string balance', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ balance: '' })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('No quota data in response');
+    expect(result.usage).toBeNull();
+  });
+
+  it('keeps a literal zero balance as a valid valueLabel', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ balance: 0 })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.usage.windows.credits.valueLabel).toBe('0 credits');
+    expect(result.usage.windows.credits_balance.valueLabel).toBe('$0.00');
+  });
+});

--- a/packages/web/server/lib/quota/providers/index.js
+++ b/packages/web/server/lib/quota/providers/index.js
@@ -15,6 +15,7 @@ import * as cursor from './cursor.js';
 import * as deepseek from './deepseek.js';
 import * as exeDev from './exe-dev.js';
 import * as google from './google/index.js';
+import * as hyper from './hyper.js';
 import * as kimi from './kimi.js';
 import * as nanogpt from './nanogpt.js';
 import * as openai from './openai.js';
@@ -71,6 +72,12 @@ const registry = {
     providerName: google.providerName,
     isConfigured: google.isConfigured,
     fetchQuota: google.fetchGoogleQuota
+  },
+  hyper: {
+    providerId: hyper.providerId,
+    providerName: hyper.providerName,
+    isConfigured: hyper.isConfigured,
+    fetchQuota: hyper.fetchQuota
   },
   'zai-coding-plan': {
     providerId: zai.providerId,
@@ -220,6 +227,7 @@ export const fetchGoogleQuota = google.fetchGoogleQuota;
 export const fetchCodexQuota = codex.fetchQuota;
 export const fetchCursorQuota = cursor.fetchQuota;
 export const fetchDeepseekQuota = deepseek.fetchQuota;
+export const fetchHyperQuota = hyper.fetchQuota;
 export const fetchCopilotQuota = copilot.fetchQuota;
 export const fetchCopilotAddonQuota = copilot.fetchQuotaAddon;
 export const fetchKimiQuota = kimi.fetchQuota;


### PR DESCRIPTION
## Intent

Add a Charm Hyper quota provider so users can see their remaining Hypercredits in the Usage page and the header provider dropdown, alongside the existing quota providers (Claude, Codex, OpenRouter, NeuralWatt, DeepSeek, etc.).

The provider fetches `GET https://hyper.charm.land/v1/credits` with a Bearer API key read from the OpenCode `auth.json` (`hyper` entry, `key` or `token` field) and surfaces the remaining balance as two balance-only windows: `credits_balance` with a dollar `valueLabel` (1 Hypercredit = $0.05, so `100` credits renders as `$5.00`) and `credits` with the native Hypercredit `valueLabel` (e.g. `100 credits`). Hyper reports a lifetime credit balance rather than a periodic quota window, so both windows carry no percentage and no reset time, matching the CrofAI/NeuralWatt/DeepSeek "balance only" provider pattern.

Reference spec: https://hyper.charm.land/docs/api/credits.html

## Non-goals

- No managed-credential form in Settings (OpenCode Go / Ollama Cloud / Cursor style). Charm Hyper uses the standard `auth.json` API key like Crof, NeuralWatt, DeepSeek, and OpenRouter.
- No model-level quota windows (`usage.models`): the Hyper credits API has no per-model data.
- No local logo asset; the UI falls back to the remote `models.dev` logo (`providers/hyper/provider.toml`, display name "Charm Hyper").

## Affected surfaces

| Surface                                          | Impact                                                                                                                                                                                                   |
| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `packages/web` server quota module               | New provider module, registry entry, and named export; new vitest suite                                                                                                                                  |
| `packages/vscode` extension host                 | Parity implementation in `quotaProviders.ts` (`HyperPayload` type, `fetchHyperQuota`, switch case, `listConfiguredQuotaProviders`); new parity tests                                                     |
| `packages/ui` shared types and registry          | `QuotaProviderId` union and `QUOTA_PROVIDERS` list; consumed by web, Electron, and VS Code runtimes. Hosted mobile and Capacitor consume the web server runtime, so no separate implementation is needed |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Provider table row added                                                                                                                                                                                 |
| External contract                                | New `hyper` auth alias read from `~/.local/share/opencode/auth.json`; no routes, persisted settings, or other provider behavior changed                                                                  |

The VS Code webview needs no change: `/api/quota/:providerId` already proxies to the bridge, and the new switch case handles dispatch in the extension host.

## Repository guidance

| Guidance                                                                   | Why it applies                                                                     | How the change complies                                                                                                                                                                     |
| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `AGENTS.md` runtime boundaries / cross-runtime parity                      | Quota fetching lives in both the web server runtime and the VS Code extension host | Both runtimes implement the provider with identical logic, error messages, and window shape                                                                                                 |
| `AGENTS.md` correctness invariants (authoritative state, explicit failure) | A fetch failure must not be masked as success                                      | `ok` / `configured` / `error` contract preserved via `buildResult`; 401/403 maps to session-expired; timeout and parse failures classified explicitly                                       |
| `openchamber-change-discipline` skill                                      | Applies to any OpenChamber source change                                           | Smallest complete change; nearest owning doc (`quota/DOCUMENTATION.md`) read and updated; package-scoped validation run                                                                     |
| `ui-api-decoupling` skill                                                  | Shared UI data access goes through runtime routes                                  | UI consumes the existing `/api/quota/:providerId` route via `runtimeFetch`; no new route and no SDK bypass                                                                                  |
| `quota/DOCUMENTATION.md` "Add a new provider" checklist                    | Owning module contract                                                             | Module shape (`providerId`, `providerName`, `aliases`, `isConfigured`, `fetchQuota`), shared `utils` helpers, registry registration, doc row, and tests all follow the checklist            |
| Code style (CONTRIBUTING.md and provider precedent)                        | Style must match Crof/NeuralWatt/DeepSeek                                          | Line-by-line comparison against `deepseek.js` and the VS Code `fetchDeepseekQuota` was verified in review; window naming reuses the existing localized `credits` / `credits_balance` labels |

## Validation

| Check                                                                                                            | Result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `bun run --cwd packages/web test server/lib/quota/providers/hyper.test.js`                                       | PASS: 9/9                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| `bun run --cwd packages/web test server/lib/quota/providers`                                                     | 89 passed / 2 failed. The 2 failures are pre-existing Windows-only claude credential-discovery tests (homedir paths), unrelated to this change and identical to the known baseline                                                                                                                                                                                                                                                                                                                                                                                                                   |
| `bun test packages/vscode/src/quotaProviders.test.ts`                                                            | PASS: 44/44 (includes 7 new Charm Hyper parity tests)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
| `bun run --cwd packages/vscode type-check`                                                                       | PASS (both `tsconfig.json` and `tsconfig.webview.json`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| `bun run --cwd packages/ui type-check`                                                                           | PASS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `bun run --cwd packages/web lint`                                                                                | PASS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `bun x eslint --ext .ts,.tsx src` (vscode)                                                                       | PASS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| `bun run dead-code`                                                                                              | Ran; report is non-blocking. `fetchHyperQuota` is listed under unused exports at `providers/index.js` and `quota/index.js`, the same pre-existing pattern as every other named quota fetcher (Claude, OpenAI, DeepSeek, etc.). No file-level or type-level findings for the new module                                                                                                                                                                                                                                                                                                               |
| `bunx oxlint` (vendored anti-slop plugin)                                                                        | Findings on the new `fetchHyperQuota` mirror identical findings — same rules, same positions, same line classes — on the DeepSeek parity block already merged in #2594 (`as` casts, `typeof` balance guard, `Record<string, UsageWindow>` annotation). `quotaProviders.ts` carries a pre-existing anti-slop backlog across the whole file. Per `AGENTS.md`, the backlog is not mass-fixed and rules are never silenced or weakened to make the check pass; the new code follows the reviewed-and-merged DeepSeek precedent, and parity is enforced by the web/VS Code parity tests rather than style |
| `bun install`                                                                                                    | Ran once so `happy-dom` (already declared as `packages/ui` devDependency, already in `bun.lock`) was installed; both type-checks then pass. No dependency changes beyond syncing the declared lockfile state                                                                                                                                                                                                                                                                                                                                                                                         |
| Desktop Release Build Smoke (`release-desktop-smoke.yml`, fork run, `airtaxi/openchamber` @ `hyper-charm-usage`) | Run https://github.com/airtaxi/openchamber/actions/runs/33986869923: Windows x64/arm64 and Linux x64/arm64 PASS (build, package, and packaged-CLI verification). macOS x64/arm64 FAIL at "Install Apple Certificate" — expected on the fork, which has no Apple signing/notarization secrets, so macOS packaging was not exercised. Quota changes are platform-neutral server/extension logic, so the non-macOS pass covers the release-build risk                                                                                                                                                   |

Not verified: live smoke test against `hyper.charm.land` (no API key available in this environment) and packaged Electron/mobile runtime behavior (static analysis only; both runtimes consume the web server runtime, so risk is low).

## Visual evidence

### Charm Hyper balance in Settings > Usage

The Settings Usage section shows a `credits_balance` card (dollar value) and a `credits` card (Hypercredits) for Charm Hyper, rendered as `valueLabel` only (for example `$5.00` and `100 credits`) with no percentage and no reset time, matching the existing balance-only provider pattern already shipped for DeepSeek/NeuralWatt.

<img width="2776" height="1656" alt="image" src="https://github.com/user-attachments/assets/b9f274cc-8652-48c4-892a-dddb4a54d621" />

### Sidebar Usage section

The sidebar Usage section lists Charm Hyper alongside the configured quota providers and shows the same dollar and credit balances.

<img width="498" height="764" alt="image" src="https://github.com/user-attachments/assets/47994225-8048-47f2-8f57-5fb9e98112b3" />

## Risks and failure behavior

- **Invalid or expired key**: 401/403 maps to `Session expired - please re-authenticate with Charm Hyper`; the provider stays `configured: true` so the UI surfaces the error instead of silently clearing state.
- **Network, timeout, or parse failure**: classified as `Request timed out`, `Invalid response from provider`, or the request message with `ok: false`; the store keeps the failure signal, so a failure never looks like authoritative empty data.
- **Empty and zero balance edge cases**: literal `0` renders as `$0.00` and `0 credits` (valid); an empty-string or missing `balance` yields `No quota data in response` (`ok: false`, `configured: true`). Both cases guard against the `Number('') === 0` trap and are tested in both runtimes.
- **Credits-to-dollar conversion**: 1 Hypercredit = $0.05 (documented constant `CREDIT_TO_USD` / `HYPER_CREDIT_TO_USD`); dollars are derived with `formatMoney` (two decimals) while whole credit counts render without decimals. Conversion values in tests were verified against actual JS floating-point behavior (e.g. `100` → `$5.00`, `25.5` → `$1.28`).
- **Security**: the API key is read from the existing `auth.json` credential store and is never logged or persisted by this change; no secrets appear in tests or docs.
- **Compatibility**: additive only (new provider ID `hyper`); no existing routes, settings, or provider behavior changed.
- **Cross-runtime**: web and VS Code logic is kept identical; any future divergence surfaces in the parity tests.
