### PR TITLE
Constrain the Thinking panel and follow live reasoning

### DIFF
--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -46,6 +46,10 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 - `ReasoningPart.tsx`
   - Thinking block UI (`ReasoningTimelineBlock`), summary + optional duration.
 
+- `useReasoningScrollFollow.ts`
+  - Keeps live reasoning pinned to the bottom while the rendered body grows,
+    with an explicit user-scroll opt-out.
+
 - `JustificationBlock.tsx`
   - Justification block wrapper over `ReasoningTimelineBlock`.
 
@@ -92,6 +96,7 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 - Running bash output falls back to `state.metadata.output` until canonical `state.output` arrives. Its output viewport grows with the content up to `46vh`, then scrolls and follows new output until the user scrolls up; following resumes when the user returns to the bottom. Live output appends or replaces rewritten snapshots as plain text without worker highlighting; finalized output normalizes ANSI terminal controls with a bounded synthetic-cell budget, bypasses the throttle, and receives the normal one-time highlighted rendering.
 - Thinking/Justification duration is hidden in `sorted` mode (handled in `ReasoningPart.tsx` + `JustificationBlock.tsx`).
 - Reasoning streaming presentation derives from the live stream phase (`streaming`/`cooldown`), never from missing persisted timing: a cached part without `time.end` is not live, and a part whose `time.end` is set never streams (issue #2020).
+- While streaming, the reasoning body is constrained to a scrollable `max-h-80` container with auto-follow to the bottom as tokens commit; auto-follow pauses if the user scrolls up and resumes upon returning to the bottom.
 
 ## "I want to change description for Perplexity" (example recipe)
 

--- a/packages/ui/src/components/chat/message/parts/ReasoningPart.test.tsx
+++ b/packages/ui/src/components/chat/message/parts/ReasoningPart.test.tsx
@@ -7,9 +7,29 @@ import type { Part } from '@opencode-ai/sdk/v2';
 
 import { I18nProvider } from '@/lib/i18n';
 import ReasoningPart, { ReasoningTimelineBlock } from './ReasoningPart';
+import { useReasoningScrollFollow } from './useReasoningScrollFollow';
 import type { StreamPhase } from '../types';
 
 type ReasoningPartFixture = Extract<Part, { type: 'reasoning' }>;
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  private readonly callback: () => void;
+
+  constructor(callback: () => void) {
+    this.callback = callback;
+    TestResizeObserver.instances.push(this);
+  }
+
+  observe(): void {}
+
+  disconnect(): void {}
+
+  trigger(): void {
+    this.callback();
+  }
+}
 
 /**
  * Mounts a real client root against a happy-dom document so mount/unmount
@@ -25,6 +45,7 @@ const DOM_GLOBAL_NAMES = [
   'Node',
   'Element',
   'HTMLElement',
+  'ResizeObserver',
   'IS_REACT_ACT_ENVIRONMENT',
 ] as const;
 
@@ -40,8 +61,10 @@ const installDomStub = () => {
     Node: happyWindow.Node,
     Element: happyWindow.Element,
     HTMLElement: happyWindow.HTMLElement,
+    ResizeObserver: TestResizeObserver,
     IS_REACT_ACT_ENVIRONMENT: true,
   };
+  TestResizeObserver.instances = [];
   for (const name of DOM_GLOBAL_NAMES) {
     Object.defineProperty(globalThis, name, { value: values[name], configurable: true, writable: true });
   }
@@ -58,8 +81,31 @@ const installDomStub = () => {
         if (descriptor) Object.defineProperty(globalThis, name, descriptor);
         else Reflect.deleteProperty(globalThis, name);
       }
+      happyWindow.close();
     },
   };
+};
+
+const ScrollFollowHarness: React.FC<{ text: string; isStreaming: boolean }> = ({ text, isStreaming }) => {
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const { handleWheelCapture, handleScroll } = useReasoningScrollFollow(
+    scrollRef,
+    contentRef,
+    isStreaming,
+    text,
+  );
+
+  return (
+    <div
+      ref={scrollRef}
+      data-scroll-follow-scroll="true"
+      onWheelCapture={handleWheelCapture}
+      onScroll={handleScroll}
+    >
+      <div ref={contentRef}>{text}</div>
+    </div>
+  );
 };
 
 // A reasoning text whose summary (first 120 chars) fits in the header but
@@ -237,6 +283,8 @@ describe('ReasoningPart streaming gating (issue #2020)', () => {
 
     expect(markup).toContain(BUSY_INDICATOR);
     expect(markup).toContain('aria-expanded="true"');
+    expect(markup).toContain('data-scrollable="true"');
+    expect(markup).toContain('max-h-80');
   });
 
   test('a live part with no committed text yet shows the busy header and no empty summary', () => {
@@ -254,7 +302,7 @@ describe('ReasoningPart streaming gating (issue #2020)', () => {
     expect(markup).not.toContain('title="');
   });
 
-  test('remounting a completed reasoning part does not re-trigger the streaming presentation', async () => {
+  test.serial('remounting a completed reasoning part does not re-trigger the streaming presentation', async () => {
     // renderToStaticMarkup cannot observe this: it has no mount lifecycle, so
     // comparing two server renders is true by construction. Mount, unmount and
     // remount a real client root instead, watching the busy indicator across
@@ -288,6 +336,73 @@ describe('ReasoningPart streaming gating (issue #2020)', () => {
 
       expect(busySeen).toEqual([false, false]);
       expect(dom.container.textContent).toContain(SHORT_REASONING);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      dom.restore();
+    }
+  });
+});
+
+describe('reasoning scroll follow', () => {
+  test.serial('keeps live reasoning pinned as the rendered body grows', async () => {
+    const dom = installDomStub();
+    const root = createRoot(dom.container);
+    let scrollHeight = 300;
+
+    try {
+      await act(async () => {
+        root.render(<ScrollFollowHarness text="first thought" isStreaming />);
+      });
+
+      const scrollElement = dom.container.querySelector('[data-scroll-follow-scroll]');
+      if (!(scrollElement instanceof HTMLElement)) {
+        throw new Error('Expected the scroll-follow harness to render a scroll element');
+      }
+
+      let scrollTop = 0;
+      Object.defineProperties(scrollElement, {
+        scrollHeight: {
+          configurable: true,
+          get: () => scrollHeight,
+        },
+        clientHeight: {
+          configurable: true,
+          value: 100,
+        },
+        scrollTop: {
+          configurable: true,
+          get: () => scrollTop,
+          set: (value: number) => {
+            scrollTop = Math.max(0, Math.min(value, scrollHeight - 100));
+          },
+        },
+      });
+
+      TestResizeObserver.instances[0]?.trigger();
+      expect(scrollElement.scrollTop).toBe(200);
+
+      await act(async () => {
+        scrollElement.scrollTop = 100;
+        const wheelEvent = new window.Event('wheel', { bubbles: true });
+        Object.defineProperty(wheelEvent, 'deltaY', { value: -40 });
+        scrollElement.dispatchEvent(wheelEvent);
+        scrollElement.dispatchEvent(new window.Event('scroll', { bubbles: true }));
+        root.render(<ScrollFollowHarness text="second thought" isStreaming />);
+      });
+      scrollHeight = 500;
+      TestResizeObserver.instances[0]?.trigger();
+      expect(scrollElement.scrollTop).toBe(100);
+
+      await act(async () => {
+        scrollElement.scrollTop = scrollHeight - 100;
+        scrollElement.dispatchEvent(new window.Event('scroll', { bubbles: true }));
+        root.render(<ScrollFollowHarness text="third thought" isStreaming />);
+      });
+      scrollHeight = 600;
+      TestResizeObserver.instances[0]?.trigger();
+      expect(scrollElement.scrollTop).toBe(500);
     } finally {
       await act(async () => {
         root.unmount();

--- a/packages/ui/src/components/chat/message/parts/ReasoningPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/ReasoningPart.tsx
@@ -10,6 +10,7 @@ import { useUIStore } from '@/stores/useUIStore';
 import { MarkdownRenderer } from '../../MarkdownRenderer';
 import { useStreamingTextThrottle } from '../../hooks/useStreamingTextThrottle';
 import { commitStreamedText } from '../../lib/streamTextCommit';
+import { useReasoningScrollFollow } from './useReasoningScrollFollow';
 import type { StreamPhase } from '../types';
 
 const TOOL_ROW_TEXT_CLASS = '!text-[length:var(--text-meta)] !leading-5 sm:!leading-6 tracking-normal';
@@ -119,8 +120,16 @@ export const ReasoningTimelineBlock: React.FC<ReasoningTimelineBlockProps> = ({
     const [shouldRenderExpandedContent, setShouldRenderExpandedContent] = React.useState(defaultExpanded === true || canAutoExpand);
     const contentId = React.useId();
     const contentRef = React.useRef<HTMLDivElement>(null);
+    const scrollRef = React.useRef<HTMLElement | null>(null);
+    const reasoningContentRef = React.useRef<HTMLDivElement | null>(null);
     const contentAnimationRef = React.useRef<AnimationPlaybackControls | null>(null);
     const contentMountedRef = React.useRef(false);
+    const { handleWheelCapture, handleScroll } = useReasoningScrollFollow(
+        scrollRef,
+        reasoningContentRef,
+        isStreaming,
+        text,
+    );
 
     const summary = React.useMemo(() => getReasoningSummary(text), [text]);
     const toggleAriaLabel = isExpanded
@@ -389,28 +398,20 @@ export const ReasoningTimelineBlock: React.FC<ReasoningTimelineBlockProps> = ({
                             className="pointer-events-none absolute left-0 top-0 bottom-0 w-px"
                             style={{ backgroundColor: 'var(--tools-border)' }}
                         />
-                        {isStreaming ? (
-                            // While streaming, let the thinking grow inline — no
-                            // capped, independently-scrollable box. The chat's own
-                            // auto-follow then handles following / releasing, so the
-                            // box never captures the wheel or fights the user's
-                            // scroll. The max-height scroll box is applied only once
-                            // the thinking has finished (the branch below).
-                            <div className="p-0">
-                                {reasoningBody}
-                            </div>
-                        ) : (
-                            <ScrollableOverlay
-                                as="div"
-                                outerClassName="max-h-80"
-                                className="p-0"
-                                useScrollShadow
-                                scrollShadowSize={36}
-                                userIntentOnly
-                            >
-                                {reasoningBody}
-                            </ScrollableOverlay>
-                        )}
+                        <ScrollableOverlay
+                            ref={scrollRef}
+                            as="div"
+                            outerClassName="max-h-80"
+                            className="p-0"
+                            data-scrollable="true"
+                            useScrollShadow
+                            scrollShadowSize={36}
+                            userIntentOnly
+                            onWheelCapture={handleWheelCapture}
+                            onScroll={handleScroll}
+                        >
+                            <div ref={reasoningContentRef}>{reasoningBody}</div>
+                        </ScrollableOverlay>
                     </div>
                 </div>
             ) : null}

--- a/packages/ui/src/components/chat/message/parts/useReasoningScrollFollow.ts
+++ b/packages/ui/src/components/chat/message/parts/useReasoningScrollFollow.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+
+type ReasoningScrollFollow = {
+    handleWheelCapture: (event: React.WheelEvent<HTMLElement>) => void;
+    handleScroll: (event: React.UIEvent<HTMLElement>) => void;
+};
+
+export const useReasoningScrollFollow = <T extends HTMLElement>(
+    scrollRef: React.RefObject<T | null>,
+    contentRef: React.RefObject<HTMLElement | null>,
+    isStreaming: boolean,
+    contentKey: string,
+): ReasoningScrollFollow => {
+    const isFollowingRef = React.useRef(true);
+
+    const followReasoningScroll = React.useCallback(() => {
+        const element = scrollRef.current;
+        if (!element || !isFollowingRef.current) {
+            return;
+        }
+        element.scrollTop = element.scrollHeight;
+    }, [scrollRef]);
+
+    // Auto-scroll to bottom as new reasoning text streams in.
+    React.useLayoutEffect(() => {
+        if (!isStreaming) {
+            isFollowingRef.current = true;
+            return;
+        }
+        followReasoningScroll();
+    }, [contentKey, followReasoningScroll, isStreaming]);
+
+    // Markdown can finish laying out after the text commit that triggered the
+    // render. Observe the content itself so a growing body stays pinned even
+    // when the scroll container's own size has not changed.
+    React.useLayoutEffect(() => {
+        if (!isStreaming) {
+            return;
+        }
+
+        const content = contentRef.current;
+        const ResizeObserverConstructor = globalThis.ResizeObserver;
+        if (!content || !ResizeObserverConstructor) {
+            return;
+        }
+
+        const observer = new ResizeObserverConstructor(() => {
+            followReasoningScroll();
+        });
+        observer.observe(content);
+        return () => observer.disconnect();
+    }, [contentRef, followReasoningScroll, isStreaming]);
+
+    const handleWheelCapture = React.useCallback((event: React.WheelEvent<HTMLElement>) => {
+        if (isStreaming && event.deltaY < 0) {
+            isFollowingRef.current = false;
+        }
+    }, [isStreaming]);
+
+    const handleScroll = React.useCallback((event: React.UIEvent<HTMLElement>) => {
+        if (!isStreaming) {
+            return;
+        }
+        const element = event.currentTarget;
+        isFollowingRef.current = element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
+    }, [isStreaming]);
+
+    return { handleWheelCapture, handleScroll };
+};

--- a/packages/ui/src/types/bun-test.d.ts
+++ b/packages/ui/src/types/bun-test.d.ts
@@ -4,6 +4,9 @@
 declare module "bun:test" {
   export function describe(name: string, fn: () => void): void;
   export function test(name: string, fn: () => void | Promise<void>, timeoutMs?: number): void;
+  export namespace test {
+    function serial(name: string, fn: () => void | Promise<void>): void;
+  }
   export interface ExpectResult {
     toEqual(expected: unknown): void;
     toBe(expected: unknown): void;


### PR DESCRIPTION
## Intent

Update the Thinking panel and keep it useful while reasoning streams. On upstream `main`, live reasoning was rendered inline without a capped, independently scrollable container, so the panel could grow through the chat. This PR puts the reasoning body in the existing scrollable overlay capped at `max-h-80`, then follows new output at the bottom while it is generated. If the user scrolls up to inspect earlier reasoning, automatic following pauses and resumes when they return to the bottom.

## Why

Especially with reason thinking models e.g. Qwen 3.8 27B - they are extreme thinking models that can think for a large number of tokens. Due to this - the chat panel ends up being a wall of reasoning tokens/trace. This change makes this more pleasant in the chat window from a UX perspective. Inspiration from Codex.

## Non-goals

This PR does not change reasoning disclosure state, completed-trace summaries, streaming transport, message persistence, or the parent chat timeline. It also does not add a new runtime-specific implementation.

## Affected surfaces

- `packages/ui`: shared `ReasoningTimelineBlock` rendering now uses the bounded scrollable Thinking panel for both streaming and completed reasoning, plus live bottom-follow behavior.
- Web, desktop, VS Code, and mobile surfaces that consume the shared UI component receive the same behavior.
- No API, transport, persistence, authentication, or runtime contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This is a shared UI source change in a worktree that also contains unrelated edits. | The PR is based on `upstream/main`, changes only the focused reasoning files, adds no dependency or changelog entry, and leaves the original worktree untouched. |
| `openchamber-change-discipline` | The change adds a hook and updates an existing renderer contract. | The behavior stays in the owning chat-message-parts module, with a focused regression test and documentation update. |
| `sync-state-invariants` | The behavior is driven by live streaming state and user scroll intent. | The hook consumes the existing `isStreaming` prop, never persists or infers session state, and resets/cleans up when streaming ends or the block unmounts. |
| `performance-engineering` | Reasoning text is a high-frequency streaming path. | The observer watches only the rendered reasoning body, the follow callback is memoized, and the observer disconnects during cleanup. |
| `theme-system` | The change alters the visible reasoning container. | It reuses the existing `ScrollableOverlay`, scroll-shadow behavior, and established `max-h-80` styling. |
| `communication-style` | This PR description is maintainer-facing text. | The description uses direct, concise language and calls out scope and verification limits. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | It is the nearest module documentation for message-part rendering. | The new hook and live reasoning scroll invariant are documented there. |
| `packages/ui/src/sync/DOCUMENTATION.md` | The renderer consumes live stream state rather than persisted history. | No sync code or authority boundary was changed; the existing live-state contract remains the source of truth. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | They define the PR handoff and visual-evidence requirements. | This PR records affected surfaces, risks, exact checks, and the visual-evidence placeholder below. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/message/parts/ReasoningPart.test.tsx` | PASS: 12 tests, 35 assertions. Covers the capped streaming container and bottom-follow/pause/resume behavior. |
| `bun run type-check:ui` | PASS. |
| `bun run build:ui` | PASS. The package script completed its TypeScript build check. |
| `bun run lint:ui` | PASS with one pre-existing warning at `packages/ui/src/apps/MobileChangesSurface.tsx:212`. |
| `bunx oxlint packages/ui/src/components/chat/message/parts/ReasoningPart.tsx packages/ui/src/components/chat/message/parts/ReasoningPart.test.tsx packages/ui/src/components/chat/message/parts/useReasoningScrollFollow.ts` | Existing findings only in `ReasoningPart.tsx` (`typeof` guards and one existing assertion); the new hook and test added no findings. |
| `bun run dead-code` | Exit 0 with the repository's existing unused-file/export backlog; the new hook was not reported. |
| Manual visual/runtime check | Not run in a browser or device. The screenshot will be uploaded separately by the author as visual evidence for the affected expanded Thinking state; no before image or recording was supplied. |

## Visual evidence

The screenshot will be uploaded separately by the author after PR creation. It shows the expanded, bounded Thinking panel while live reasoning is being generated.

## Risks and failure behavior

- The `ResizeObserver` path is feature-detected. If it is unavailable, text-commit follow still works and no observer is retained.
- The observer disconnects when streaming ends or the component unmounts.
- Upward wheel/scroll intent pauses automatic following so the panel does not fight manual inspection; following resumes when the user returns to the bottom.
- The change is limited to rendering and has no persistence, network, security, or data-loss impact. Reverting commit `31f756c` removes the behavior.

<img width="775" height="374" alt="Screenshot 2026-09-07 at 10 48 35 am" src="https://github.com/user-attachments/assets/418dffc9-a2fd-49cf-9c63-612a883ab2af" />
