### PR TITLE
fix: parse ollama cloud cost-based usage windows and credits balance

### DIFF
--- a/packages/ui/src/components/sections/usage/QuotaCredentials.tsx
+++ b/packages/ui/src/components/sections/usage/QuotaCredentials.tsx
@@ -41,7 +41,7 @@ export const QuotaCredentials: React.FC<{ providerId: ProviderId; providerName: 
         <p className="typography-meta text-muted-foreground">{t('settings.providers.page.quotaCredentials.exeDevTokenInstructions')}</p>
         <code className="typography-code block whitespace-pre-wrap break-all rounded bg-muted/50 px-2 py-1.5 text-xs text-foreground">{EXE_DEV_TOKEN_COMMAND}</code>
       </div>}
-      {providerId === 'ollama-cloud' && field('cookie', t('settings.providers.page.openCodeGo.authCookie'), 'session=...')}
+      {providerId === 'ollama-cloud' && field('cookie', t('settings.providers.page.openCodeGo.authCookie'), 'aid=...; __Secure-session=...')}
       {providerId === 'exe-dev' && field('usageToken', t('settings.providers.page.quotaCredentials.usageToken'), t('settings.providers.page.quotaCredentials.tokenPlaceholder'))}
       {providerId === 'cursor' && field('accessToken', t('settings.providers.page.quotaCredentials.accessToken'), t('settings.providers.page.quotaCredentials.tokenPlaceholder'))}
       {providerId === 'cursor' && field('refreshToken', t('settings.providers.page.quotaCredentials.refreshToken'), t('settings.providers.page.quotaCredentials.tokenPlaceholder'))}

--- a/packages/vscode/src/quotaCredentials.ts
+++ b/packages/vscode/src/quotaCredentials.ts
@@ -59,7 +59,7 @@ export const validateCredential = async (provider: ManagedProvider, credential: 
     const response = await fetch('https://ollama.com/settings', { headers: { Cookie: credential.cookie }, redirect: 'manual', signal: AbortSignal.timeout(15_000) });
     if (!response.ok || (response.status >= 300 && response.status < 400)) throw new Error('Ollama Cloud authentication failed');
     const html = await response.text();
-    if (!/Session\s+usage|Weekly\s+usage|Premium[^0-9]*[0-9]+\s*\/\s*[0-9]+/i.test(html)) throw new Error('Ollama Cloud usage data could not be parsed');
+    if (!/Session\s+usage|Weekly\s+usage|Premium[^0-9]*[0-9]+\s*\/\s*[0-9]+|Monthly\s+usage/i.test(html)) throw new Error('Ollama Cloud usage data could not be parsed');
   }
   if (provider === 'cursor') {
     if (!credential.accessToken && credential.refreshToken) {

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1899,6 +1899,39 @@ const parseOllamaSettingsHtml = (html: string) => {
     });
   }
 
+  // Cost-based plans render "Monthly usage" with a dollar amount instead of
+  // session/weekly/premium windows; support both page shapes.
+  const monthlyMatch = html.match(/Monthly\s+usage[\s\S]{0,200}?\$([0-9][0-9,.]*)\s+of\s+\$([0-9][0-9,.]*)/i);
+  if (monthlyMatch) {
+    const used = toNumber(monthlyMatch[1].replace(/,/g, ''));
+    const total = toNumber(monthlyMatch[2].replace(/,/g, ''));
+    const usedPercent = total && used !== null ? Math.min(100, (used / total) * 100) : null;
+    windows.monthly = toUsageWindow({
+      usedPercent,
+      windowSeconds: null,
+      resetAt: null,
+      valueLabel: `$${monthlyMatch[1]} / $${monthlyMatch[2]}`,
+    });
+  }
+
+  // "Extra usage" credits block (visible when credits/auto-reload is enabled):
+  // a balance, not a percent. Anchor on "Balance remaining" — nearby "Add $5"
+  // and auto-reload copy also contain dollar amounts. Surfaced with the
+  // credits_balance key and OpenAI-style plain money label (the UI renders
+  // it as "Credits Balance"); a $0 balance is omitted rather than shown.
+  const balanceMatch = html.match(/Balance\s+remaining[\s\S]{0,200}?\$([0-9][0-9,.]*)/i);
+  if (balanceMatch) {
+    const balance = toNumber(balanceMatch[1].replace(/,/g, ''));
+    if (balance !== 0) {
+      windows.credits_balance = toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `$${balanceMatch[1]}`,
+      });
+    }
+  }
+
   return windows;
 };
 

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -35,7 +35,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `zhipuai-coding-plan` | Zhipu AI Coding Plan | `providers/zhipuai-coding-plan.js` | `zhipuai-coding-plan`, `zhipuai`, `zhipu` |
 | `minimax-coding-plan` | MiniMax Coding Plan (minimax.io) | `providers/minimax-coding-plan.js` / `providers/minimax-shared.js` | `minimax-coding-plan` |
 | `minimax-cn-coding-plan` | MiniMax Coding Plan (minimaxi.com) | `providers/minimax-cn-coding-plan.js` / `providers/minimax-shared.js` | `minimax-cn-coding-plan` |
-| `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Manual cookie stored under `~/.config/openchamber/quota/` |
+| `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Manual cookie pasted into Settings (`aid=...; __Secure-session=...` from `ollama.com`), stored under `~/.config/openchamber/quota/` |
 | `wafer` | Wafer.ai | `providers/wafer.js` | `wafer`, `wafer-ai`, `wafer_ai`, `wafer.ai` |
 | `opencode-go` | OpenCode Go | `providers/opencode-go.js` | `opencode-go` API key from OpenCode `auth.json` |
 | `neuralwatt` | NeuralWatt | `providers/neuralwatt.js` | `neuralwatt` (API key under `key` or `token`) |
@@ -104,6 +104,10 @@ Web and VS Code accept finite numeric balances and non-empty numeric strings. Mi
 - Each `limits[].detail` rate-limit block returns `remaining` (available) with no `used` field.
 
 The provider computes `usedPercent` from whichever of `used`/`remaining` is present (`used` takes precedence when both exist) rather than assuming one field name. Both `packages/web/server/lib/quota/providers/kimi.js` and `packages/vscode/src/quotaProviders.ts` (`fetchKimiQuota`) must stay in sync — the VS Code extension duplicates this parsing logic rather than importing it.
+
+## Ollama Cloud settings-page shapes
+
+Ollama Cloud authentication uses two cookies (`aid` and `__Secure-session`) pasted together as one single-line Cookie header value. Ollama serves two different `/settings` page shapes and `parseOllamaSettingsHtml` supports both: session/weekly/premium-interaction windows (percent-based plans) and a `monthly` window derived from "Monthly usage: $X of $Y used" (cost-based plans) with a symmetric `$X / $Y` money `valueLabel` that reads correctly in both used/remaining display modes. The "Extra usage" credits block is surfaced as a balance-only `credits_balance` window with a plain money `valueLabel` when present, matching the Codex/DeepSeek credits treatment ("Credits Balance" in the UI); a $0 balance is omitted instead of showing an empty credits row. Keep `packages/web/server/lib/quota/providers/ollama-cloud.js` and `packages/vscode/src/quotaProviders.ts` (`parseOllamaSettingsHtml`) in sync — the VS Code extension duplicates this parsing logic rather than importing it.
 
 ## GitHub Copilot quota semantics
 

--- a/packages/web/server/lib/quota/providers/ollama-cloud.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.js
@@ -35,6 +35,37 @@ export const parseOllamaSettingsHtml = (html) => {
       valueLabel: `${used ?? 0} / ${total ?? 0}`
     });
   }
+  // Cost-based plans render "Monthly usage" with a dollar amount instead of
+  // session/weekly/premium windows; support both page shapes.
+  const monthlyMatch = html.match(/Monthly\s+usage[\s\S]{0,200}?\$([0-9][0-9,.]*)\s+of\s+\$([0-9][0-9,.]*)/i);
+  if (monthlyMatch) {
+    const used = toNumber(monthlyMatch[1].replace(/,/g, ''));
+    const total = toNumber(monthlyMatch[2].replace(/,/g, ''));
+    const usedPercent = total && used !== null ? Math.min(100, (used / total) * 100) : null;
+    windows.monthly = toUsageWindow({
+      usedPercent,
+      windowSeconds: null,
+      resetAt: null,
+      valueLabel: `$${monthlyMatch[1]} / $${monthlyMatch[2]}`
+    });
+  }
+  // "Extra usage" credits block (visible when credits/auto-reload is enabled):
+  // a balance, not a percent. Anchor on "Balance remaining" — nearby "Add $5"
+  // and auto-reload copy also contain dollar amounts. Surfaced with the
+  // credits_balance key and OpenAI-style plain money label (the UI renders
+  // it as "Credits Balance"); a $0 balance is omitted rather than shown.
+  const balanceMatch = html.match(/Balance\s+remaining[\s\S]{0,200}?\$([0-9][0-9,.]*)/i);
+  if (balanceMatch) {
+    const balance = toNumber(balanceMatch[1].replace(/,/g, ''));
+    if (balance !== 0) {
+      windows.credits_balance = toUsageWindow({
+        usedPercent: null,
+        windowSeconds: null,
+        resetAt: null,
+        valueLabel: `$${balanceMatch[1]}`
+      });
+    }
+  }
   return windows;
 };
 

--- a/packages/web/server/lib/quota/providers/ollama-cloud.test.js
+++ b/packages/web/server/lib/quota/providers/ollama-cloud.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { fetchOllamaCloudUsage } from './ollama-cloud.js';
+import { parseOllamaSettingsHtml, fetchOllamaCloudUsage } from './ollama-cloud.js';
 
 describe('Ollama Cloud quota provider', () => {
   it('rejects redirects without forwarding credentials', async () => {
@@ -8,5 +8,37 @@ describe('Ollama Cloud quota provider', () => {
 
   it('rejects successful pages without usage data', async () => {
     await expect(fetchOllamaCloudUsage({ cookie: 'session=secret' }, async () => new Response('<html></html>'))).rejects.toThrow('could not be parsed');
+  });
+
+  it('parses session/weekly/premium windows', () => {
+    const windows = parseOllamaSettingsHtml('<p>Session usage: 42%</p><p>Weekly usage: 7%</p><p>Premium 120 / 1000</p>');
+    expect(windows.session.usedPercent).toBe(42);
+    expect(windows.weekly.usedPercent).toBe(7);
+    expect(windows.premium.usedPercent).toBe(12);
+    expect(windows.premium.valueLabel).toBe('120 / 1000');
+  });
+
+  it('parses the cost-based monthly usage shape', () => {
+    const html = '<span class="text-sm">Monthly usage</span>\n      <span class="text-sm "\n        >$4.39 of $60 used</span\n      >';
+    const windows = parseOllamaSettingsHtml(html);
+    expect(windows.monthly.usedPercent).toBeCloseTo(7.3, 1);
+    expect(windows.monthly.valueLabel).toBe('$4.39 / $60');
+    expect(windows.monthly.remainingPercent).toBeCloseTo(92.7, 1);
+  });
+
+  it('parses the extra-usage credits balance', () => {
+    const html = '<div><span>Balance remaining</span><span>$12.50</span></div><button>Add $5</button>';
+    const windows = parseOllamaSettingsHtml(html);
+    expect(windows.credits_balance.usedPercent).toBeNull();
+    expect(windows.credits_balance.valueLabel).toBe('$12.50');
+  });
+
+  it('omits the credits balance when it is zero', () => {
+    const html = '<div><span>Balance remaining</span><span>$0.00</span></div>';
+    expect(parseOllamaSettingsHtml(html).credits_balance).toBeUndefined();
+  });
+
+  it('ignores nearby dollar amounts that are not the balance', () => {
+    expect(parseOllamaSettingsHtml('<p>Add $5 to your balance when it hits $0</p>').credits_balance).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Intent

Ollama Cloud switched its /settings page for cost-based plans. The quota parser only knew the percent-based shape (session/weekly/premium), so an account on a dollar plan matched nothing: the fetch threw "Ollama Cloud usage data could not be parsed" and every quota surface showed nothing for that provider.

This PR teaches both parsers the second shape. A "Monthly usage $X of $Y used" row becomes a `monthly` window with a symmetric `$X / $Y` money label, so it reads correctly in both used and remaining display modes. The "Extra usage" block becomes a balance-only `credits_balance` window (the same treatment Codex and DeepSeek get, rendered as "Credits Balance" by the shared UI), and a $0 balance emits no window at all. Credential validation accepts the new page shape, and the Settings cookie placeholder now shows the real two-cookie format (`aid=...; __Secure-session=...`).

## Non-goals

- Credential normalizers are untouched. Real pastes are a single line (`aid=...; __Secure-session=...`, with a space, no line breaks), which the existing trim-based normalizer already accepts. Confirmed live on a real account before reverting an earlier whitespace-stripping attempt.
- Other providers are untouched. Claude's `extra_usage` window (Anthropic spend) and the Codex/DeepSeek `credits_balance` handling behave exactly as before.
- No UI code changes. Labels come from the existing shared window map in `packages/ui/src/lib/quota/utils.ts`; `credits_balance` and `monthly` already map to "Credits Balance" and "Monthly".

## Affected surfaces

- `packages/web/server/lib/quota/providers/ollama-cloud.js` and its test. The web server serves both the browser UI and the Electron desktop runtime, so web and desktop get the fix together.
- `packages/vscode/src/quotaProviders.ts` (duplicated `parseOllamaSettingsHtml`, kept in sync per the quota DOCUMENTATION.md rule) and `packages/vscode/src/quotaCredentials.ts` (validation regex only; the normalizer stays byte-identical to upstream).
- `packages/ui/src/components/sections/usage/QuotaCredentials.tsx` (placeholder copy only).
- No persisted or external contract changes. The credential cookie still goes only to `ollama.com` with `redirect: 'manual'`.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariants (never let fetch failure masquerade as authoritative empty success) | Quota parsing decides what a provider's usage rows show | A regex miss still throws the explicit "could not be parsed" error; the new blocks only add windows when they match, so no fake empty success and no wrong rows |
| `packages/web/server/lib/quota/DOCUMENTATION.md` (Ollama Cloud settings-page shapes) | Owning doc for this provider and the web/VS Code parser sync rule | Both parsers updated line for line, the doc section now describes the `credits_balance` key, the `$X / $Y` label, and the $0 omission |
| `.agents/skills/communication-style` | PR and doc wording | Plain, concrete descriptions of what the user sees |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run server/lib/quota/providers/ollama-cloud.test.js` (packages/web) | 7/7 pass: redirect fail-safe, unparseable-page fail-safe, percent shape, monthly shape (`$4.39 / $60`), credits balance, $0 omission, "Add $5" decoy rejection |
| `bun run --cwd packages/vscode type-check` | Clean on both tsconfigs |
| `bun run electron:build` + `verify:linux-appimage` | Built and verified at this HEAD (x64, OpenCode CLI 1.18.29, 4 native modules) |
| Live `ollama.com/settings` | Maintainer confirmed both shapes parse on the final code: old percent shape (5h/weekly windows) and new dollar-per-month shape |
| Two `pr-review` rounds on this branch | Round 1 returned MERGE-THEN-FIX (out-of-scope lockfile residue); resolved, then re-reviewed: round 2 returned MERGE with no new findings |

Not verified by automation: nothing further is outstanding. The automated PR reviewer re-checks at this HEAD.

## Visual evidence

Before: a cost-based plan produced no usage rows and the credential save failed with "Ollama Cloud usage data could not be parsed". After: the Usage page shows a Monthly row reading `$4.39 / $60`, and with credits enabled a Credits Balance row showing the plain money value (a $0 balance shows no row); the Settings pane shows the Ollama Cloud cookie field with the `aid=...; __Secure-session=...` placeholder, in narrow and wide panes, light and dark.

Before (settings):
<img width="647" height="393" alt="image" src="https://github.com/user-attachments/assets/097f4f1e-eaf7-42df-a5e9-f106556d3f18" />


New plan shape:
<img width="302" height="68" alt="Screenshot_20260906_103817" src="https://github.com/user-attachments/assets/12f2badf-a111-4d0c-a200-f1bf6c0c0337" />

Old plan shape (free)
<img width="303" height="94" alt="Screenshot_20260906_102452" src="https://github.com/user-attachments/assets/a8b9c76d-052a-4dd0-a861-7e18fd00f7a0" />

Settings:
<img width="644" height="449" alt="image" src="https://github.com/user-attachments/assets/e192d39e-1583-425a-9cde-794afdcc3122" />



## Risks and failure behavior

- Page-shape drift fails loudly: an unmatched page throws the explicit parse error instead of showing stale or wrong numbers. Rollback is one revert.
- The regexes anchor on page copy ("Monthly usage", "Balance remaining") with bounded character windows, the same technique the existing premium and balance parsers use. Nearby dollar amounts that are not the balance are covered by a test (the "Add $5" decoy).
- Cross-runtime drift is the standing risk for this provider; the duplicated VS Code parser is covered by the documented sync rule and was verified line-for-line in review.
- No security change: no new endpoints, no new credential storage, cookie still sent only to `ollama.com` with manual redirects.
