### PR TITLE
fix(git): pass allowUnsafeCredentialHelper for token identity switching

### DIFF
--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -352,7 +352,7 @@ const buildGitEnv = async () => {
   return env;
 };
 
-const createGit = async (directory, { allowUnsafeSshCommand = false } = {}) => {
+const createGit = async (directory, { allowUnsafeSshCommand = false, allowUnsafeCredentialHelper = false } = {}) => {
   const env = await buildGitEnv();
   const spawnOptions = { windowsHide: true };
   const binary = getGitBinary();
@@ -360,8 +360,9 @@ const createGit = async (directory, { allowUnsafeSshCommand = false } = {}) => {
   const unsafe = hasCustomBinary || allowUnsafeSshCommand
     ? {
       ...(hasCustomBinary && { allowUnsafeCustomBinary: true }),
-      ...(allowUnsafeSshCommand && { allowUnsafeSshCommand: true }),
-    }
+        ...(allowUnsafeSshCommand && { allowUnsafeSshCommand: true }),
+        ...(allowUnsafeCredentialHelper && { allowUnsafeCredentialHelper: true }),
+      }
     : undefined;
   // Always pin simple-git to an explicit working directory. Omitting baseDir
   // makes simple-git use process.cwd(), which breaks when the OpenChamber
@@ -2146,7 +2147,7 @@ export async function hasLocalIdentity(directory) {
 }
 
 export async function setLocalIdentity(directory, profile) {
-  const git = await createGit(directory, { allowUnsafeSshCommand: true });
+  const git = await createGit(directory, { allowUnsafeSshCommand: true, allowUnsafeCredentialHelper: true });
 
   try {
 

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -183,6 +183,41 @@ describe.runIf(canRunGit())('setLocalIdentity', () => {
       "ssh -i '/tmp/test key' -o IdentitiesOnly=yes"
     );
   });
+
+  it('configures the stored credential helper for token auth with the targeted simple-git opt-in', async () => {
+    const { tmpDir } = await createTempRepo();
+
+    await setLocalIdentity(tmpDir, {
+      userName: 'Token User',
+      userEmail: 'token@example.com',
+      authType: 'token',
+      host: 'github.com',
+    });
+
+    expect(runGit(tmpDir, ['config', '--local', '--get', 'credential.helper']).trim()).toBe('store');
+  });
+
+  it('clears the stored credential helper when switching to SSH auth', async () => {
+    const { tmpDir } = await createTempRepo();
+
+    await setLocalIdentity(tmpDir, {
+      userName: 'Token User',
+      userEmail: 'token@example.com',
+      authType: 'token',
+      host: 'github.com',
+    });
+    await setLocalIdentity(tmpDir, {
+      userName: 'SSH User',
+      userEmail: 'ssh@example.com',
+      authType: 'ssh',
+      sshKey: '/tmp/test key',
+    });
+
+    expect(runGit(tmpDir, ['config', '--local', '--get', 'core.sshCommand']).trim()).toBe(
+      "ssh -i '/tmp/test key' -o IdentitiesOnly=yes"
+    );
+    expect(() => runGit(tmpDir, ['config', '--local', '--get', 'credential.helper'])).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Switching to a **token-auth** Git identity throws:

```
Configuring credential.helper is not permitted without enabling allowUnsafeCredentialHelper
```

`setLocalIdentity` already opts into simple-git's escape hatch for the SSH branch (`allowUnsafeSshCommand`, forwarded by `createGit`), but the token branch (`addConfig('credential.helper', 'store')`) is missing the matching opt-in introduced for it by simple-git's expanded unsafe-config blocklist.

Fix: forward a new `allowUnsafeCredentialHelper` option through `createGit` and enable it in `setLocalIdentity` alongside the existing SSH opt-in.

## Root cause timeline

| When | Event |
|---|---|
| 2026-01-14 (v1.4.8) | Token-based identity auth shipped with `simple-git ^3.28.0`, whose blocklist only covered `protocol.allow` / `--upload-pack` — the token branch worked. |
| 2026-04 (simple-git 3.35/3.36) | The blocklist moved into `@simple-git/argv-parser` and expanded to 24 keys, now including `credential.helper` **and** `core.sshCommand`. |
| after the bump | Both branches broke. The SSH branch got the targeted opt-in (`allowUnsafeSshCommand: true`, covered by the existing test); the token branch — which has no test — was missed and has been broken since. |

## Changes

- `createGit` accepts and forwards `allowUnsafeCredentialHelper` (mirrors the existing `allowUnsafeSshCommand` plumbing).
- `setLocalIdentity` passes `allowUnsafeCredentialHelper: true`.
- Tests: token branch writes `credential.helper=store`; switching token → SSH writes `core.sshCommand` and clears `credential.helper` (mirrors the existing SSH test).

## Test plan

- [x] `vitest run server/lib/git/service.test.js -t setLocalIdentity` — 3/3 pass
- [x] Full `service.test.js` — 90 pass; 2 pre-existing failures on this machine reproduce on unmodified `main` (locale-dependent git stderr + `/tmp` filesystem-boundary worktree lock recovery), unrelated to this change
- [x] Manual: token identity switch now writes `credential.helper=store` and clears `core.sshCommand`; SSH switch unchanged
