### PR TITLE
fix(quota): raise Node's 250ms connect-attempt cap that breaks provider fetches

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -37,6 +37,7 @@ import { createRelayDevTunnelBridge } from './relay-dev-tunnel.mjs';
 import { attachRendererRecovery } from './renderer-recovery.mjs';
 import { mintOutsideFileGrant } from '@openchamber/web/server/lib/fs/routes.js';
 import { fetchUpdateNotes } from '@openchamber/web/server/lib/changelog/update-notes.js';
+import { applyConnectAttemptTimeout } from '@openchamber/web/server/lib/network-defaults.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -104,6 +105,11 @@ if (shouldIgnoreLoopbackConnectionLimit({
 })) {
   app.commandLine.appendSwitch('ignore-connections-limit', '127.0.0.1,localhost');
 }
+// This process runs quota/provider fetches under Node/undici, whose happy-eyeballs
+// default aborts each connect attempt after 250ms — distant provider endpoints
+// routinely need longer handshakes, surfacing as "fetch failed" (#3399). No-op on
+// runtimes without the setter.
+applyConnectAttemptTimeout();
 
 protocol.registerSchemesAsPrivileged([
   {

--- a/packages/web/bin/cli.js
+++ b/packages/web/bin/cli.js
@@ -72,6 +72,13 @@ import {
   printJson,
   logStatus,
 } from './cli-output.js';
+import { applyConnectAttemptTimeout } from '../server/lib/network-defaults.js';
+
+// The CLI process performs provider fetches (quota/usage, update notes) under
+// Node/undici, whose happy-eyeballs default aborts each connect attempt after
+// 250ms — distant provider endpoints routinely need longer handshakes, surfacing
+// as "fetch failed" (#3399). No-op on runtimes without the setter.
+applyConnectAttemptTimeout();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/web/server/lib/network-defaults.js
+++ b/packages/web/server/lib/network-defaults.js
@@ -1,0 +1,23 @@
+import net from 'node:net';
+
+// Node caps each happy-eyeballs connect attempt at 250ms by default
+// (autoSelectFamilyAttemptTimeout). TCP handshakes to provider endpoints that are
+// geographically distant routinely take 300-1500ms, so fetch() from a Node process
+// aborts every attempt (ETIMEDOUT) and surfaces "fetch failed" even though the host
+// is reachable — e.g. the z.ai quota endpoint from an IPv4-only egress (#3399).
+//
+// Every Node process entrypoint that performs provider fetches raises the
+// per-attempt cap. Family autoselection itself stays enabled, so the IPv6→IPv4
+// fallback and ::1/localhost servers keep working; disabling it instead breaks
+// local MCP servers. Runtimes without the setter (Bun's fetch path, older Node)
+// are a no-op.
+export const CONNECT_ATTEMPT_TIMEOUT_MS = 5_000;
+
+export const applyConnectAttemptTimeout = (netModule = net) => {
+  try {
+    netModule.setDefaultAutoSelectFamilyAttemptTimeout(CONNECT_ATTEMPT_TIMEOUT_MS);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/web/server/lib/network-defaults.test.js
+++ b/packages/web/server/lib/network-defaults.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import net from 'node:net';
+
+import { applyConnectAttemptTimeout, CONNECT_ATTEMPT_TIMEOUT_MS } from './network-defaults.js';
+
+describe('applyConnectAttemptTimeout', () => {
+  it('raises the per-attempt connect timeout on runtimes that expose the setter', () => {
+    const previous = net.getDefaultAutoSelectFamilyAttemptTimeout();
+    try {
+      expect(applyConnectAttemptTimeout()).toBe(true);
+      expect(net.getDefaultAutoSelectFamilyAttemptTimeout()).toBe(CONNECT_ATTEMPT_TIMEOUT_MS);
+    } finally {
+      net.setDefaultAutoSelectFamilyAttemptTimeout(previous);
+    }
+  });
+
+  it('is a no-op on runtimes without the setter', () => {
+    expect(applyConnectAttemptTimeout({})).toBe(false);
+  });
+
+  it('survives a throwing setter', () => {
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn(() => {
+      throw new Error('not supported');
+    });
+    expect(applyConnectAttemptTimeout({ setDefaultAutoSelectFamilyAttemptTimeout })).toBe(false);
+  });
+
+  it('leaves family autoselection itself untouched', () => {
+    const setDefaultAutoSelectFamily = vi.fn();
+    const setDefaultAutoSelectFamilyAttemptTimeout = vi.fn();
+    applyConnectAttemptTimeout({ setDefaultAutoSelectFamily, setDefaultAutoSelectFamilyAttemptTimeout });
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledTimes(1);
+    expect(setDefaultAutoSelectFamilyAttemptTimeout).toHaveBeenCalledWith(CONNECT_ATTEMPT_TIMEOUT_MS);
+    expect(setDefaultAutoSelectFamily).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #3399

## Intent

The usage panel shows **"fetch failed"** for the z.ai coding plan while chat with the same provider works, on hosts where `api.z.ai` resolves to unreachable AAAA records and the IPv4 TCP handshake takes more than 250ms. The reporter's diagnosis (confirmed `fix-ready` in triage): quota fetches run in the **Electron main process under Node/undici**, whose happy-eyeballs default `autoSelectFamilyAttemptTimeout = 250` aborts each connect attempt before a distant endpoint's handshake completes; every address is exhausted and the fetch surfaces as `TypeError: fetch failed`. Chat runs through the bundled Bun-based opencode CLI, which has no such cap — hence the confusing asymmetry.

Reporter's reproduction on the affected host (`fetch("https://api.z.ai/api/coding/v4/usage")` ×3): Node **3/3 fail** (`ETIMEDOUT@8.217.x` + `ENETUNREACH@240b:...`), Bun **3/3 OK** (HTTP 401), and Node **3/3 OK** with `--network-family-autoselection-attempt-timeout=5000` — a user-side `NODE_OPTIONS` workaround is not viable because Electron filters it in packaged apps.

The same quota module also runs in the `openchamber` CLI server process (`bin/cli.js`, `#!/usr/bin/env node`), which shares the Node default, so the fix is applied at both Node entrypoints that host it:

- New `packages/web/server/lib/network-defaults.js` — `applyConnectAttemptTimeout()` calls `net.setDefaultAutoSelectFamilyAttemptTimeout(5000)`, feature-safe (try/catch, no-op where the setter does not exist) and **does not** touch `setDefaultAutoSelectFamily`, which the issue explicitly warns against (disabling family autoselection breaks `::1`/localhost MCP servers).
- `packages/electron/main.mjs` — called once next to the existing process-wide network defaults (`proxy-bypass-list`, connection-limit policy).
- `packages/web/bin/cli.js` — called once at process start, covering `openchamber serve` and every other CLI command that performs provider fetches.

## Non-goals

- No change to per-fetch behavior: timeouts, headers, retries, and the quota adapters themselves are untouched; only the per-attempt connect cap of the process changes.
- Not routing quota fetches through the bundled Bun opencode process (the issue lists it as an alternative; the process default is the smaller change).
- Not adding HTTP_PROXY support — that is a different failure mode tracked separately (#3328, #3105).
- The VS Code extension's own quota stack (`packages/vscode/src/quotaProviders.ts`, a separate fetch path that does not import this server module) is untouched; no report ties it to this symptom.
- Bun-run web deployments are untouched — Bun has no 250ms cap and the helper is a no-op there.

## Affected surfaces

- `packages/web`: new `server/lib/network-defaults.js` (+ vitest), one call at the top of `bin/cli.js`.
- `packages/electron`: one import and one call in `main.mjs` early init, next to the existing Chromium network switches.
- Every provider quota adapter served from a Node process benefits (zai, codex, xai, …) — they all use the global `fetch()` in-process. Plausibly the same mechanism behind #2640 (Codex `fetch failed` on Windows), which this also addresses when its handshake exceeds 250ms.
- Desktop (Electron in-process server) and CLI/web (`openchamber serve` under Node) are the two affected runtimes. Bun-run servers, VS Code, mobile, and relay transports are unaffected.
- No persisted data, routes, API contracts, or exports consumed elsewhere change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Executable source + process-wide runtime behavior | Smallest complete change: one shared helper + one call per Node entrypoint that hosts the quota module; classified as platform/runtime behavior risk, validated with focused tests plus package-scoped type-check/lint and both full package suites |
| `desktop-shell` + `packages/electron/README.md` | Electron main init change | One call next to the existing network defaults; no preload/IPC surface; domain stays in the web-server module that owns the fetches |
| Root `AGENTS.md` validation rules | Server JS and CLI JS are not covered by TS lint | Focused vitest for the new module, `node --check` for both entry files, full web + electron suites |

## Validation

| Check | Result |
|---|---|
| `bunx vitest run server/lib/network-defaults.test.js` (packages/web) | 4/4 pass: real `node:net` value flips 250→5000 and restores; no-op on `{}`; survives throwing setter; never calls `setDefaultAutoSelectFamily` |
| `bun run --cwd packages/web test` (isolated runner) | 1989 passed, 2 skipped |
| `bun run --cwd packages/electron test` (includes main.mjs change) | 19/19 test files passed |
| `bun run --cwd packages/web type-check` (`tsc --noEmit`) | pass |
| `bun run --cwd packages/electron type-check` (`node --check main.mjs preload.mjs`) + `node --check` on `cli.js` and `network-defaults.js` | pass |
| `bun run --cwd packages/web lint` | pass |
| `bunx oxlint` on the four touched files | no findings on the new files or `cli.js`; `main.mjs` findings pre-exist on untouched lines |
| `bun run dead-code` | no new findings (same pre-existing report as base) |
| Author host corroboration (below) | Node default measured `getDefaultAutoSelectFamilyAttemptTimeout() === 250`; `api.z.ai` resolves AAAA `240b:4001:…` with no global IPv6 route on this host either |

Author-host network profile (second data point for the DNS premise, gathered before the fix):

```
$ node -p "require('node:net').getDefaultAutoSelectFamilyAttemptTimeout()"
250
$ getent ahosts api.z.ai | sort -u
240b:4001:139:8a02:… / 240b:4001:139:8a07:… (AAAA) + 8.217.100.151 (A)
$ curl -6 https://api.z.ai/ → instant failure (no global IPv6 route)
```

Not verified by hand: a live before-fail on this author's own egress — its TCP connect to `api.z.ai` is intercepted by a local TUN proxy and completes in <1ms, so the 250ms cap never bites here. The operative before/after evidence is the reporter's 3/3 table (Node fail → Node+5000ms OK), which the reporter measured on an unproxied host; the unit test proves the applied value on real `node:net`, and the fix matches the triage-confirmed suggestion verbatim in mechanism.

## Visual evidence

No rendered UI changes. The user-visible delta for the reporter's scenario: the usage panel for z.ai coding plan changes from `fetch failed` to rendered quota numbers on hosts with slow handshakes; no layout, text, or theme change. The reporter's environment is the only place the failing state is reproducible; this author's host cannot show the before state for the egress reason documented above.

## Risks and failure behavior

- The default is process-wide in the two entrypoints: every outbound `fetch` there now allows up to 5s per address family attempt before falling back, instead of 250ms. Happy-eyeballs interleaving is unchanged, so reachable hosts are unaffected; the worst case is that a genuinely dead host's connect failure surfaces seconds later than before. No fetch becomes less patient, and no overall request timeout is removed — adapters keep their existing abort/timeout behavior.
- On runtimes without `setDefaultAutoSelectFamilyAttemptTimeout`, the helper returns `false` and behavior is exactly as today (try/catch feature safety, tested).
- `setDefaultAutoSelectFamily` is never called, so IPv6→IPv4 fallback and `::1`/localhost MCP servers keep working — the regression the issue warns about is structurally excluded (asserted by test).
- Rollback is a single revert of the helper and the two call sites; no persisted state or external contract is involved.
