### PR TITLE
fix(quota): drop NeuralWatt key-name valueLabel so allowance windows render percent

### DIFF
--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -429,7 +429,7 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     assert.equal(result.usage!.windows.credits_balance!.valueLabel, '$32.68');
   });
 
-  test('surfaces subscription and allowance windows (allowance keyed by period, key name in valueLabel)', async () => {
+  test('surfaces subscription and allowance windows (allowance keyed by period, percent value)', async () => {
     const payload = {
       ...DOCUMENTED_SUBSCRIPTION_PAYLOAD,
       balance: { credits_remaining_usd: 200 },
@@ -447,11 +447,11 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     assert.ok(Math.abs((subWindow!.usedPercent as number) - (13.9023 / 20.0) * 100) < 1e-2);
 
     // Allowance window is keyed by the localized period label ("monthly");
-    // key name flows through valueLabel for identification.
+    // the usage value stays a percent — no key-name valueLabel.
     const allowWindow = result.usage!.windows.monthly;
     assert.ok(allowWindow);
     assert.equal(allowWindow!.usedPercent, 25);
-    assert.equal(allowWindow!.valueLabel, 'Prod');
+    assert.equal(allowWindow!.valueLabel, undefined);
     assert.equal(allowWindow!.resetAt, Date.parse('2026-08-01T00:00:00Z'));
 
     assert.equal(result.usage!.windows.credits_balance, undefined);
@@ -476,7 +476,7 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     assert.ok(Math.abs((window!.usedPercent as number) - (25 / 55) * 100) < 1e-2);
     assert.equal(window!.windowSeconds, 30 * 86400);
     assert.equal(window!.resetAt, Date.parse('2026-08-01T00:00:00Z'));
-    assert.equal(window!.valueLabel, 'prod-key');
+    assert.equal(window!.valueLabel, undefined);
     assert.equal(result.usage!.windows.credits_balance, undefined);
   });
 
@@ -515,7 +515,7 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     assert.ok(window);
     assert.equal(window!.windowSeconds, 604800);
     assert.equal(window!.resetAt, Date.parse('2026-07-04T00:00:00Z'));
-    assert.equal(window!.valueLabel, 'Prod');
+    assert.equal(window!.valueLabel, undefined);
   });
 
   test('uses daily as the allowance key when period is daily', async () => {
@@ -555,7 +555,7 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     assert.equal(window!.usedPercent, 25);
   });
 
-  test('marks blocked allowance as 100% with valueLabel set', async () => {
+  test('marks blocked allowance as 100% with percent value', async () => {
     const payload = {
       balance: { credits_remaining_usd: 30 },
       subscription: null,
@@ -571,7 +571,7 @@ describe('NeuralWatt quota provider (VS Code parity)', () => {
     const window = result.usage!.windows.monthly;
     assert.ok(window);
     assert.equal(window!.usedPercent, 100);
-    assert.equal(window!.valueLabel, 'sample');
+    assert.equal(window!.valueLabel, undefined);
   });
 
   test('falls back to credits_balance when neither subscription nor allowance exists', async () => {

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -2512,7 +2512,6 @@ const fetchNeuralwattQuota = async (): Promise<ProviderResult> => {
     const subscription = payload?.subscription ?? null;
     const inOverage = Boolean(subscription?.in_overage);
     const allowance = payload?.key?.allowance ?? null;
-    const keyName = payload?.key?.name ?? null;
     const creditsRemaining = toNumber(payload?.balance?.credits_remaining_usd);
 
     const windows: Record<string, UsageWindow> = {};
@@ -2558,19 +2557,17 @@ const fetchNeuralwattQuota = async (): Promise<ProviderResult> => {
         : (spent !== null && effectiveLimit !== null && effectiveLimit > 0
             ? Math.max(0, Math.min(100, (spent / effectiveLimit) * 100))
             : null);
-      // Window title is the localized period label (daily/weekly/monthly); key
-      // name is attached via valueLabel for identification (wafer precedent).
+      // Window title is the localized period label (daily/weekly/monthly); the
+      // usage value stays a percent so the UI's display-mode toggle applies.
       const periodKey = (period === 'daily' || period === 'weekly' || period === 'monthly' || period === 'month')
         ? (period === 'month' ? 'monthly' : period)
         : 'billing_cycle';
-      const labelName = typeof keyName === 'string' && keyName.trim() ? keyName.trim() : null;
       const resetAt = toTimestamp(allowance.reset_at);
       const windowSeconds = period ? neuralwattWindowSeconds(period) : null;
       windows[periodKey] = toUsageWindow({
         usedPercent,
         windowSeconds,
         resetAt,
-        ...(labelName ? { valueLabel: labelName } : {}),
       });
     } else if (creditsRemaining !== null) {
       windows.credits_balance = toUsageWindow({

--- a/packages/web/server/lib/quota/providers/neuralwatt.js
+++ b/packages/web/server/lib/quota/providers/neuralwatt.js
@@ -74,7 +74,6 @@ export const fetchQuota = async () => {
     const subscription = payload?.subscription ?? null;
     const inOverage = Boolean(subscription?.in_overage);
     const allowance = payload?.key?.allowance ?? null;
-    const keyName = payload?.key?.name ?? null;
     const creditsRemaining = toNumber(payload?.balance?.credits_remaining_usd);
 
     const windows = {};
@@ -116,19 +115,17 @@ export const fetchQuota = async () => {
         : (spent !== null && effectiveLimit !== null && effectiveLimit > 0
             ? Math.max(0, Math.min(100, (spent / effectiveLimit) * 100))
             : null);
-      // Window title is the localized period label (daily/weekly/monthly); key
-      // name is attached via valueLabel for identification (wafer precedent).
+      // Window title is the localized period label (daily/weekly/monthly); the
+      // usage value stays a percent so the UI's display-mode toggle applies.
       const periodKey = (period === 'daily' || period === 'weekly' || period === 'monthly' || period === 'month')
         ? (period === 'month' ? 'monthly' : period)
         : 'billing_cycle';
-      const labelName = asNonEmptyString(keyName);
       const resetAt = toTimestamp(allowance.reset_at);
       const windowSeconds = period ? periodToWindowSeconds(period) : null;
       windows[periodKey] = toUsageWindow({
         usedPercent,
         windowSeconds,
-        resetAt,
-        ...(labelName ? { valueLabel: labelName } : {})
+        resetAt
       });
     } else if (creditsRemaining !== null) {
       windows.credits_balance = toUsageWindow({

--- a/packages/web/server/lib/quota/providers/neuralwatt.test.js
+++ b/packages/web/server/lib/quota/providers/neuralwatt.test.js
@@ -89,7 +89,7 @@ describe('NeuralWatt quota provider', () => {
     expect(result.usage.windows.credits_balance.valueLabel).toBe('$32.68');
   });
 
-  it('surfaces subscription and allowance windows (allowance keyed by period, key name in valueLabel)', async () => {
+  it('surfaces subscription and allowance windows (allowance keyed by period, percent value)', async () => {
     const payload = {
       ...DOCUMENTED_SUBSCRIPTION_PAYLOAD,
       balance: { credits_remaining_usd: 200 },
@@ -107,11 +107,11 @@ describe('NeuralWatt quota provider', () => {
     expect(subWindow.usedPercent).toBeCloseTo((13.9023 / 20.0) * 100, 4);
 
     // Allowance window is keyed by the localized period label ("monthly");
-    // key name flows through valueLabel for identification.
+    // the usage value stays a percent — no key-name valueLabel.
     const allowWindow = result.usage.windows.monthly;
     expect(allowWindow).toBeDefined();
     expect(allowWindow.usedPercent).toBe(25);
-    expect(allowWindow.valueLabel).toBe('Prod');
+    expect(allowWindow.valueLabel).toBeUndefined();
     expect(allowWindow.resetAt).toBe(Date.parse('2026-08-01T00:00:00Z'));
 
     // credits_balance suppressed because allowance is present
@@ -137,7 +137,7 @@ describe('NeuralWatt quota provider', () => {
     expect(window.usedPercent).toBeCloseTo((25 / 55) * 100, 4);
     expect(window.windowSeconds).toBe(30 * 86400);
     expect(window.resetAt).toBe(Date.parse('2026-08-01T00:00:00Z'));
-    expect(window.valueLabel).toBe('prod-key');
+    expect(window.valueLabel).toBeUndefined();
     expect(result.usage.windows.credits_balance).toBeUndefined();
   });
 
@@ -176,7 +176,7 @@ describe('NeuralWatt quota provider', () => {
     expect(window).toBeDefined();
     expect(window.windowSeconds).toBe(604800);
     expect(window.resetAt).toBe(Date.parse('2026-07-04T00:00:00Z'));
-    expect(window.valueLabel).toBe('Prod');
+    expect(window.valueLabel).toBeUndefined();
   });
 
   it('uses daily as the allowance key when period is daily', async () => {
@@ -216,7 +216,7 @@ describe('NeuralWatt quota provider', () => {
     expect(window.usedPercent).toBe(25);
   });
 
-  it('marks blocked allowance as 100% with valueLabel set', async () => {
+  it('marks blocked allowance as 100% with percent value', async () => {
     const payload = {
       balance: { credits_remaining_usd: 30 },
       subscription: null,
@@ -231,7 +231,7 @@ describe('NeuralWatt quota provider', () => {
 
     const window = result.usage.windows.monthly;
     expect(window.usedPercent).toBe(100);
-    expect(window.valueLabel).toBe('sample');
+    expect(window.valueLabel).toBeUndefined();
   });
 
   it('falls back to credits_balance when neither subscription nor allowance exists', async () => {


### PR DESCRIPTION
## Intent

The NeuralWatt quota provider attached the API key's **name** as the allowance window's `valueLabel`. The shared UI renders the value slot as `valueLabel ?? formatPercent(percent)` (`packages/ui/src/lib/quota/utils.ts:25`), so in every usage surface — work-status rows, the collapsed headline, usage cards, mobile provider cards, and the tray — the key name *replaced* the percentage instead of complementing it. A window read "Monthly → `my-production-key`" with no usage figure anywhere, and because the label is a static string it also short-circuited the usage/remaining display-mode toggle in both modes.

This PR removes the key-name `valueLabel`. The allowance window now carries only `usedPercent`/`remainingPercent`, so the UI renders a real percentage, respects the display-mode toggle, and applies the existing 50%/80% warn/critical toning. The key name carried no information: the OpenCode auth file holds exactly one `neuralwatt` entry, so there is nothing to disambiguate. Dollar-based windows (subscription kWh, credits balance) are unaffected.

## Non-goals

- No change to the subscription window (plan-name title, kWh percent) or the `credits_balance` fallback window — its `$X` money `valueLabel` is intentional and stays.
- No change to allowance window keying (`daily`/`weekly`/`monthly`/`billing_cycle`) or window seconds/reset timestamps.
- No shared-UI changes and no progress bars added to work-status rows; bars there are a panel-wide design property for all providers, not a NeuralWatt defect.
- No wafer-style `$X / $Y` money label as a replacement: a server-computed `valueLabel` cannot respond to the client-side usage/remaining toggle; percent is the correct metric for this window.

## Affected surfaces

- `packages/web/server/lib/quota/providers/neuralwatt.js` — serves the web and desktop (Electron) runtimes.
- `packages/vscode/src/quotaProviders.ts` — the VS Code extension's duplicated parsing logic, kept in lockstep per the quota module's sync rule.
- Both owning test files updated to the new contract.
- `packages/ui` is untouched: every consumer already falls back to `formatPercent` when `valueLabel` is absent (verified at `formatQuotaValueLabel` call sites: `WorkStatusUsageSection.tsx`, `UsageCard.tsx`, `UsageProviderCards.tsx`, `VSCodeLayout.tsx`, `useTraySync.ts`).
- External contract unchanged: the same NeuralWatt `/v1/quota` payload is parsed, and the quota result shape is identical except the optional `valueLabel` field is now omitted on the allowance window.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` instruction order + `openchamber-change-discipline` | Source change in a mirrored provider; every risk class must have an owner and the narrowest validation. | Smallest complete change (net −6 lines, deletion over addition); local-implementation risk validated with focused suites plus package-scoped type-check/lint in the one TypeScript workspace; no files added/removed and no export shape change, so `dead-code` is not triggered. |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Owning module docs; state the sync rule and response contract. | Web provider and VS Code `quotaProviders.ts` keep identical deletion and comments; provider table row (line 41) and the response-contract section remain accurate — no `valueLabel` semantics were documented for NeuralWatt, so no doc statement turned false. |
| Security rule: never log or expose secrets | The API key name transited to the UI before. | The name is no longer read or surfaced; nothing else from `payload.key` reaches the client. |

## Validation

| Check | Result |
|---|---|
| `bun run test server/lib/quota/providers/neuralwatt.test.js` (vitest, packages/web) | 14/14 pass |
| `bun test src/quotaProviders.test.ts` (packages/vscode) | 70/70 pass |
| `bun run type-check` (packages/vscode, both tsconfigs) | clean |
| `bun run lint` (packages/vscode eslint) | clean |
| `bunx oxlint` on the 4 changed paths | only pre-existing anti-slop findings in other providers (`quotaProviders.ts:2698+`, crof/deepseek) — known backlog, outside the edited hunks |

Not verified:

- **Live NeuralWatt API behavior.** The change is deletion-only on an optional output field, so the mocked contract tests cover the payload round-trip; no live account call was made.
- Repo-wide `bun run type-check` / `lint` / `test` / `build` were not run for this focused diff; the touched runtimes (web server JS — which TS/lint does not cover — and VS Code) got their applicable checks. Full workspace checks to be confirmed before the PR is marked ready.

## Visual evidence

This is a user-visible change: the NeuralWatt allowance value switches from the raw key name (e.g. `my-production-key`) to a percentage (e.g. `25%`), and the usage/remaining toggle now flips that number instead of repeating the same static string in both modes.

Screenshot (no change in the settings part)

Before (The key name is displayed where the usage should be):
<img width="298" height="70" alt="image" src="https://github.com/user-attachments/assets/8763170d-230d-4ff7-af8a-bf3b7bbaa7ea" />

After (The usage percentage is displayed and the key name is not):
<img width="306" height="72" alt="image" src="https://github.com/user-attachments/assets/d70bb9b8-c70f-476b-b522-667e44ebda0d" />

## Risks and failure behavior

- None identified beyond the intended display change: the diff deletes an optional field from one provider's window object in two mirrored modules. No persisted state, no migration, no fetch-path change; error and fallback branches (including `credits_balance` and `blocked → 100%`) are covered by unchanged tests that still pass.
- If NeuralWatt ever exposes multiple keys per auth entry, the window would lose per-key disambiguation — out of scope for today's single-key contract and not observable in the current API.
