### PR TITLE
fix: forward agent/model/variant to session creation

### DIFF
--- a/packages/web/server/lib/openchamber-sessions/routes.js
+++ b/packages/web/server/lib/openchamber-sessions/routes.js
@@ -193,7 +193,7 @@ const runPromptAsync = async ({ baseUrl, authHeaders, sessionID, directory, payl
   }
 };
 
-const createSession = async ({ baseUrl, authHeaders, directory, title }) => {
+const createSession = async ({ baseUrl, authHeaders, directory, title, agent, model, variant }) => {
   const sessionUrl = new URL(`${baseUrl}/session`);
   sessionUrl.searchParams.set('directory', directory);
   const response = await fetch(sessionUrl.toString(), {
@@ -204,7 +204,13 @@ const createSession = async ({ baseUrl, authHeaders, directory, title }) => {
       'content-type': 'application/json',
       accept: 'application/json',
     },
-    body: JSON.stringify({ directory, ...(title ? { title } : {}) }),
+    body: JSON.stringify({
+      directory,
+      ...(title ? { title } : {}),
+      ...(agent ? { agent } : {}),
+      ...(model ? { model } : {}),
+      ...(variant ? { variant } : {}),
+    }),
   });
 
   if (!response.ok) {
@@ -630,6 +636,9 @@ export const createOpenChamberSessionService = (dependencies) => {
       authHeaders,
       directory: sessionDirectory,
       ...(title ? { title } : {}),
+      ...(agent ? { agent } : {}),
+      ...(model ? { model } : {}),
+      ...(variant ? { variant } : {}),
     });
 
     let dispatch = { model, agent, variant, promptDispatched: false, dispatchedAsCommand: false };


### PR DESCRIPTION
## Problem

`createSession()` in `packages/web/server/lib/openchamber-sessions/routes.js` only sent `{ directory, title }` to the OpenCode server, dropping the `agent` field entirely. The `create()` function read `payload.agent` but never forwarded it, so every session was created with the OpenCode default (`build`) and the agent was only applied later at prompt time.

This causes sessions spawned with `--agent manager` to silently land on `build` — the agent is only applied at prompt time, after any verification window.

## Fix

Forward `agent`, `model`, and `variant` in the session create POST body:

1. Updated `createSession` signature to accept `agent`, `model`, `variant`
2. Spread those fields into the JSON body when present
3. Updated the call site in `create()` to pass them through

## Impact

- Sessions are now created with the requested agent from the start
- No more silent agent flips after the verification window
- Model and variant are also forwarded, fixing the same class of bug for those fields

## Testing

- Verified on our fork (deployed and live since 2026-09-06)
- `openchamber-sessions/routes.test.js` — 27/27 pass
- Live test: spawn `--agent manager`, wait 10s, `status` still shows `manager`