### PR TITLE
feat: add search to the new session project picker

### DIFF
--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -189,7 +189,14 @@ and the send path reading the same grammar.
   also owns the advisory dirty state for the selected directory, clearing it as
   soon as the target changes so a warning never names a previous branch.
 - `ui/DraftTargetSelectors.tsx` owns the controlled project/worktree picker
-  state and registers its application shortcuts locally. The selectors only
+  state and registers its application shortcuts locally. The desktop project
+  picker is a searchable popup: it ranks the current projects with
+  `rankByQuery` over display label and path, keeps the query and the active
+  result as transient local state that resets on every close, and commits
+  through the existing project-change flow only on explicit activation.
+  Filtering changes the result area below the anchored input without moving
+  the search field. The
+  worktree Select and the mobile bottom sheets are unchanged. The selectors only
   consume their shared prefix while the draft target UI is mounted.
 
 ## Input recall ownership

--- a/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
+++ b/packages/ui/src/components/chat/composer/ui/DraftTargetSelectors.tsx
@@ -1,10 +1,11 @@
 /**
  * Where a new session will run: the project and the directory within it.
  *
- * Desktop uses inline selects; mobile uses bottom sheets, because a native
- * select over a keyboard-resized viewport is unusable. Both render the same
- * options from the same hook, and both offer creating a worktree inline so the
- * user does not have to leave the draft to make one.
+ * Desktop uses a searchable project popup and an inline branch/worktree
+ * select; mobile uses bottom sheets, because a native select over a
+ * keyboard-resized viewport is unusable. Both render the same options from
+ * the same hook, and both offer creating a worktree inline so the user does
+ * not have to leave the draft to make one.
  */
 
 import React from 'react';
@@ -12,8 +13,19 @@ import React from 'react';
 import { Icon } from '@/components/icon/Icon';
 import { Input } from '@/components/ui/input';
 import { MobileOverlayPanel } from '@/components/ui/MobileOverlayPanel';
+import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { shouldDismissDropdown } from '@/components/ui/dropdown-navigation';
+import { Popover } from '@base-ui/react/popover';
+import { cn } from '@/lib/utils';
+import { dropdownMenuPopupClass } from '@/components/ui/dropdown-menu.styles';
+import {
+    Command,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command';
+import { handleDropdownNavigationKey, shouldDismissDropdown } from '@/components/ui/dropdown-navigation';
+import { isIMECompositionEvent } from '@/lib/ime';
 import {
     Select,
     SelectContent,
@@ -28,6 +40,7 @@ import { useI18n } from '@/lib/i18n';
 import { matchesRankQuery, rankByQuery } from '@/lib/search/fuzzySearch';
 import { PROJECT_COLOR_MAP, PROJECT_ICON_MAP, ProjectIconImage } from '@/lib/projectMeta';
 import { createWorktreeDraft } from '@/lib/worktreeSessionCreator';
+import { shortcutRegistry } from '@/lib/shortcuts';
 import { useKeybind } from '@/hooks/useKeybind';
 import type { Theme } from '@/types/theme';
 import { normalizePath } from '../attachments/filePaths';
@@ -136,8 +149,34 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
         theme,
     } = props;
     const [openPicker, setOpenPicker] = React.useState<'project' | 'worktree' | null>(null);
+    const [projectQuery, setProjectQuery] = React.useState('');
+    const [projectActiveId, setProjectActiveId] = React.useState<string | null>(null);
+    const [projectFocusReturn, setProjectFocusReturn] = React.useState(false);
     const projectTriggerRef = React.useRef<HTMLButtonElement>(null);
     const worktreeTriggerRef = React.useRef<HTMLButtonElement>(null);
+    const projectSearchRef = React.useRef<HTMLInputElement>(null);
+    // Preserve Select's dialog portal and main-area containment.
+    const [projectPortalContainer, setProjectPortalContainer] = React.useState<HTMLElement | null>(null);
+    const [projectCollisionBoundary, setProjectCollisionBoundary] = React.useState<Element | null>(null);
+    const syncProjectPopupContainers = React.useCallback((target: EventTarget | null) => {
+        const element = target instanceof HTMLElement ? target : null;
+        const dialog = element?.closest('[data-slot="dialog-content"], [role="dialog"]');
+        setProjectPortalContainer(dialog instanceof HTMLElement ? dialog : null);
+        setProjectCollisionBoundary(element?.closest('main') ?? null);
+    }, []);
+    // The popover owns no shortcut suspension (unlike Select/DropdownMenu
+    // wrappers), so suspend global shortcuts while the project popup is
+    // open and restore them on close/unmount.
+    const projectSuspendRef = React.useRef<(() => void) | null>(null);
+    React.useEffect(() => {
+        if (openPicker !== 'project') return;
+        projectSuspendRef.current?.();
+        projectSuspendRef.current = shortcutRegistry.suspend();
+        return () => {
+            projectSuspendRef.current?.();
+            projectSuspendRef.current = null;
+        };
+    }, [openPicker]);
     const handlePickerKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
         if (openPicker === null || !shouldDismissDropdown(event)) return;
         event.preventDefault();
@@ -147,6 +186,11 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
 
     useKeybind('open_draft_project_picker', () => {
         projectTriggerRef.current?.focus();
+        setProjectFocusReturn(false);
+        setProjectQuery('');
+        setProjectActiveId(
+            projects.some((project) => project.id === selectedProject.id) ? selectedProject.id : null,
+        );
         setOpenPicker('project');
     });
     useKeybind('open_draft_worktree_picker', () => {
@@ -155,9 +199,41 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
         setOpenPicker('worktree');
     });
 
+    const filteredProjects = React.useMemo(
+        () => openPicker === 'project'
+            ? rankByQuery(projects, projectQuery, (project) => [getProjectDisplayLabel(project), project.path])
+            : projects,
+        [openPicker, projects, projectQuery],
+    );
+
+    // Transient search must never survive to the next opening, including
+    // picker switches and draft unmounts.
+    React.useEffect(() => {
+        if (openPicker !== 'project') {
+            setProjectQuery('');
+            setProjectActiveId(null);
+        }
+    }, [openPicker]);
+    // After a query or project-list change, retain the active ID only
+    // while it stays visible; otherwise fall to the first result (or none
+    // when the list is empty) so Enter cannot commit a hidden row.
+    React.useEffect(() => {
+        if (openPicker !== 'project') return;
+        setProjectActiveId((current) => {
+            if (current && filteredProjects.some((project) => project.id === current)) return current;
+            return filteredProjects[0]?.id ?? null;
+        });
+    }, [filteredProjects, openPicker]);
+
     const handleProjectChange = (projectId: string) => {
         onProjectChange(projectId);
+        setProjectFocusReturn(true);
         setOpenPicker(null);
+    };
+
+    const handleProjectSelect = (projectId: string) => {
+        if (!filteredProjects.some((project) => project.id === projectId)) return;
+        handleProjectChange(projectId);
     };
 
     const handleDirectoryChange = (directory: string) => {
@@ -167,33 +243,152 @@ export function DraftTargetSelectors(props: DraftTargetProps) {
 
     return (
         <div className="mb-1.5 flex min-w-0 items-center gap-1.5 px-0.5">
-            <Select
-                value={selectedProject.id}
+            {/* Plain popover (not a menu): the popup owns a combobox +
+                listbox, so menu/menuitem semantics would be wrong here. */}
+            <Popover.Root
                 open={openPicker === 'project'}
-                onOpenChange={(open) => setOpenPicker(open ? 'project' : null)}
-                onValueChange={handleProjectChange}
-                disableGlobalShortcuts
+                onOpenChange={(open, eventDetails) => {
+                    if (open) {
+                        setProjectFocusReturn(false);
+                        // Seed the active row from the committed project so
+                        // Enter without typing repeats the current choice.
+                        // The clamp below keeps it when still visible and
+                        // falls to the first result otherwise.
+                        setProjectQuery('');
+                        setProjectActiveId(
+                            projects.some((project) => project.id === selectedProject.id)
+                                ? selectedProject.id
+                                : null,
+                        );
+                        setOpenPicker('project');
+                        return;
+                    }
+                    setProjectQuery('');
+                    setProjectActiveId(null);
+                    const reason = eventDetails?.reason;
+                    setProjectFocusReturn(reason === 'escape-key');
+                    setOpenPicker(null);
+                }}
+                onOpenChangeComplete={(open) => {
+                    // Return focus after Base UI finishes closing so the
+                    // trigger itself, not document body, keeps keyboard flow.
+                    if (!open && projectFocusReturn) {
+                        projectTriggerRef.current?.focus();
+                        setProjectFocusReturn(false);
+                    }
+                    // Focus the search once the popup mounts; the opening
+                    // shortcut focuses the trigger first.
+                    if (open && openPicker === 'project') projectSearchRef.current?.focus();
+                }}
             >
-                <SelectTrigger
-                    ref={projectTriggerRef}
-                    onKeyDown={handlePickerKeyDown}
-                    size="sm"
-                    className="h-7 min-w-0 w-fit max-w-[42vw] sm:max-w-[18rem] border-transparent bg-transparent px-1.5 hover:bg-transparent data-[popup-open]:bg-transparent"
+                <Popover.Trigger
+                    render={
+                        <Button
+                            ref={projectTriggerRef}
+                            variant="ghost"
+                            size="sm"
+                            aria-haspopup="dialog"
+                            className="h-7 min-w-0 w-fit max-w-[42vw] justify-start gap-1 px-1.5 normal-case sm:max-w-[18rem]"
+                            onPointerDownCapture={(event) => syncProjectPopupContainers(event.currentTarget)}
+                            onFocusCapture={(event) => syncProjectPopupContainers(event.currentTarget)}
+                        />
+                    }
                 >
-                    <SelectValue>
+                    <span className="flex min-w-0 items-center gap-1.5">
                         {selectedProject.kind === 'chat'
                             ? <span className="truncate">{t('chat.chatInput.chooseProject')}</span>
                             : <ProjectLabel project={selectedProject} theme={theme} />}
-                    </SelectValue>
-                </SelectTrigger>
-                <SelectContent side="top" collisionAvoidance={{ side: 'none' }} constrainToMain fitContent onKeyDown={handlePickerKeyDown}>
-                    {projects.map((project) => (
-                        <SelectItem key={project.id} value={project.id} showSelectedBackground={false} className="max-w-[24rem] truncate">
-                            <ProjectLabel project={project} theme={theme} />
-                        </SelectItem>
-                    ))}
-                </SelectContent>
-            </Select>
+                        <Icon name="arrow-down-s" className="size-4 shrink-0 opacity-50" />
+                    </span>
+                </Popover.Trigger>
+                <Popover.Portal container={projectPortalContainer ?? undefined}>
+                    {/* side="bottom" anchors the popup's top edge at the
+                        trigger: the search field stays fixed at the
+                        selector's level while filtering, and only the
+                        results area below changes height. Disabling side
+                        flips keeps the input stationary during filtering.
+                        Horizontal shifting keeps the popup inside main. The
+                        --available-height cap comes free from the shared
+                        popup class, so the list scrolls within the space
+                        below the trigger. */}
+                    <Popover.Positioner
+                        side="bottom"
+                        align="start"
+                        sideOffset={4}
+                        collisionAvoidance={{ side: 'none' }}
+                        collisionBoundary={projectCollisionBoundary ?? undefined}
+                        className="app-region-no-drag z-50"
+                    >
+                        <Popover.Popup
+                            role="dialog"
+                            aria-label={t('chat.chatInput.draftPicker.projectTitle')}
+                            className={cn(dropdownMenuPopupClass, 'flex w-72 max-w-[calc(100vw-2rem)] flex-col p-0')}
+                            initialFocus={false}
+                            finalFocus={false}
+                        >
+                            {/* Filtering and ordering are owned by rankByQuery above;
+                                cmdk's own filter would re-filter and reorder the
+                                already-ranked rows. */}
+                            <Command
+                                className="min-h-0 flex-1"
+                                shouldFilter={false}
+                                value={projectActiveId ?? undefined}
+                                onValueChange={setProjectActiveId}
+                            >
+                                <CommandInput
+                                    ref={projectSearchRef}
+                                    aria-label={t('chat.chatInput.draftPicker.searchProjects')}
+                                    placeholder={t('chat.chatInput.draftPicker.searchProjects')}
+                                    value={projectQuery}
+                                    onValueChange={setProjectQuery}
+                                    onKeyDown={(event) => {
+                                        // Command owns active-item navigation, so only
+                                        // translate the repository's Ctrl+N/P
+                                        // convention into arrows at the input.
+                                        // IME-composing keys must never move the
+                                        // active row or dismiss the popup.
+                                        if (isIMECompositionEvent(event)) {
+                                            event.stopPropagation();
+                                            return;
+                                        }
+                                        handleDropdownNavigationKey(event, (navigationKey) => {
+                                            event.currentTarget.dispatchEvent(new KeyboardEvent('keydown', {
+                                                key: navigationKey,
+                                                bubbles: true,
+                                                cancelable: true,
+                                            }));
+                                        });
+                                    }}
+                                />
+                                <CommandList label={t('chat.chatInput.draftPicker.projectTitle')}>
+                                    {filteredProjects.length === 0 ? (
+                                        <div role="status" className="px-3 py-6 text-center typography-ui-label text-muted-foreground">
+                                            {t('chat.chatInput.draftPicker.noProjectsFound')}
+                                        </div>
+                                    ) : (
+                                        filteredProjects.map((project) => (
+                                            <CommandItem
+                                                key={project.id}
+                                                value={project.id}
+                                                onSelect={handleProjectSelect}
+                                                aria-current={project.id === selectedProject.id ? true : undefined}
+                                                className="max-w-full"
+                                            >
+                                                <span className="min-w-0 flex-1 truncate">
+                                                    <ProjectLabel project={project} theme={theme} />
+                                                </span>
+                                                {project.id === selectedProject.id ? (
+                                                    <Icon name="check" className="size-4 shrink-0 text-muted-foreground" />
+                                                ) : null}
+                                            </CommandItem>
+                                        ))
+                                    )}
+                                </CommandList>
+                            </Command>
+                        </Popover.Popup>
+                    </Popover.Positioner>
+                </Popover.Portal>
+            </Popover.Root>
 
             {showBranchSelector ? (
                 <Select

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -2178,6 +2178,7 @@ export const dict = {
   'chat.chatInput.draftPicker.projectTitle': 'Projekt',
   'chat.chatInput.draftPicker.searchProjects': 'Projekte durchsuchen...',
   'chat.chatInput.draftPicker.searchBranches': 'Branches durchsuchen...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'Keine Projekte gefunden.',
   'chat.chatInput.worktrees': 'Worktrees',
   'chat.chatInput.worktreeNew': '+ Neu',
   'chat.chatInput.drop.insertMention': 'Hier ablegen, um als Erwähnung einzufügen',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2396,6 +2396,7 @@ export const dict = {
   'chat.chatInput.draftPicker.projectTitle': 'Project',
   'chat.chatInput.draftPicker.searchProjects': 'Search projects...',
   'chat.chatInput.draftPicker.searchBranches': 'Search branches...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'No projects found',
   'chat.chatInput.worktrees': 'Worktrees',
   'chat.chatInput.worktreeNew': '+ New',
   'chat.chatInput.drop.insertMention': 'Drop to insert as mention',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -2396,7 +2396,7 @@ export const dict = {
   'chat.chatInput.draftPicker.projectTitle': 'Project',
   'chat.chatInput.draftPicker.searchProjects': 'Search projects...',
   'chat.chatInput.draftPicker.searchBranches': 'Search branches...',
-  'chat.chatInput.draftPicker.noProjectsFound': 'No projects found',
+  'chat.chatInput.draftPicker.noProjectsFound': 'No projects found.',
   'chat.chatInput.worktrees': 'Worktrees',
   'chat.chatInput.worktreeNew': '+ New',
   'chat.chatInput.drop.insertMention': 'Drop to insert as mention',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -2362,6 +2362,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.chatInput.draftPicker.projectTitle": "Proyecto",
   "chat.chatInput.draftPicker.searchProjects": "Buscar proyectos...",
   "chat.chatInput.draftPicker.searchBranches": "Buscar ramas...",
+  "chat.chatInput.draftPicker.noProjectsFound": "No se encontraron proyectos.",
   "chat.chatInput.worktrees": "Worktrees",
   "chat.chatInput.worktreeNew": "+ Nuevo",
   "chat.chatInput.drop.insertMention": "Suelta para insertar como mención",

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -2107,6 +2107,7 @@ export const dict = {
   'chat.chatInput.draftPicker.projectTitle': 'Projet',
   'chat.chatInput.draftPicker.searchProjects': 'Rechercher des projets...',
   'chat.chatInput.draftPicker.searchBranches': 'Rechercher des branches...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'Aucun projet trouvé.',
   'chat.chatInput.worktrees': 'Worktrees',
   'chat.chatInput.worktreeNew': '+ Nouveau',
   'chat.chatInput.drop.insertMention': 'Déposer pour insérer comme mention',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -2395,6 +2395,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.draftPicker.projectTitle': 'プロジェクト',
   'chat.chatInput.draftPicker.searchProjects': 'プロジェクトを検索...',
   'chat.chatInput.draftPicker.searchBranches': 'ブランチを検索...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'プロジェクトが見つかりません。',
   'chat.chatInput.worktrees': 'ワークツリー',
   'chat.chatInput.worktreeNew': '+ 新規',
   'chat.chatInput.drop.insertMention': 'ドロップしてメンションとして挿入',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -2396,6 +2396,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.draftPicker.projectTitle': '프로젝트',
   'chat.chatInput.draftPicker.searchProjects': '프로젝트 검색...',
   'chat.chatInput.draftPicker.searchBranches': '브랜치 검색...',
+  'chat.chatInput.draftPicker.noProjectsFound': '프로젝트를 찾을 수 없습니다.',
   'chat.chatInput.worktrees': '워크트리',
   'chat.chatInput.worktreeNew': '+ 새로 만들기',
   'chat.chatInput.drop.insertMention': '여기에 놓아 멘션으로 추가',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -1262,6 +1262,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.draftPicker.projectTitle': 'Projekt',
   'chat.chatInput.draftPicker.searchProjects': 'Szukaj projektów...',
   'chat.chatInput.draftPicker.searchBranches': 'Szukaj gałęzi...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'Nie znaleziono projektów.',
   'chat.chatInput.drop.attachFiles': 'Drop files here to attach',
   'chat.chatInput.drop.insertMention': 'Drop to insert as mention',
   'chat.chatInput.fileFallback': 'file',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -2362,6 +2362,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.chatInput.draftPicker.projectTitle": "Projeto",
   "chat.chatInput.draftPicker.searchProjects": "Buscar projetos...",
   "chat.chatInput.draftPicker.searchBranches": "Buscar branches...",
+  "chat.chatInput.draftPicker.noProjectsFound": "Nenhum projeto encontrado.",
   "chat.chatInput.worktrees": "Worktrees",
   "chat.chatInput.worktreeNew": "+ Novo",
   "chat.chatInput.drop.insertMention": "Solte para inserir como menção",

--- a/packages/ui/src/lib/i18n/messages/tr.ts
+++ b/packages/ui/src/lib/i18n/messages/tr.ts
@@ -2336,6 +2336,7 @@ export const dict = {
   'chat.chatInput.draftPicker.projectTitle': 'Proje',
   'chat.chatInput.draftPicker.searchProjects': 'Projelerde ara...',
   'chat.chatInput.draftPicker.searchBranches': 'Branch\'lerde ara...',
+  'chat.chatInput.draftPicker.noProjectsFound': 'Proje bulunamadı.',
   'chat.chatInput.worktrees': 'Worktree\'ler',
   'chat.chatInput.worktreeNew': '+ Yeni',
   'chat.chatInput.drop.insertMention': 'Mention olarak eklemek için bırak',

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -2362,6 +2362,7 @@ export const dict: Record<I18nKey, string> = {
   "chat.chatInput.draftPicker.projectTitle": "Проєкт",
   "chat.chatInput.draftPicker.searchProjects": "Пошук проєктів...",
   "chat.chatInput.draftPicker.searchBranches": "Пошук гілок...",
+  "chat.chatInput.draftPicker.noProjectsFound": "Проєктів не знайдено.",
   "chat.chatInput.worktrees": "Worktree",
   "chat.chatInput.worktreeNew": "+ Новий",
   "chat.chatInput.drop.insertMention": "Відпустіть, щоб вставити як згадку",

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -2362,6 +2362,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.draftPicker.projectTitle': '项目',
   'chat.chatInput.draftPicker.searchProjects': '搜索项目...',
   'chat.chatInput.draftPicker.searchBranches': '搜索分支...',
+  'chat.chatInput.draftPicker.noProjectsFound': '未找到项目。',
   'chat.chatInput.worktrees': '工作树',
   'chat.chatInput.worktreeNew': '+ 新建',
   'chat.chatInput.drop.insertMention': '释放以插入为提及',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -2366,6 +2366,7 @@ export const dict: Record<I18nKey, string> = {
   'chat.chatInput.draftPicker.projectTitle': '專案',
   'chat.chatInput.draftPicker.searchProjects': '搜尋專案...',
   'chat.chatInput.draftPicker.searchBranches': '搜尋分支...',
+  'chat.chatInput.draftPicker.noProjectsFound': '找不到專案。',
   'chat.chatInput.worktrees': 'Worktree',
   'chat.chatInput.worktreeNew': '+ 新增',
   'chat.chatInput.drop.insertMention': '放開以插入為提及',


### PR DESCRIPTION
## Intent

Add name/path search to the New session project picker so a long project list can be filtered while typing. The popup opens below and left-aligned with its trigger; filtering keeps the input stationary. Fixes #3406.

## Non-goals

Branch/worktree selection, mobile bottom sheets and command-palette search keep their existing behavior. The VS Code visibility gate stays unchanged.

## Affected surfaces

Shared `packages/ui` desktop composer used by web and Electron, plus the empty-result string in all 12 locale dictionaries. Search, active-row navigation, selection, cancellation and empty states change. No API, persisted-data or dependency changes.

## Repository guidance

| Guidance | Application |
|---|---|
| `AGENTS.md`, `CONTRIBUTING.md`, `openchamber-change-discipline` | Local selector change; no shared control, dependency or changelog edits. |
| `theme-system`, tokens reference | Shared Button/Command and semantic tokens; bounded scroller with main/dialog containment. |
| `locale-ui-patterns`, `communication-style` | Translated empty state and accessible project labels. |
| `performance-engineering`, `scripts/perf/DOCUMENTATION.md` | Reuse `rankByQuery`, rank only while open, measure the real component with synthetic lists. |
| Composer `DOCUMENTATION.md` | Query and active ID stay local; document ownership and commit through the existing project-change callback. |

## Validation

Full validation was run on `d9e74fd2f`. Current HEAD `7a93f4736` changes only the English empty-state punctuation; locale tests and focused ESLint passed again.

| Check | Result |
|---|---|
| `bun run type-check`, `bun run lint`, `bun run build` | Passed across workspaces. Lint retains one existing `MobileChangesSurface.tsx` warning. |
| `bun run test` | Root 3/3, UI 402/402, VS Code 35/35 and Electron 19/19 test files passed. Web: 181/182 files, 1985 passed, 1 skipped, 1 failure. |
| Baseline check for the web failure | The unchanged parent revision reproduces `env-runtime.test.js`'s login-shell-probe failure: this Mac has `/opt/homebrew/bin/opencode`, while the test expects null. This PR does not change that module. |
| Focused search/i18n tests and selector oxlint | Passed. |
| Local production application | Name/path/typo search, Space, arrows, Ctrl+N/P, Enter, empty Enter, Escape/focus return, query reset, draft/attachment preservation and popup containment passed. Final alignment: trigger and popup both x=462; input position unchanged through full/filtered/empty states. |
| Real-component fixture | Duplicate labels with distinct IDs, active-row removal, Chat-only and synthetic composing-key checks passed. Last row reachable with 1000 projects at 900x500 and 700x600. |

Native screen-reader/IME input and packaged Electron/VS Code execution were not tested. Fixture visuals do not claim server integration.

## Visual evidence

Production fixture at `d9e74fd2f` using synthetic projects, with the actual selector and theme tokens. The follow-up adds only the trailing period in "No projects found."; the captures still represent layout, filtering and keyboard behavior, but show the earlier punctuation. [Interaction recording](https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/search.webm) shows filtering, no matches, clearing, keyboard selection and dismissal. [Evidence details and measurements](https://github.com/maximtop/openchamber/tree/27f4ae29fab8a486c7b0902b2207c9386b2662a4).

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/before.png" width="360" alt="Original unfiltered project picker"> | <img src="https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/after-light.png" width="360" alt="Search below the left-aligned trigger"> |

[Dark theme](https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/after-dark.png) · [Narrow window](https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/after-narrow.png) · [Empty result](https://raw.githubusercontent.com/maximtop/openchamber/27f4ae29fab8a486c7b0902b2207c9386b2662a4/empty.png)

## Risks and failure behavior

Enter commits only a visible project ID. Removing the active project falls back to a visible row; an empty result cannot change the project. Closing clears transient search state and releases shortcut suspension. No persistence migration or network operation is introduced; rollback is a code revert.

All rows still render when opened. At 1000 synthetic projects, median opening acknowledgement increased from 44.4 to 69.0 ms; search/empty/clear p95 were 30.0/35.5/47.8 ms. These are DOM acknowledgement measurements, not compositor latency. The final alignment-only prop does not change the measured ranking/rendering path.


## Review follow-up

Added the trailing period requested in the review. Inspected installed `@base-ui/react` 1.4.0: Popover uses `useDismiss`, whose document keydown listener uses bubble phase and whose own composition tracking ignores Escape while composition is active, including a WebKit compositionend delay. Together with the existing input guard, the reported IME concern does not identify a confirmed defect. Native IME testing remains unperformed. No event-handling change was made.
