### PR TITLE
fix(ui): never downgrade an explicit Steer to a queue delivery

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -1381,7 +1381,14 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                 sessionActions.dismissOpenPermissionsForSession(currentSessionId),
                 sessionActions.dismissOpenQuestionsForSession(currentSessionId),
             ]);
-            if (deniedPermissions || dismissedQuestions) {
+            // An explicit Steer ("delivery === 'steer'") is never downgraded
+            // to the queue: silently converting it is what made steered
+            // follow-ups surface as a queue entry on top of the delivered
+            // message. The blockers above are dismissed either way; after
+            // that, `prompt_async` with delivery "steer" is exactly the user
+            // intent — it steers the active run, and starts the next turn when
+            // the session is in fact already idle.
+            if ((deniedPermissions || dismissedQuestions) && delivery !== 'steer') {
                 void handleQueueMessage();
                 return;
             }


### PR DESCRIPTION
## What

With Follow-up behavior set to **Steer**, submitting a follow-up on a busy session is silently converted into a server-queue delivery whenever the blocking-prompt branch reports any dismissal:

`packages/ui/src/components/chat/ChatInput.tsx`, in `handleSubmit`:

```ts
if (deniedPermissions || dismissedQuestions) {
    void handleQueueMessage();
    return;
}
```

The fallback ignores `delivery === 'steer'`. Stale permission/question rows in the client stores (e.g. permissions replied out-of-band, so the client never saw `permission.replied`) make the dismiss calls return true on ordinary sends, so every Steer on an affected session becomes a queue item instead. Observable: the message later re-enters the chat via the queue dispatch while the queue block is still rendered (reads as sent twice), or pops in minutes later at run end. Fresh sessions with no blocker history steer correctly, confirming the trigger.

## Change

When `delivery === 'steer'`, dismiss the blockers (that part is correct) but do not queue — proceed with the direct send (`prompt_async` with `delivery: "steer"` steers the active run, and starts the next turn when the session is in fact already idle). Queue-mode and non-steer sends keep the existing fallback. One file, +8/−1, with an explanatory comment at the branch.

## Verification

- `tsc --noEmit` clean (packages/ui)
- `bun test` session-actions (75 pass) + session-ui-store (47 pass)
- web vitest: 1866 pass; the only 2 failures are identical on the unpatched v1.22.1/v1.22.2 baseline (env-dependent, unrelated)
- Live capture on 1.22.1 before the fix: single Enter press → `POST /api/message-queue/.../items` at t+0.0s, dispatch delivers it as a fresh user message at t+1.1s

## Scope note

This covers the silent downgrade only. Two related observations from the same repro sessions are left for the accompanying issue (steer into a tool-executing turn sometimes aborts it without starting the new turn; a restored queue item can sit undispatched on an idle session) — both need upstream/maintainer input, not bundled here.

Addresses defect 1 in #3370; the remaining reports stay open.

