### PR TITLE
fix(chat): shrink markdown table wrappers to column widths

### DIFF
--- a/packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx
+++ b/packages/ui/src/components/chat/MarkdownRendererImpl.performance.test.tsx
@@ -383,6 +383,9 @@ describe('MarkdownRenderer DOM mount performance contract', () => {
       expect(table?.classList.contains('min-w-full')).toBe(false);
       expect(table?.classList.contains('w-full')).toBe(false);
       expect(table?.parentElement?.classList.contains('overflow-x-auto')).toBe(true);
+      const wrapper = table?.closest('[data-markdown="table-wrapper"]');
+      expect(wrapper?.classList.contains('w-fit')).toBe(true);
+      expect(wrapper?.classList.contains('max-w-full')).toBe(true);
       expect(cells.length).toBeGreaterThan(0);
       expect(cells.every((cell) => cell.classList.contains('min-w-[120px]'))).toBe(true);
       expect(cells.every((cell) => cell.classList.contains('max-w-[320px]'))).toBe(true);

--- a/packages/ui/src/components/chat/markdown/decorate.ts
+++ b/packages/ui/src/components/chat/markdown/decorate.ts
@@ -344,7 +344,7 @@ const decorateTables = (root: HTMLElement, labels: DecorateLabels): void => {
     if (existing) continue;
 
     const wrapper = document.createElement('div');
-    wrapper.className = 'group my-4 flex flex-col space-y-2';
+    wrapper.className = 'group my-4 flex w-fit max-w-full flex-col space-y-2';
     wrapper.setAttribute('data-markdown', 'table-wrapper');
 
     const toolbar = document.createElement('div');


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Remove the empty area to the right of narrow Markdown tables. The table already uses the sum of its measured column widths, but its bordered scroll container still stretches across the message.

Add `w-fit max-w-full` to the table wrapper so the border and toolbar follow the table width, capped by the available message width. In the desktop reproduction, the columns total 440px and the outer border shrinks from 720px to 442px, including borders.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

No changes to column measurement, the 120-320px column limits, streaming/fixed-layout timing, text wrapping, copy/download behavior, or other Markdown blocks. No dependencies, public contracts, or persisted data change.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

`packages/ui` Markdown tables, shared by web, Electron, VS Code, hosted mobile, and Capacitor. Narrow tables shrink to their content; wide tables keep horizontal scrolling. The native shells, server, APIs, and authentication code are unchanged.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Why it applies | How the change complies |
|---|---|---|
|  |  |  |
| `AGENTS.md`, `openchamber-change-discipline` | Local shared-UI behavior | One layout-class change and assertions in the existing renderer test. No new exports, lifecycle logic, or unrelated cleanup. |
| `theme-system` | Table container styling | Reuses layout utilities and preserves existing semantic colors, borders, buttons, and icons. No new color, icon, or theme reference is needed. |
| `performance-engineering`, `diagnose` | Markdown decoration and layout | Reproduced the real column/container mismatch. Added no geometry reads, observers, caches, or repeated work. The existing operation-count tests still pass. This is a layout fix, not a performance claim. |
| Root `README.md`, `CONTRIBUTING.md`, PR template | Shared UI ownership and review evidence | UI has no package README or nearer Markdown-renderer `DOCUMENTATION.md`. No documented ownership or contract changes. Evidence below uses the real routes and source trees. |
| `communication-style`, `#ocb-pr` | PR text and visual handoff | English template, original PNG comparisons from pinned base/head trees, and explicit validation limits. |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

| Check | Result |
|---|---|
|  |  |
| `bun test ./src/components/chat/MarkdownRendererImpl.performance.test.tsx -t 'fixes body-sized table columns once the stream settles'`, from `packages/ui`, before the fix | Failed on the new wrapper assertion, as expected. |
| `bun test ./src/components/chat/MarkdownRendererImpl.performance.test.tsx`, from `packages/ui`, after the fix | 8 passed, 0 failed, including column widths, wrapper constraints, deferred work, and DOM reuse. Existing KaTeX test-environment warning remains. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | No errors. One pre-existing hook-dependency warning in `MobileChangesSurface.tsx:212`. |
| `bun run build:web` | Passed, with bundle-size warnings. |
| `git diff --check 6e585898c5260d1b4c0c1849a27dcf7a6f87aaf6...HEAD` | Passed. |
| Local browser replay using the reported message and real decoration/CSS | Short, wide, settled, and pending-stream tables passed layout assertions. A 375px viewport retained horizontal scrolling without page overflow. |
| Real `/` pages at base and final HEAD | 1440x1000, light and dark. Table remains 440px; bordered wrapper changes from 720px to 442px. Toolbar follows the wrapper. |
| Real `/mobile.html` pages at base and final HEAD | 390x844, light, `device-mobile` confirmed. Both retain a 440px table in a 364px scroll area. Real horizontal wheel input reaches `scrollLeft=76`; the last cell is visible and page width remains 390px. |

Checks ran against the same source files committed in this PR. No source changed after validation. Native Electron/VS Code/Capacitor packages, mobile dark mode, and the workspace-wide suites were not run for this local CSS change. Narrow desktop replay is not presented as mobile-runtime evidence.

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

Before: detached worktree at base `6e585898c5260d1b4c0c1849a27dcf7a6f87aaf6`. After: final head `7635c2a4dffa3987a28b5927299ba72c8d714baf`. Both ran their own loopback HMR server. Each pair uses the same reported session, theme, viewport, and table position. Images are original browser clip captures of the relevant message, excluding unrelated sidebar content; no DOM or source was altered for the comparison.

| Route / runtime / viewport | Before | After |
|---|---|---|
| `/`, shared desktop web UI, 1440x1000, light | ![Before: table border fills the message width](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/5c8435135abf99f46a259129a6b8bfb6ad0bf4cb/table-base-desktop-light.png) | ![After: border and toolbar follow the column widths](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/13ce2a5aa019dbd9f8eed6d6c0988805754ac7ac/table-head-desktop-light.png) |
| `/`, shared desktop web UI, 1440x1000, dark | ![Before: empty bordered area in dark mode](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/c5bbdc269c1afbd5bfb1d66999d29325d2003bd8/table-base-desktop-dark.png) | ![After: compact table in dark mode](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/0c497fa6b310760536854d6aede59472de90075b/table-head-desktop-dark.png) |
| `/mobile.html`, mobile web, 390x844, light | ![Before: mobile table retains its constrained scroll area](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/b7f48adb08d11b791e16641ac98d4db57b7a3e14/table-base-mobile-light.png) | ![After: mobile table keeps the same narrow layout](https://gist.githubusercontent.com/ChangeHow/1a55359cd6f84e61d16f625f5bb7bbe1/raw/b7f48adb08d11b791e16641ac98d4db57b7a3e14/table-head-mobile-light.png) |

The mobile pair is intentionally unchanged: the available width is smaller than the table, so both versions must scroll instead of stretching the page. All six raw image URLs were verified with `gh api --method HEAD --include` and returned `200 OK` with `Content-Type: image/png`.

## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

The main risk is losing narrow-screen overflow containment when making the wrapper intrinsic-width. `max-w-full` caps the wrapper and the existing `overflow-x-auto` child retains scrolling, checked in both responsive desktop replay and the actual mobile route. No asynchronous failure, data migration, authentication, or transport behavior changes. Reverting the layout-class change restores the prior presentation without touching data.

The LAN acceptance server was stopped. Screenshot servers and the detached base worktree are temporary and are cleaned up before PR handoff. The original dark color mode was restored after capture. Changelog files are unchanged.
