### PR TITLE
fix(desktop): keep non-ASCII desktop entries out of Open In matching

### DIFF
--- a/packages/electron/linux-app-discovery.mjs
+++ b/packages/electron/linux-app-discovery.mjs
@@ -145,7 +145,11 @@ export const readLinuxDesktopEntries = async (options = {}) => {
 const desktopEntryMatchesApp = (entry, appName, appId = '') => {
   const needles = uniqueStrings([appName, appId]).flatMap((value) => [normalizeComparable(value), normalizeCompactComparable(value)]).filter(Boolean);
   const haystacks = [entry.name, entry.id, path.basename(entry.filePath || ''), entry.exec]
-    .flatMap((value) => [normalizeComparable(value), normalizeCompactComparable(value)]);
+    .flatMap((value) => [normalizeComparable(value), normalizeCompactComparable(value)])
+    // A value with no ASCII letters or digits (e.g. a CJK-only Name) normalizes to the empty
+    // string, and needle.includes('') is true for every app — drop it so such entries can
+    // only match through a field that still carries comparable text.
+    .filter(Boolean);
   return needles.some((needle) => haystacks.some((haystack) => haystack === needle || haystack.includes(needle) || needle.includes(haystack)));
 };
 

--- a/packages/electron/linux-app-discovery.test.mjs
+++ b/packages/electron/linux-app-discovery.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildLinuxOpenSpecs,
+  filterLinuxInstalledApps,
+  parseDesktopEntry,
+} from './linux-app-discovery.mjs';
+
+const NON_ASCII_ONLY_ENTRY = `[Desktop Entry]
+Type=Application
+Name=抖音
+Exec=/usr/bin/example --app-url=https://www.douyin.com/
+Icon=example`;
+
+const TEST_ENV = { PATH: '/nonexistent-openchamber-test-bin' };
+
+const parseEntryAt = (content, id) => parseDesktopEntry(content, `/usr/share/applications/${id}.desktop`);
+
+test('still parses desktop entries whose Name has no ASCII letters or digits', () => {
+  const entry = parseEntryAt(NON_ASCII_ONLY_ENTRY, 'example');
+  assert.ok(entry);
+  assert.equal(entry.name, '抖音');
+  assert.equal(entry.exec, '/usr/bin/example --app-url=https://www.douyin.com/');
+});
+
+test('a non-ASCII-only desktop entry does not mark every app as installed', async () => {
+  const entry = parseEntryAt(NON_ASCII_ONLY_ENTRY, 'example');
+  const installed = await filterLinuxInstalledApps(
+    ['Visual Studio Code', 'Cursor', 'Sublime Text'],
+    { entries: [entry] },
+  );
+  assert.deepEqual(installed, []);
+});
+
+test('Open In specs never launch a non-ASCII-only entry for another app', () => {
+  const entry = parseEntryAt(NON_ASCII_ONLY_ENTRY, 'example');
+  const specs = buildLinuxOpenSpecs({
+    targetPath: '/tmp/project',
+    appId: 'vscode',
+    appName: 'Visual Studio Code',
+    entries: [entry],
+    env: TEST_ENV,
+  });
+  assert.deepEqual(specs, []);
+});
+
+test('ASCII desktop entries still match their own app and build their own launch spec', async () => {
+  const entry = parseEntryAt(`[Desktop Entry]
+Type=Application
+Name=Visual Studio Code
+Exec=/usr/bin/code %F
+Icon=code`, 'code');
+  const installed = await filterLinuxInstalledApps(
+    ['Visual Studio Code', 'Cursor'],
+    { entries: [entry] },
+  );
+  assert.deepEqual(installed, ['Visual Studio Code']);
+
+  const specs = buildLinuxOpenSpecs({
+    targetPath: '/tmp/project',
+    appId: 'vscode',
+    appName: 'Visual Studio Code',
+    entries: [entry],
+    env: TEST_ENV,
+  });
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].program, '/usr/bin/code');
+  assert.deepEqual(specs[0].args, ['/tmp/project']);
+});
+
+test('entries mixing ASCII and non-ASCII still match through their ASCII part', () => {
+  const entry = parseEntryAt(`[Desktop Entry]
+Type=Application
+Name=VSCode 抖音版
+Exec=/usr/local/bin/vscode-douyin %F
+Icon=vscode-douyin`, 'vscode-douyin');
+  const specs = buildLinuxOpenSpecs({
+    targetPath: '/tmp/project',
+    appId: 'vscode',
+    appName: 'Visual Studio Code',
+    entries: [entry],
+    env: TEST_ENV,
+  });
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].program, '/usr/local/bin/vscode-douyin');
+});

--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -240,6 +240,9 @@ const GITHUB_FEATURE_REQUEST_URL = 'https://github.com/openchamber/openchamber/i
 const DISCORD_INVITE_URL = 'https://discord.gg/ZYRSdnwwKA';
 const INSTALLED_APPS_CACHE_TTL_SECS = 60 * 60 * 24;
 const INSTALLED_APPS_CACHE_FILE = 'discovered-apps.json';
+// Bump when discovery results change shape or matching semantics change, so cached
+// entries written by an older build are treated as stale and refresh immediately.
+const INSTALLED_APPS_CACHE_VERSION = 2;
 const LINUX_DESKTOP_ENTRIES_CACHE_TTL_MS = 30_000;
 const OPENCODE_SHUTDOWN_GRACE_MS = 100;
 const { autoUpdater } = updaterPkg;
@@ -4386,11 +4389,13 @@ const handleInvoke = async (browserWindow, command, args = {}) => {
       }
       const cachedApps = Array.isArray(cache?.apps) ? cache.apps : [];
       const hasCache = Boolean(cache);
-      const isCacheStale = !cache || (now - Number(cache.updatedAt || 0)) > INSTALLED_APPS_CACHE_TTL_SECS;
+      const isCacheStale = !cache
+        || cache.version !== INSTALLED_APPS_CACHE_VERSION
+        || (now - Number(cache.updatedAt || 0)) > INSTALLED_APPS_CACHE_TTL_SECS;
       const refresh = async () => {
         const apps = await buildPlatformInstalledApps(Array.isArray(args.apps) ? args.apps : []);
         await fsp.mkdir(path.dirname(cachePath), { recursive: true });
-        await fsp.writeFile(cachePath, JSON.stringify({ updatedAt: now, apps }, null, 2));
+        await fsp.writeFile(cachePath, JSON.stringify({ version: INSTALLED_APPS_CACHE_VERSION, updatedAt: now, apps }, null, 2));
         emitToAllWindows('openchamber:installed-apps-updated', apps);
       };
       if (process.platform !== 'darwin' && process.platform !== 'win32' && process.platform !== 'linux') {


### PR DESCRIPTION
Fixes #3323

## Intent

On Linux, any visible `.desktop` entry whose comparable fields contain no ASCII letters or digits (for example a PWA installed as `Name=抖音`) made the **Open in** menu list every supported editor and terminal as installed, show that entry's icon on every row, and launch that entry's command instead of the selected editor.

`desktopEntryMatchesApp` in `packages/electron/linux-app-discovery.mjs` normalizes values by stripping everything outside `[a-z0-9]`. The `needles` array filters empty results; the `haystacks` array did not. A CJK-only `Name` therefore produced `""` haystacks, and the reverse substring check `needle.includes("")` is true for every requested app, so `findEntry` returned the unrelated entry — and `filterLinuxInstalledApps`, `buildLinuxInstalledApps` (icons), and `buildLinuxOpenSpecs` (launch commands) all followed it.

The change: normalized haystack values that end up empty are now dropped, exactly like needles. An entry with no comparable text in `name`, `id`, file name, and `exec` can no longer match anything; an entry with comparable text in any field matches as before.

The second part is the cache. `discovered-apps.json` is written once and trusted for 24 hours, so machines that already cached the poisoned list would keep the hijacked menu until the TTL expired after upgrading. The cache payload now carries a `version` field (`INSTALLED_APPS_CACHE_VERSION = 2`), and a cache whose version does not match is treated as stale: `desktop_get_installed_apps` takes the same refresh path as TTL expiry (`void refresh()` plus the `openchamber:installed-apps-updated` broadcast), so the corrected list lands on first use after upgrade.

Reproduced before the fix against the real module functions (script and output under Validation): every requested app counted as installed and `buildLinuxOpenSpecs` returned the unrelated entry's command; after the fix both return empty for that entry, while ASCII and mixed-script entries still match.

## Non-goals

- No change to matching semantics beyond the empty-string degeneration: substring and compact-substring matching, terminal fallbacks, CLI probing, and file-manager discovery are untouched.
- No new escaping or sanitizing of `Exec=` values — command construction from desktop entries is unchanged; only which entry may be selected changed.
- No migration or deletion of existing `discovered-apps.json` files; a version mismatch routes through the existing stale-cache refresh path.
- Windows and macOS app discovery are untouched.

## Affected surfaces

- `packages/electron` only: `linux-app-discovery.mjs` (one filter in `desktopEntryMatchesApp`), `main.mjs` (`INSTALLED_APPS_CACHE_VERSION`, the version check in `isCacheStale`, `version` in the written payload), and the new `linux-app-discovery.test.mjs`.
- Linux desktop runtime: the installed-apps list behind `desktop_get_installed_apps`, the **Open in** menu built from `buildLinuxOpenSpecs`, and icon resolution in `buildLinuxInstalledApps` (the wrong entry also supplied the wrong icon).
- Web, VS Code, and mobile runtimes are unaffected — this module is imported only by the Electron main process and its tests.
- Persisted data: `discovered-apps.json` gains a `version` field. Files written by older builds still parse and still serve their cached list while the immediate refresh runs, matching the existing stale-while-revalidate behavior. No other persisted format changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `desktop-shell` + `packages/electron/README.md` | Change inside the Electron package, including an IPC handler's cache | Native behavior stays in `packages/electron`; no preload/renderer surface change; no new IPC shape — the cache file is main-process-internal |
| `openchamber-change-discipline` | Executable source change | Smallest complete change: one filter, one version constant, one stale condition; local-implementation risk class, validated with focused tests plus package-scoped type-check and lint |
| Root `AGENTS.md` changelog rule | User-visible desktop fix | No changelog edit; release notes stay maintainer-only |
| `bunx oxlint` anti-slop check | New and edited JS | No findings in `linux-app-discovery.mjs` or the new test file; the reported `main.mjs` findings sit on untouched lines and pre-exist on `main` |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/electron test` (isolated runner, includes the new file) | 20/20 test files passed |
| `node --test ./linux-app-discovery.test.mjs` | 5/5 pass: parse keeps a CJK-only entry; both hijack paths (installed list, Open In specs) return empty for it; ASCII entry still matches and builds its own spec; mixed-script entry still matches through its ASCII part |
| `bun run --cwd packages/electron type-check` (`node --check main.mjs preload.mjs`) | pass |
| `bun run --cwd packages/electron lint` | pass |
| `bunx oxlint` on the three touched files | clean on both `linux-app-discovery` files; `main.mjs` findings are pre-existing on untouched lines |
| `bun run dead-code` | no new findings from this change (report items pre-exist in other packages) |
| Standalone before/after reproduction against the module at base commit `2dfd1190e` | before: 3/3 apps "installed", Open In spec = `/usr/bin/example`; after: `[]` and `[]` |

Reproduction script (imports the real module; same entry as the issue):

```js
import { parseDesktopEntry, filterLinuxInstalledApps, buildLinuxOpenSpecs } from './packages/electron/linux-app-discovery.mjs';
const entry = parseDesktopEntry(`[Desktop Entry]
Type=Application
Name=抖音
Exec=/usr/bin/example --app-url=https://www.douyin.com/
Icon=example`, '/usr/share/applications/example.desktop');
console.log(await filterLinuxInstalledApps(['Visual Studio Code', 'Cursor', 'Sublime Text'], { entries: [entry] }));
console.log(buildLinuxOpenSpecs({ targetPath: '/tmp/project', appId: 'vscode', appName: 'Visual Studio Code', entries: [entry], env: { PATH: '/nonexistent' } }));
```

Output on base `main` (bug): `["Visual Studio Code","Cursor","Sublime Text"]` and `[{program:"/usr/bin/example",args:["--app-url=https://www.douyin.com/","/tmp/project"]}]`. Output on this branch: `[]` and `[]`.

Not verified: a live desktop session driving the rendered **Open in** menu (this checkout has no display available) and the packaged-app upgrade path reading a version-1 cache file. The menu path is covered through the same exported functions the IPC handler calls, and the cache path reuses the existing TTL-expiry route, which that handler already exercises.

## Visual evidence

No rendered UI in this environment. The observable change for the reporter's scenario: currently every requested app appears installed with the unrelated entry's icon and launches its command; after the fix the menu lists only apps that resolve to their own desktop entry or CLI, each launching itself. Before-state screenshots are in the linked issue; the behavioral delta is pinned by the regression tests above.

## Risks and failure behavior

- Matching becomes strictly narrower: an entry all of whose comparable fields normalize to empty can no longer match any app. That degeneration is the bug; no legitimate entry could match except through `needle.includes("")`.
- An entry with a non-ASCII name but comparable ASCII in `id`, file name, or `exec` still matches through those fields, exactly as before (covered by the mixed-script test).
- Cache: on the first `desktop_get_installed_apps` after upgrade, a version-1 cache still answers from disk while the refresh is in flight — identical to today's TTL-expiry behavior — and the `openchamber:installed-apps-updated` event replaces the list. If the refresh fails, the next call retries; no new failure mode.
- Rollback is a single revert. A `version: 2` cache is ordinary JSON to an older build (the extra field is ignored), so a downgrade at worst re-poisons the list until that build's own TTL logic refreshes it.
- Security: this only narrows which desktop entries may be selected; `Exec=` tokenizing, quoting, and field-code expansion are unchanged. An attacker-controlled `.desktop` file remains a local-install trust boundary exactly as before — this change removes one way an unrelated non-ASCII entry could silently capture menu rows.
