### PR TITLE
fix(quota): read OpenRouter usage from /api/v1/key

### DIFF
--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -17,6 +17,7 @@ const AUTH = JSON.stringify({
   crof: { key: 'test-token' },
   neuralwatt: { key: 'test-token' },
   'opencode-go': { key: 'test-token' },
+  openrouter: { key: 'test-token' },
   'zai-coding-plan': { key: 'test-token' },
   deepseek: { key: 'test-token' },
   hyper: { key: 'test-token' },
@@ -111,6 +112,180 @@ describe('OpenCode Go quota provider (VS Code parity)', () => {
     assert.equal(result.usage!.windows['5h']!.usedPercent, 25);
     assert.throws(() => fs.statSync(legacyPath));
   });
+});
+
+describe('OpenRouter quota provider (VS Code parity)', () => {
+  const documentedPayload = {
+    data: {
+      label: 'test-key',
+      usage: 3.17561396,
+      usage_daily: 0.0000018,
+      usage_weekly: 0.0000018,
+      usage_monthly: 3.17561396,
+      limit: 30,
+      limit_remaining: 29.9999982,
+      limit_reset: 'daily',
+      is_free_tier: true,
+      is_management_key: false,
+      include_byok_in_limit: false,
+      byok_usage: 0,
+    },
+  };
+
+  test('reads the documented key endpoint and emits the current reset window', async () => {
+    let requestedUrl = '';
+    let requestInit: RequestInit | undefined;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      requestedUrl = url;
+      requestInit = init;
+      return mockResponse(documentedPayload);
+    }) as typeof fetch;
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(requestedUrl, 'https://openrouter.ai/api/v1/key');
+    assert.equal(requestedUrl.includes('/api/v1/credits'), false);
+    assert.equal(new Headers(requestInit?.headers).get('Authorization'), 'Bearer test-token');
+    assert.equal(new Headers(requestInit?.headers).get('Accept-Encoding'), 'identity');
+    assert.ok(requestInit?.signal instanceof AbortSignal);
+    assert.deepEqual(Object.keys(result.usage!.windows), ['daily']);
+    assert.equal(result.usage!.windows.daily!.windowSeconds, 86400);
+    assert.equal(result.usage!.windows.daily!.valueLabel, '$0.00 / $30.00');
+    assert.ok(typeof result.usage!.windows.daily!.resetAt === 'number');
+  });
+
+  test('maps an unlimited null-limit key to a monthly spent window', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      data: { limit: null, limit_remaining: null, limit_reset: null, usage_monthly: 12.5, is_management_key: false },
+    })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(Object.keys(result.usage!.windows), ['monthly']);
+    assert.equal(result.usage!.windows.monthly!.usedPercent, null);
+    assert.equal(result.usage!.windows.monthly!.windowSeconds, 30 * 86400);
+    assert.equal(result.usage!.windows.monthly!.valueLabel, '$12.50 spent');
+    assert.ok(typeof result.usage!.windows.monthly!.resetAt === 'number');
+  });
+
+  test('maps a lifetime cap to a credits window without reset metadata', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: null, usage_monthly: 5 },
+    })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+    const window = result.usage!.windows.credits;
+
+    assert.ok(window);
+    assert.equal(window!.windowSeconds, null);
+    assert.equal(window!.resetAt, null);
+  });
+
+  test('maps an unrecognized reset period to a credits window', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: 'yearly', usage_monthly: 5 },
+    })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.ok(result.usage!.windows.credits);
+    assert.equal(result.usage!.windows.credits!.windowSeconds, null);
+    assert.equal(result.usage!.windows.credits!.resetAt, null);
+  });
+
+  test('clamps percent at 100 while leaving the money label unclamped', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      data: { limit: 30, limit_remaining: -1, limit_reset: 'monthly', usage_monthly: 31 },
+    })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+    const window = result.usage!.windows.monthly;
+
+    assert.equal(window!.usedPercent, 100);
+    assert.equal(window!.valueLabel, '$31.00 / $30.00');
+  });
+
+  test('uses a weekly window and derives its reset on Monday UTC', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: 'weekly', usage_monthly: 5 },
+    })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+    const window = result.usage!.windows.weekly;
+
+    assert.ok(window);
+    assert.equal(window!.windowSeconds, 604800);
+    assert.equal(new Date(window!.resetAt!).getUTCDay(), 1);
+  });
+
+  test('rejects management keys with an inference-key error', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({ data: { is_management_key: true } })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.usage, null);
+    assert.equal(result.error, 'Management key configured — quota needs an inference API key');
+  });
+
+  for (const status of [401, 403]) {
+    test(`maps HTTP ${status} to session expiry`, async () => {
+      stubFetchFailing(async () => ({}), { ok: false, status });
+
+      const result = await fetchQuotaForProvider('openrouter');
+
+      assert.equal(result.ok, false);
+      assert.equal(result.error, 'Session expired — please re-authenticate with OpenRouter');
+    });
+  }
+
+  test('reports invalid JSON as a parse failure', async () => {
+    globalThis.fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    }) as unknown as Response) as typeof fetch;
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Invalid response from provider');
+  });
+
+  test('normalizes timeout failures', async () => {
+    stubFetchReturning(() => Promise.reject(new DOMException('Timed out', 'TimeoutError')));
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'Request timed out');
+  });
+
+  test('rejects a response without usable quota data', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({ data: { limit: 30, limit_remaining: null } })));
+
+    const result = await fetchQuotaForProvider('openrouter');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.usage, null);
+    assert.equal(result.error, 'No quota data in response');
+  });
+
+  for (const payload of [{ data: {} }, { data: null }]) {
+    test(`rejects ${JSON.stringify(payload)} without quota data`, async () => {
+      stubFetchReturning(() => Promise.resolve(mockResponse(payload)));
+
+      const result = await fetchQuotaForProvider('openrouter');
+
+      assert.equal(result.ok, false);
+      assert.equal(result.configured, true);
+      assert.equal(result.usage, null);
+      assert.equal(result.error, 'No quota data in response');
+    });
+  }
 });
 
 

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -1975,6 +1975,28 @@ const fetchCursorQuota = async (): Promise<ProviderResult> => {
   } catch (error) { return buildResult({ providerId: 'cursor', providerName: 'Cursor', ok: false, configured: true, error: error instanceof Error ? error.message : 'Request failed' }); }
 };
 
+const openRouterResetAt = (period: string | null, nowMs: number): number | null => {
+  const now = new Date(nowMs);
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+
+  if (period === 'daily') return Date.UTC(year, month, day + 1);
+  if (period === 'weekly') {
+    const daysUntilMonday = ((8 - now.getUTCDay()) % 7) || 7;
+    return Date.UTC(year, month, day + daysUntilMonday);
+  }
+  if (period === 'monthly') return Date.UTC(year, month + 1, 1);
+  return null;
+};
+
+const PERIOD_SECONDS = { daily: 86400, weekly: 604800, monthly: 30 * 86400 };
+type OpenRouterPeriod = keyof typeof PERIOD_SECONDS;
+
+const isOpenRouterPeriod = (value: unknown): value is OpenRouterPeriod => (
+  typeof value === 'string' && Object.prototype.hasOwnProperty.call(PERIOD_SECONDS, value)
+);
+
 const fetchOpenRouterQuota = async (): Promise<ProviderResult> => {
   const auth = readAuthFile();
   const entry = normalizeAuthEntry(getAuthEntry(auth, ['openrouter'])) as Record<string, unknown> | null;
@@ -1990,13 +2012,16 @@ const fetchOpenRouterQuota = async (): Promise<ProviderResult> => {
     });
   }
 
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
   try {
-    const response = await fetch('https://openrouter.ai/api/v1/credits', {
+    const response = await fetch('https://openrouter.ai/api/v1/key', {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
+        'Accept-Encoding': 'identity',
       },
+      signal: timeoutSignal,
     });
 
     if (!response.ok) {
@@ -2005,20 +2030,86 @@ const fetchOpenRouterQuota = async (): Promise<ProviderResult> => {
         providerName: 'OpenRouter',
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`,
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with OpenRouter'
+          : `API error: ${response.status}`,
       });
     }
 
-    const payload = await response.json() as Record<string, unknown>;
-    const credits = payload.data as Record<string, unknown> | undefined;
-    const totalCredits = toNumber(credits?.total_credits);
-    const totalUsage = toNumber(credits?.total_usage);
-    const remaining = totalCredits !== null && totalUsage !== null
-      ? Math.max(0, totalCredits - totalUsage)
-      : null;
-    let valueLabel: string | null = null;
-    if (remaining !== null && totalUsage !== null) {
-      valueLabel = `$${formatMoney(remaining)} left · $${formatMoney(totalUsage)} spent`;
+    const payload = await response.json() as unknown;
+    const dataContainer = asObject(payload);
+    const data = asObject(dataContainer?.data);
+    if (data === null) {
+      return buildResult({
+        providerId: 'openrouter',
+        providerName: 'OpenRouter',
+        ok: false,
+        configured: true,
+        error: 'No quota data in response',
+      });
+    }
+
+    if (data.is_management_key === true) {
+      return buildResult({
+        providerId: 'openrouter',
+        providerName: 'OpenRouter',
+        ok: false,
+        configured: true,
+        error: 'Management key configured — quota needs an inference API key',
+      });
+    }
+
+    const limit = toNumber(data.limit);
+    const limitRemaining = toNumber(data.limit_remaining);
+    if (limit !== null && limitRemaining === null) {
+      return buildResult({
+        providerId: 'openrouter',
+        providerName: 'OpenRouter',
+        ok: false,
+        configured: true,
+        error: 'No quota data in response',
+      });
+    }
+
+    const usageMonthly = toNumber(data.usage_monthly);
+    if (limit === null && usageMonthly === null) {
+      return buildResult({
+        providerId: 'openrouter',
+        providerName: 'OpenRouter',
+        ok: false,
+        configured: true,
+        error: 'No quota data in response',
+      });
+    }
+
+    const nowMs = Date.now();
+    let windowKey: string;
+    let windowSeconds: number | null;
+    let resetAt: number | null;
+    let usedPercent: number | null;
+    let valueLabel: string;
+
+    if (limit === null) {
+      windowKey = 'monthly';
+      windowSeconds = PERIOD_SECONDS.monthly;
+      resetAt = openRouterResetAt('monthly', nowMs);
+      usedPercent = null;
+      valueLabel = `$${formatMoney(usageMonthly)} spent`;
+    } else {
+      const used = Math.max(0, limit - (limitRemaining ?? 0));
+      const percent = limit > 0 ? (used / limit) * 100 : null;
+      usedPercent = percent === null ? null : Math.min(100, percent);
+      valueLabel = `$${formatMoney(used)} / $${formatMoney(limit)}`;
+
+      if (isOpenRouterPeriod(data.limit_reset)) {
+        windowKey = data.limit_reset;
+        windowSeconds = PERIOD_SECONDS[data.limit_reset];
+        resetAt = openRouterResetAt(data.limit_reset, nowMs);
+      } else {
+        windowKey = 'credits';
+        windowSeconds = null;
+        resetAt = null;
+      }
     }
 
     return buildResult({
@@ -2028,22 +2119,28 @@ const fetchOpenRouterQuota = async (): Promise<ProviderResult> => {
       configured: true,
       usage: {
         windows: {
-          credits: toUsageWindow({
-            usedPercent: null,
-            windowSeconds: null,
-            resetAt: null,
+          [windowKey]: toUsageWindow({
+            usedPercent,
+            windowSeconds,
+            resetAt,
             valueLabel,
           }),
         },
       },
     });
   } catch (error) {
+    const isTimeout = error instanceof DOMException && (error.name === 'TimeoutError' || (error.name === 'AbortError' && timeoutSignal.aborted));
+    const isParseError = error instanceof SyntaxError;
     return buildResult({
       providerId: 'openrouter',
       providerName: 'OpenRouter',
       ok: false,
       configured: true,
-      error: error instanceof Error ? error.message : 'Request failed',
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : error instanceof Error ? error.message : 'Request failed',
     });
   }
 };

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -124,6 +124,16 @@ snapshot carries `entitlement`, `remaining`, `unlimited`, and
 - When entitlement/remaining are unusable, fall back to `100 - percent_remaining`.
 - Snapshots other than `premium_interactions` (legacy annual plans) yield zero windows.
 
+## OpenRouter key semantics
+
+OpenRouter quota reads `GET https://openrouter.ai/api/v1/key`, which is documented as callable with any valid API key. `GET /api/v1/credits` is documented as "Management key required" and is not used. Calling `/credits` with a normal inference key has been observed to return HTTP 200 with `{total_credits:0, total_usage:0}` rather than an error; this behavior is not documented and is why the old implementation silently rendered "$0.00 left · $0.00 spent". A `/credits` fallback for unlimited keys would render the same zeros, so unlimited keys report `usage_monthly` instead.
+
+The documented `limit`, `limit_remaining`, and `limit_reset` fields are present and null on unlimited keys; null means unlimited, never missing data. For a limited key, window usage is `limit - limit_remaining`, not `usage`: `usage` is all-time and measures a different axis from the current reset window. Pairing `usage` with the current limit produces a wrong number. `limit_remaining` is server-computed and already honors `include_byok_in_limit`, so `byok_*` fields are ignored.
+
+Unlimited keys report `usage_monthly` in a `monthly` window with no percent. `limit_reset` is a period string (`daily`, `weekly`, `monthly`, or null), not a timestamp; `resetAt` is derived from the documented midnight-UTC boundaries, with weeks starting Monday. A set `limit` with a null `limit_reset` is a lifetime cap and maps to the `credits` window with no reset.
+
+Keep `packages/web/server/lib/quota/providers/openrouter.js` and `packages/vscode/src/quotaProviders.ts` in sync, as with the Kimi and Copilot providers; the VS Code extension duplicates this parsing logic rather than importing the web provider.
+
 ## Notes for contributors
 - Keep provider IDs stable; clients use them directly.
 - Avoid adding alias-based dispatch in `fetchQuotaForProvider`; dispatch currently expects exact provider IDs.

--- a/packages/web/server/lib/quota/providers/openrouter.js
+++ b/packages/web/server/lib/quota/providers/openrouter.js
@@ -5,12 +5,30 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
+  asObject,
   formatMoney
 } from '../utils/index.js';
 
 export const providerId = 'openrouter';
 export const providerName = 'OpenRouter';
-const aliases = ['openrouter'];
+export const aliases = ['openrouter'];
+const OPENROUTER_QUOTA_URL = 'https://openrouter.ai/api/v1/key';
+const PERIOD_SECONDS = { daily: 86400, weekly: 604800, monthly: 30 * 86400 };
+
+export const resolveResetAt = (limitReset, nowMs) => {
+  const now = new Date(nowMs);
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const d = now.getUTCDate();
+
+  if (limitReset === 'daily') return Date.UTC(y, m, d + 1);
+  if (limitReset === 'weekly') {
+    const dow = now.getUTCDay();
+    return Date.UTC(y, m, d + ((8 - dow) % 7 || 7));
+  }
+  if (limitReset === 'monthly') return Date.UTC(y, m + 1, 1);
+  return null;
+};
 
 export const isConfigured = () => {
   const auth = readAuthFile();
@@ -33,13 +51,16 @@ export const fetchQuota = async () => {
     });
   }
 
+  const timeoutSignal = AbortSignal.timeout(15_000);
+
   try {
-    const response = await fetch('https://openrouter.ai/api/v1/credits', {
+    const response = await fetch(OPENROUTER_QUOTA_URL, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json'
-      }
+        'Accept-Encoding': 'identity'
+      },
+      signal: timeoutSignal
     });
 
     if (!response.ok) {
@@ -48,45 +69,119 @@ export const fetchQuota = async () => {
         providerName,
         ok: false,
         configured: true,
-        error: `API error: ${response.status}`
+        error: response.status === 401 || response.status === 403
+          ? 'Session expired — please re-authenticate with OpenRouter'
+          : `API error: ${response.status}`
       });
     }
 
     const payload = await response.json();
-    const credits = payload?.data ?? {};
-    const totalCredits = toNumber(credits.total_credits);
-    const totalUsage = toNumber(credits.total_usage);
-    const remaining = totalCredits !== null && totalUsage !== null
-      ? Math.max(0, totalCredits - totalUsage)
-      : null;
-    let valueLabel = null;
-    if (remaining !== null && totalUsage !== null) {
-      valueLabel = `$${formatMoney(remaining)} left · $${formatMoney(totalUsage)} spent`;
+    const data = asObject(payload?.data);
+
+    if (data === null) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No quota data in response'
+      });
     }
 
-    const windows = {
-      credits: toUsageWindow({
-        usedPercent: null,
-        windowSeconds: null,
-        resetAt: null,
-        valueLabel
-      })
-    };
+    if (data.is_management_key === true) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'Management key configured — quota needs an inference API key'
+      });
+    }
+
+    const limit = toNumber(data.limit);
+    const limitRemaining = toNumber(data.limit_remaining);
+    if (limit !== null && limitRemaining === null) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No quota data in response'
+      });
+    }
+
+    const usageMonthly = toNumber(data.usage_monthly);
+    if (limit === null && usageMonthly === null) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: 'No quota data in response'
+      });
+    }
+
+    const nowMs = Date.now();
+    let windowKey;
+    let windowSeconds;
+    let resetAt;
+    let usedPercent;
+    let valueLabel;
+
+    if (limit === null) {
+      windowKey = 'monthly';
+      windowSeconds = PERIOD_SECONDS.monthly;
+      resetAt = resolveResetAt('monthly', nowMs);
+      usedPercent = null;
+      valueLabel = `$${formatMoney(usageMonthly)} spent`;
+    } else {
+      const used = Math.max(0, limit - limitRemaining);
+      const percent = limit > 0 ? (used / limit) * 100 : null;
+      usedPercent = percent === null ? null : Math.min(100, percent);
+      valueLabel = `$${formatMoney(used)} / $${formatMoney(limit)}`;
+
+      if (Object.hasOwn(PERIOD_SECONDS, data.limit_reset)) {
+        windowKey = data.limit_reset;
+        windowSeconds = PERIOD_SECONDS[data.limit_reset];
+        resetAt = resolveResetAt(data.limit_reset, nowMs);
+      } else {
+        windowKey = 'credits';
+        windowSeconds = null;
+        resetAt = null;
+      }
+    }
 
     return buildResult({
       providerId,
       providerName,
       ok: true,
       configured: true,
-      usage: { windows }
+      usage: {
+        windows: {
+          [windowKey]: toUsageWindow({
+            usedPercent,
+            windowSeconds,
+            resetAt,
+            valueLabel
+          })
+        }
+      }
     });
   } catch (error) {
+    const isTimeout = error instanceof DOMException && (
+      error.name === 'TimeoutError' || (error.name === 'AbortError' && timeoutSignal.aborted)
+    );
+    const isParseError = error instanceof SyntaxError;
     return buildResult({
       providerId,
       providerName,
       ok: false,
       configured: true,
-      error: error instanceof Error ? error.message : 'Request failed'
+      error: isTimeout
+        ? 'Request timed out'
+        : isParseError
+          ? 'Invalid response from provider'
+          : (error instanceof Error ? error.message : 'Request failed')
     });
   }
 };

--- a/packages/web/server/lib/quota/providers/openrouter.test.js
+++ b/packages/web/server/lib/quota/providers/openrouter.test.js
@@ -1,0 +1,330 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({ openrouter: { key: 'test-token' } }),
+}));
+
+import { fetchQuota, resolveResetAt } from './openrouter.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body, init = {}) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  ...init,
+});
+
+// Documented payload shape from https://openrouter.ai/docs/api_reference/limits
+const DOCUMENTED_PAYLOAD = {
+  data: {
+    label: 'Default',
+    limit: 30,
+    limit_remaining: 25,
+    limit_reset: 'monthly',
+    include_byok_in_limit: false,
+    usage: 5,
+    usage_daily: 1,
+    usage_weekly: 3,
+    usage_monthly: 5,
+    byok_usage: 0,
+    byok_usage_daily: 0,
+    byok_usage_weekly: 0,
+    byok_usage_monthly: 0,
+    is_free_tier: false,
+    is_management_key: false,
+    is_provisioning_key: false,
+    creator_user_id: 'user-fixture',
+    expires_at: null,
+    rate_limit: null
+  }
+};
+
+const expectMonthlyReset = (resetAt) => {
+  expect(resetAt).toEqual(expect.any(Number));
+  const resetDate = new Date(resetAt);
+  expect(resetDate.getUTCDate()).toBe(1);
+  expect(resetDate.getUTCHours()).toBe(0);
+  expect(resetAt - Date.now()).toBeGreaterThan(0);
+  expect(resetAt - Date.now()).toBeLessThanOrEqual(31 * 86400 * 1000);
+};
+
+describe('OpenRouter quota provider', () => {
+  it('builds a monthly window from the documented payload', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse(DOCUMENTED_PAYLOAD)));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.monthly;
+
+    expect(result.ok).toBe(true);
+    expect(result.providerId).toBe('openrouter');
+    expect(window.usedPercent).toBeCloseTo(16.6667, 3);
+    expect(window.valueLabel).toBe('$5.00 / $30.00');
+    expect(window.windowSeconds).toBe(30 * 86400);
+    expectMonthlyReset(window.resetAt);
+  });
+
+  it('uses the daily window and preserves the observed funded-key values', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: {
+        usage: 3.17561396,
+        usage_daily: 0.0000018,
+        usage_weekly: 0.0000018,
+        usage_monthly: 3.17561396,
+        limit: 30,
+        limit_remaining: 29.9999982,
+        limit_reset: 'daily',
+        is_free_tier: true,
+        is_management_key: false,
+        include_byok_in_limit: false,
+        byok_usage: 0
+      }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.daily;
+
+    expect(window).toBeDefined();
+    expect(window.windowSeconds).toBe(86400);
+    expect(window.valueLabel).toBe('$0.00 / $30.00');
+    expect(window.usedPercent).toBeLessThan(0.001);
+    expect(window.resetAt % 86400000).toBe(0);
+    expect(window.resetAt - Date.now()).toBeGreaterThan(0);
+    expect(window.resetAt - Date.now()).toBeLessThanOrEqual(86400000);
+  });
+
+  it('builds a monthly unlimited window from null limit fields', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: {
+        limit: null,
+        limit_remaining: null,
+        limit_reset: null,
+        usage_monthly: 3.17561396,
+        is_management_key: false
+      }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.monthly;
+
+    expect(window.usedPercent).toBeNull();
+    expect(window.valueLabel).toBe('$3.18 spent');
+    expect(window.windowSeconds).toBe(30 * 86400);
+    expectMonthlyReset(window.resetAt);
+  });
+
+  it('uses a credits window for a lifetime cap', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: null, usage_monthly: 5 }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.credits;
+
+    expect(window).toBeDefined();
+    expect(window.resetAt).toBeNull();
+    expect(window.windowSeconds).toBeNull();
+  });
+
+  it('uses a credits window for an unrecognized reset period', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: 'yearly', usage_monthly: 5 }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.credits;
+
+    expect(window).toBeDefined();
+    expect(window.resetAt).toBeNull();
+    expect(window.windowSeconds).toBeNull();
+  });
+
+  it('builds a weekly window from a weekly limit', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 30, limit_remaining: 25, limit_reset: 'weekly', usage_monthly: 5 }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.weekly;
+
+    expect(window).toBeDefined();
+    expect(window.windowSeconds).toBe(604800);
+    expect(new Date(window.resetAt).getUTCDay()).toBe(1);
+    expect(window.resetAt - Date.now()).toBeGreaterThan(0);
+    expect(window.resetAt - Date.now()).toBeLessThanOrEqual(7 * 86400 * 1000);
+  });
+
+  it('ignores BYOK usage when calculating the quota label and percent', async () => {
+    const withByokPayload = {
+      ...DOCUMENTED_PAYLOAD,
+      data: {
+        ...DOCUMENTED_PAYLOAD.data,
+        include_byok_in_limit: true,
+        byok_usage_monthly: 100,
+        byok_usage: 100
+      }
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResponse(DOCUMENTED_PAYLOAD))
+      .mockResolvedValueOnce(mockResponse(withByokPayload));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const withoutByok = await fetchQuota();
+    const withByok = await fetchQuota();
+
+    expect(withByok.usage.windows.monthly.valueLabel)
+      .toBe(withoutByok.usage.windows.monthly.valueLabel);
+    expect(withByok.usage.windows.monthly.usedPercent)
+      .toBe(withoutByok.usage.windows.monthly.usedPercent);
+  });
+
+  it('rejects management keys with a specific error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { is_management_key: true }
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.usage).toBeNull();
+    expect(result.error).toBe('Management key configured — quota needs an inference API key');
+  });
+
+  it.each([401, 403])('maps %s to a session-expired error', async (status) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Session expired — please re-authenticate with OpenRouter');
+  });
+
+  it('reports invalid-response on JSON parse failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError('Unexpected token'); },
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Invalid response from provider');
+  });
+
+  it('reports a normalized timeout error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError')));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Request timed out');
+  });
+
+  it('returns no-quota-data when data is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({})));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('No quota data in response');
+    expect(result.usage).toBeNull();
+  });
+
+  it('returns no-quota-data when data is empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ data: {} })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('No quota data in response');
+    expect(result.usage).toBeNull();
+  });
+
+  it.each([null, []])('returns no-quota-data when data is %s', async (data) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ data })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.usage).toBeNull();
+    expect(result.error).toBe('No quota data in response');
+  });
+
+  it('returns no-quota-data when a limit has no remaining value', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 30, limit_remaining: null, usage_monthly: 5 }
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('No quota data in response');
+  });
+
+  it('keeps a zero limit valid with a null percent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 0, limit_remaining: 0, limit_reset: 'monthly', usage_monthly: 0 }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.monthly;
+
+    expect(result.ok).toBe(true);
+    expect(window.usedPercent).toBeNull();
+    expect(window.valueLabel).toBe('$0.00 / $0.00');
+  });
+
+  it('requests the key endpoint and never the credits endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(DOCUMENTED_PAYLOAD));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchQuota();
+
+    const requestedUrl = fetchMock.mock.calls[0][0];
+    expect(requestedUrl).toBe('https://openrouter.ai/api/v1/key');
+    expect(requestedUrl).not.toContain('/api/v1/credits');
+  });
+
+  it('resolves daily reset at the next UTC day across year boundaries', () => {
+    expect(resolveResetAt('daily', Date.UTC(2024, 11, 31, 23, 59))).toBe(Date.UTC(2025, 0, 1));
+  });
+
+  it('resolves weekly reset from Sunday to the next Monday', () => {
+    expect(resolveResetAt('weekly', Date.UTC(2024, 0, 7, 12))).toBe(Date.UTC(2024, 0, 8));
+  });
+
+  it('resolves weekly reset from Monday to the following Monday', () => {
+    expect(resolveResetAt('weekly', Date.UTC(2024, 0, 8, 12))).toBe(Date.UTC(2024, 0, 15));
+  });
+
+  it('resolves weekly reset from Wednesday to the next Monday', () => {
+    expect(resolveResetAt('weekly', Date.UTC(2024, 0, 10, 12))).toBe(Date.UTC(2024, 0, 15));
+  });
+
+  it('resolves monthly reset from January 31 to February 1', () => {
+    expect(resolveResetAt('monthly', Date.UTC(2024, 0, 31, 12))).toBe(Date.UTC(2024, 1, 1));
+  });
+
+  it('resolves monthly reset across December to January', () => {
+    expect(resolveResetAt('monthly', Date.UTC(2024, 11, 31, 23, 59))).toBe(Date.UTC(2025, 0, 1));
+  });
+
+  it('clamps percent at 100 while leaving the money label unclamped', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: { limit: 30, limit_remaining: -1, limit_reset: 'monthly', usage_monthly: 31 }
+    })));
+
+    const result = await fetchQuota();
+    const window = result.usage.windows.monthly;
+
+    expect(window.usedPercent).toBe(100);
+    expect(window.valueLabel).toBe('$31.00 / $30.00');
+  });
+});


### PR DESCRIPTION
## Intent

OpenRouter quota showed `$0.00 left · $0.00 spent` for keys that clearly had money behind them.

The provider called `GET /api/v1/credits`. OpenRouter documents that endpoint as requiring a management key, and it does return `403 Only management keys can perform this operation` in that case. What it does with a normal inference key is worse than a 403: it answers `HTTP 200` with `{"total_credits":0,"total_usage":0}`. Because the response is a success, the existing `!response.ok` guard could never catch it, and the provider happily formatted two zeros into a money label. That behavior is observed rather than documented, so this PR treats it as an OpenRouter quirk to design around rather than a contract to rely on.

Reproduced against a real funded key, both calls seconds apart:

```
GET /api/v1/key      usage 3.17561396   usage_monthly 3.17561396
                     limit 30           limit_remaining 29.9999982
                     limit_reset "daily"  is_management_key false

GET /api/v1/credits  HTTP 200  {"total_credits": 0, "total_usage": 0}
```

A single billed request moved `usage` from `3.17561216` to `3.17561396` and `limit_remaining` from `30` to `29.9999982`, while `/credits` stayed at zero throughout.

The provider now reads `GET /api/v1/key`, which OpenRouter documents as callable with any valid API key. A key with a spending limit reports its own usage against that limit, in the window named by `limit_reset`. A key without a limit reports `usage_monthly`.

Window usage is `limit - limit_remaining`, not `usage`. This matters and is easy to get wrong: `usage` is all-time, while `limit_remaining` tracks the current reset window. On the key above they differ by six orders of magnitude, so pairing `usage` with `limit` would have replaced a wrong number with a different wrong number. `limit_remaining` is also computed server side and already accounts for `include_byok_in_limit`, which is why the `byok_*` fields are ignored rather than added in.

The same commit brings the provider up to the standard `providers/deepseek.js` already sets, since it was missing all of it: a 15 second timeout, 401 and 403 mapped to a session-expired message, parse failures mapped to `Invalid response from provider`, an explicit `No quota data in response` result, and the `aliases` export that `quota/DOCUMENTATION.md` requires. It adds the missing `openrouter.test.js`, and keeps the VS Code copy in sync.

## Non-goals

Surfacing an account's overall OpenRouter dashboard balance. This came up because the affected account shows roughly $3000 there while the key reports far less, and it is worth being direct about why that number is not in this PR. No documented OpenRouter endpoint exposes an organization credit pool, grant, or promotional balance to a non-management key. That is a conclusion drawn from the documented endpoint permissions rather than an explicit statement that no such endpoint exists, so it could change if OpenRouter documents one. On the account in question `is_free_tier` is `true`, which means the balance is not purchased credit anyway. The honest outcome is accurate per-key usage and limits, not that figure.

Changing how the shared UI renders quota. `packages/ui` is untouched. Reworking the other 15 providers that declare `aliases` without exporting it.

## On the `/credits` fallback from the issue thread

The thread landed on preferring `/api/v1/key` when a key has a limit and keeping `/credits` as the fallback when it does not, so that personal and unlimited keys behave as they do today. I started there, and I want to flag what I hit rather than quietly do something else.

I could not get that fallback to produce a useful number for an unlimited key. A key with no individual limit still gets `HTTP 200` and `{"total_credits":0,"total_usage":0}` from `/credits`, the same response that produces the label this issue is about, so the fallback path lands on `$0.00 left · $0.00 spent` for exactly the keys it was meant to cover. Since a limit is opt-in when a key is created, I would expect that to be the common shape rather than an edge case.

What this PR does instead is report `usage_monthly` for those keys, in a monthly window with no percent. They still show a real money label, which I think preserves the intent behind keeping the fallback even though the mechanism is different.

One case the fallback did serve is a management key, which gets a genuine balance from `/credits`. I have left that out on the reasoning that management keys cannot call completion endpoints, so such a key cannot work as an OpenChamber model provider anyway, and keeping the call would add a second request and a second failure path for it. The provider detects `is_management_key` and returns an explanatory error instead of a misleading `$0.00 spent`. If you would rather keep that case working, gating a `/credits` call on `is_management_key` is a small change and I am glad to add it.

If I have misread the intent here, or if there is `/credits` behavior I did not manage to reproduce, I am happy to rework this part.

## Affected surfaces

`packages/web/server/lib/quota/providers/openrouter.js` is the provider used by web, desktop, and Electron through the quota dispatcher. Its `providerId` stays `openrouter` and the result shape is unchanged, so nothing downstream needs updating.

`packages/vscode/src/quotaProviders.ts` carries its own copy of this parsing logic rather than importing the web provider, the same arrangement `DOCUMENTATION.md` already records for Kimi, Copilot, and Z.ai. `fetchOpenRouterQuota` had the identical bug and gets the identical fix, so the two runtimes do not disagree about the same key. The two implementations are deliberately structured the same way to make that easy to audit.

The user-visible change is the quota label and window. OpenRouter previously produced a single `credits` window with no percent. It now produces one window keyed `daily`, `weekly`, or `monthly` for a limited key, or `credits` for a limit with no reset period, or `monthly` for an unlimited key. Those keys are already localized, so no locale files change.

Window contract detail worth flagging: the provider now emits `usedPercent` and `windowSeconds`, which it never did before, so OpenRouter rows can render a progress bar and participate in headline selection. A `valueLabel` is still always emitted, which preserves the money-label behavior from #1085 and #1127. The percent that #1085 objected to was derived from lifetime total against current balance. This one is bounded by a real reset window, which is a different quantity.

`packages/ui` is unaffected because `formatQuotaValueLabel(valueLabel, percent)` returns `valueLabel` whenever the provider supplies one, and this provider always does.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `packages/web/server/lib/quota/DOCUMENTATION.md`, response contract | It states provider modules must export `providerId`, `providerName`, `aliases`, `isConfigured`, and `fetchQuota`. The file exported everything except `aliases`. | `aliases` is now exported. Results are still built with `buildResult` and `toUsageWindow`, so the payload shape is unchanged. |
| `DOCUMENTATION.md`, web and VS Code parity | The file records that the VS Code extension duplicates quota parsing for Kimi, Copilot, and Z.ai and must stay in sync. OpenRouter had the same duplication and the same bug. | Both runtimes changed together, with the same check order, window mapping, labels, and error strings. A new `OpenRouter key semantics` section documents the field semantics and the `/credits` behavior so this is not reintroduced. |
| `.agents/skills/openchamber-change-discipline` | Risk classification. This is a module contract change, since `aliases` becomes an export, and a cross-workspace contract change, since two runtimes carry the logic. | Both runtimes and their tests were validated. The diff stays inside the OpenRouter path, and the 15 other providers that keep `aliases` module-private were left alone. |
| Same skill, structural discipline | It rejects blind casts and asks that the normal path read top to bottom. | The VS Code version was restructured into the same explicit limited and unlimited branches as the web version so TypeScript narrows naturally, removing two non-null assertions and a five-level nested ternary. |
| `providers/deepseek.js` as the local pattern | Nearest hardened provider with the same single-endpoint money-label shape. | Timeout, status mapping, parse-error mapping, and the no-quota-data result are copied from it rather than invented. `deepseek.test.js` sets the test conventions this file follows. |
| `.agents/skills/communication-style` | Governs this PR body and the documentation section. | Documentation states behavior as fact rather than instruction, and avoids bold-label list formatting. |
| `.agents/skills/update-changelog` | It gates changelog edits to explicit maintainer requests. | No changelog entry. `changelog/` is untouched. |

## Validation

| Check | Result |
|---|---|
| `bun run type-check` | Pass |
| `bun run lint` | Pass |
| `bun run test` | 407/408 files. The one failure is `packages/ui/src/lib/persistence.test.ts`, which is pre-existing and unrelated. Details below. |
| `bun run build` | Pass, 3m24s |
| `bun run --cwd packages/web test` | Pass, 2013 tests |
| `bun run --cwd packages/vscode test` | Pass, 35/35 files |
| Live check against the configured key | Provider output matched `GET /api/v1/key` read at the same moment on window key, label, percent, and reset |

On the failing file. It also fails on unmodified `origin/main`, checked out into a separate worktree with no part of this branch applied, where it reported 16 failing tests with `warn: offline` and 5 second timeouts against a runtime settings API. Across four runs it failed, passed, failed, and failed, so it is flaky here and sensitive to network availability in this sandbox. `git diff --stat` shows this branch changes no file under `packages/ui`, so it cannot be the cause. `packages/ui/src/lib/relay/tunnel-client.test.ts` behaved the same way on the first baseline run.

Live verification was a read of `GET /api/v1/key`, a read of `GET /api/v1/credits`, and one trivial billed inference request costing $0.0000018 to confirm which counters move. The key was never logged or committed.

Not verified: behavior against a real management key, and against a real key whose `limit_reset` is `weekly` or `monthly`, since the available key is daily-limited. Those paths are covered by unit tests using documented payload shapes but have not been exercised against live OpenRouter responses. Also not verified: the VS Code extension running inside VS Code, as opposed to its test suite.

## Visual evidence

No screenshot. The browser available in this environment runs on a different machine with no network route to the local OpenChamber server, so the usage panel could not be loaded and captured. Rather than mock something up, here is the same evidence at the layer the UI reads from.

Both captured from `GET /api/quota/openrouter` on a locally running OpenChamber server, same key, same machine, minutes apart, with only the provider file swapped between runs.

Before, on upstream `main`:

```json
{
  "providerId": "openrouter", "ok": true, "configured": true,
  "usage": { "windows": { "credits": {
    "usedPercent": null, "remainingPercent": null,
    "windowSeconds": null, "resetAt": null,
    "valueLabel": "$0.00 left · $0.00 spent"
  } } }
}
```

After, on this branch:

```json
{
  "providerId": "openrouter", "ok": true, "configured": true,
  "usage": { "windows": { "daily": {
    "usedPercent": 0.000005999999999062312, "remainingPercent": 99.999994,
    "windowSeconds": 86400, "resetAt": 1788825600000,
    "resetAtFormatted": "Tue, Sep 8, 2:00 AM",
    "valueLabel": "$0.00 / $30.00"
  } } }
}
```

In the panel that is the difference between an OpenRouter row reading `$0.00 left · $0.00 spent` with no bar, and a `Daily` row reading `$0.00 / $30.00` with a bar and a reset time. The label text is `valueLabel` verbatim, because `formatQuotaValueLabel` returns it whenever it is present. This particular key has spent almost nothing inside its daily window, which is why the used figure rounds to `$0.00`. Its all-time `usage` is `$3.18`, and deliberately not what the daily row reports. A screenshot on request from anyone able to run the UI against a funded key.

## Risks and failure behavior

The main behavioral risk is the one described above: a user with a management key configured loses a working balance readout and gets an explanatory error instead. That is intentional, and the population should be effectively zero because such a key cannot run inference.

Every failure path returns `ok: false` with `configured: true` and `usage: null`, so the row degrades to an error rather than a misleading number. That covers 401 and 403, other HTTP errors, timeouts after 15 seconds, malformed JSON, a missing or non-object `data`, a limit with no `limit_remaining`, and an unlimited key with no `usage_monthly`. There is no caching and no retry, so a failed refresh affects only that refresh.

Unlimited keys are the case most likely to be got wrong, since `limit`, `limit_remaining`, and `limit_reset` are all documented as present and null there. Null means unlimited, never missing data, and the tests pin that a fully null trio still produces a valid monthly window rather than an error.

Zero is treated as a real value throughout. A key that has spent nothing shows `$0.00 / $30.00` rather than falling into the no-data path. A `limit` of `0` yields a null percent instead of dividing by zero. A negative `limit_remaining`, which would mean overspend, clamps the percent at 100 while leaving the money label unclamped so the overage stays visible.

`resetAt` is derived rather than returned by the API, since `limit_reset` is a period string. The derivation uses `Date.UTC` only, which normalizes overflow, and was checked across all seven weekdays plus December 31, January 31, and February 29. It is a display value, not a billing figure.

No credentials are logged or persisted. Provider IDs, the result contract, and the shared UI are unchanged, so rollback is reverting this commit with nothing to migrate.

One housekeeping note: exporting `aliases` makes `bun run dead-code` list `aliases openrouter` as an unused namespace export. It already reports the same for claude, exe-dev, google, hyper, and opencode-go, so this adds a line to an existing pattern rather than a new one. Say the word and I will make it module-private instead, though that would put the file back out of step with the documented export contract.
