### PR TITLE
fix(server): dispatch restored queue past a pre-boot unfinished tail

### DIFF
--- a/packages/web/server/lib/message-queue/runtime.js
+++ b/packages/web/server/lib/message-queue/runtime.js
@@ -214,6 +214,12 @@ export function createMessageQueueRuntime({
   let writePromise = Promise.resolve();
   let stopped = false;
 
+  // A restart kills every run, so an unfinished assistant message older than
+  // this marker cannot be live evidence of a streaming turn — treating it as
+  // one strands restored queue items forever, because no completion event
+  // will ever arrive for a run that died with the previous server.
+  const runtimeStartedAt = now();
+
   /** In-memory only — a restart has no in-flight sends. */
   const sending = new Map(); // sessionId → itemId
   const timers = new Map(); // sessionId → timeout
@@ -380,7 +386,15 @@ export function createMessageQueueRuntime({
     }).catch(() => null));
     if (!messages) return null;
     const last = asRecord(asRecord(messages[messages.length - 1])?.info);
-    if (last?.role === 'assistant' && asCount(asRecord(last.time)?.completed) === null) return false;
+    const lastTime = asRecord(last?.time);
+    if (last?.role === 'assistant' && asCount(lastTime?.completed) === null) {
+      const created = asCount(lastTime?.created);
+      if (created === null || created >= runtimeStartedAt) return false;
+      // Unfinished tail from before this runtime started: its run died with
+      // the previous server, so it must not block delivery. (A missing
+      // created timestamp stays conservative and blocks, as before.)
+      console.log(`[message-queue] ignoring pre-boot unfinished tail for ${sessionId}`);
+    }
     return true;
   };
 

--- a/packages/web/server/lib/message-queue/runtime.test.js
+++ b/packages/web/server/lib/message-queue/runtime.test.js
@@ -58,7 +58,7 @@ const createOpenCode = () => {
   return { state, fetchImpl };
 };
 
-const createRuntime = ({ dataDir = makeDataDir(), openCode = createOpenCode(), knowledge = null, retryDelayMs } = {}) => {
+const createRuntime = ({ dataDir = makeDataDir(), openCode = createOpenCode(), knowledge = null, retryDelayMs, now } = {}) => {
   let eventHandler = () => {};
   let statusHandler = () => {};
   const broadcasts = [];
@@ -79,6 +79,7 @@ const createRuntime = ({ dataDir = makeDataDir(), openCode = createOpenCode(), k
     abortHoldMs: 50,
   };
   if (retryDelayMs) options.retryDelayMs = retryDelayMs;
+  if (now) options.now = now;
   const runtime = createMessageQueueRuntime(options);
   return {
     runtime,
@@ -175,9 +176,10 @@ describe('message queue runtime', () => {
   });
 
   it('does not send into a running turn even when the status event says idle', async () => {
-    const { runtime, openCode, emit } = createRuntime();
+    const { runtime, openCode, emit } = createRuntime({ now: () => 10_000 });
     runtime.start();
-    openCode.state.tail = [{ info: { role: 'assistant', time: { created: 1 } } }];
+    // Live unfinished turn: created after this runtime started.
+    openCode.state.tail = [{ info: { role: 'assistant', time: { created: 10_001 } } }];
     await runtime.enqueue(SESSION, DIRECTORY, item());
     emit({ type: 'session.status', properties: { sessionID: SESSION, status: { type: 'idle' } } });
     await settle();
@@ -185,10 +187,24 @@ describe('message queue runtime', () => {
 
     // The reply completes: that alone drains the queue (a missed idle event
     // must not strand it).
-    openCode.state.tail = [{ info: { role: 'assistant', time: { created: 1, completed: 2 } } }];
-    emit({ type: 'message.updated', properties: { info: { role: 'assistant', sessionID: SESSION, time: { created: 1, completed: 2 } } } });
+    openCode.state.tail = [{ info: { role: 'assistant', time: { created: 10_001, completed: 10_002 } } }];
+    emit({ type: 'message.updated', properties: { info: { role: 'assistant', sessionID: SESSION, time: { created: 10_001, completed: 10_002 } } } });
     await settle();
     expect(openCode.state.sent).toHaveLength(1);
+  });
+
+  it('delivers past an unfinished tail that predates this runtime (dead pre-restart run)', async () => {
+    const { runtime, openCode, emit } = createRuntime({ now: () => 10_000 });
+    runtime.start();
+    // Assistant reply interrupted by a server restart: unfinished, but older
+    // than this runtime — no completion event will ever arrive for it, so it
+    // must not block a restored queue forever.
+    openCode.state.tail = [{ info: { role: 'assistant', time: { created: 1 } } }];
+    await runtime.enqueue(SESSION, DIRECTORY, item());
+    emit({ type: 'session.status', properties: { sessionID: SESSION, status: { type: 'idle' } } });
+    await settle();
+    expect(openCode.state.sent).toHaveLength(1);
+    expect(openCode.state.sent[0].path).toBe(`/session/${SESSION}/prompt_async`);
   });
 
   it('treats an unreachable OpenCode as unknown, not idle', async () => {


### PR DESCRIPTION
## What

A restart kills every run, but the message tail keeps the interrupted assistant reply with no `time.completed`. `isSessionIdle` treated that tail as live evidence of a streaming turn forever: no completion event can ever arrive for a dead run, the status map lists no idle sessions, and the tick's busy path only waits for the next idle event. Result: a restored queue item sat undispatched on an idle session indefinitely, with zero log output (observed: ~45 minutes of silence after a boot-time restore on 1.22.2).

## Change

Record the runtime boot marker (`runtimeStartedAt`) and ignore unfinished tails older than it — they cannot be live turns. A missing `created` timestamp stays conservative and still blocks, as before. Two files, +36/−6, with a regression test.

## Verification

- New test `delivers past an unfinished tail that predates this runtime`: **fails on unpatched code, passes with the fix**; full queue-runtime file 25/25 green
- End-to-end on an isolated harness (real web server + real managed opencode, seeded dead-run tail, item queued, server rebooted): unpatched strands the item in complete silence for 50s+; patched logs `ignoring pre-boot unfinished tail` and `sent queued message`, queue drains, user message lands in the session
- Adjacent live-turn test updated to use a post-boot timestamp so it keeps testing a genuinely live turn

Related to #3370 (defect 3 of that issue). Does not touch defects 1 (covered by #3369) or 2.