### PR TITLE
fix(git): preserve untracked diffs when Git emits warnings

### DIFF
--- a/packages/web/server/lib/git/DOCUMENTATION.md
+++ b/packages/web/server/lib/git/DOCUMENTATION.md
@@ -132,6 +132,7 @@ The following functions are internal helpers used by exported functions:
 - `GET /api/git/range-diff` is served by the OpenChamber web server, so it is available to web, desktop, and mobile clients. The shared `GitAPI.getGitRangeDiff` is therefore optional: web supplies the HTTP implementation, and VS Code does not implement it because the extension host serves Git through its own bridge rather than these routes. Features built on range diffs (currently the AI diff walkthrough) are not offered in VS Code.
 
 ### Staged and unstaged change handling
+- Untracked patches from `getDiff` and `getUntrackedDiffs` use `git diff --no-index` with separate stdout, stderr, and process exit status. Exit codes 0 and 1 return stdout only, so line-ending warnings never become patch text or request failures. Other exits and process failures reject the single-file request; the batch keeps an empty entry for the failed path and preserves the other results.
 - `status.files` exposes both `index` and `working_dir` codes. Shared UI uses these as separate scopes: staged rows are derived from non-empty `index` statuses, while unstaged rows are derived from `working_dir` statuses and untracked files.
 - A file with both staged and unstaged changes can appear in both UI sections. Staged rows request diffs with `staged: true`; unstaged rows request normal working-tree diffs.
 - The shared Git panel exposes explicit staging actions. Unstaged rows use `stageFile`, staged rows use `unstageFile`, and commits operate on the current staged index.

--- a/packages/web/server/lib/git/service.js
+++ b/packages/web/server/lib/git/service.js
@@ -942,7 +942,7 @@ const runGitCommand = async (cwd, args) => {
   } catch (error) {
     return {
       success: false,
-      exitCode: typeof error?.code === 'number' ? error.code : 1,
+      exitCode: Number.isInteger(error?.code) ? error.code : null,
       stdout: String(error?.stdout || ''),
       stderr: String(error?.stderr || ''),
       message: parseGitErrorText(error),
@@ -2465,6 +2465,21 @@ export async function getStatus(directory, options = {}) {
   }
 }
 
+const getNoIndexDiff = async (repoRoot, repoPath, contextLines) => {
+  const args = ['diff', '--no-color'];
+  if (Number.isFinite(contextLines)) {
+    args.push(`-U${Math.max(0, contextLines)}`);
+  }
+  args.push('--no-index', '--', '/dev/null', repoPath);
+  const result = await runGitCommand(repoRoot, args);
+  // Exit 1 means differences, even when Git also writes warnings to stderr.
+  // Spawn and buffer errors have no numeric exit code and must still fail.
+  if (result.exitCode === 0 || result.exitCode === 1) {
+    return result.stdout;
+  }
+  throw new Error(result.stderr || result.message || 'Failed to get untracked Git diff');
+};
+
 export async function getDiff(directory, { path: filePath, staged = false, contextLines = 3 } = {}) {
   const { directoryPath, directoryGit, repoRoot, git } = await createRepositoryGitContext(directory);
 
@@ -2515,21 +2530,7 @@ export async function getDiff(directory, { path: filePath, staged = false, conte
         ].join('\n');
       }
 
-      const noIndexArgs = ['diff', '--no-color'];
-      if (typeof contextLines === 'number' && !Number.isNaN(contextLines)) {
-        noIndexArgs.push(`-U${Math.max(0, contextLines)}`);
-      }
-      noIndexArgs.push('--no-index', '--', '/dev/null', fileContext.repoPath);
-      try {
-        const noIndexDiff = await git.raw(noIndexArgs);
-        return noIndexDiff;
-      } catch (noIndexError) {
-        // git diff --no-index returns exit code 1 when differences exist (not a real error)
-        if (noIndexError.exitCode === 1 && noIndexError.message) {
-          return noIndexError.message;
-        }
-        throw noIndexError;
-      }
+      return await getNoIndexDiff(repoRoot, fileContext.repoPath, contextLines);
     }
   } catch (error) {
     console.error('Failed to get Git diff:', error);
@@ -2578,7 +2579,7 @@ export async function getUntrackedDiffs(directory, filePaths = [], { concurrency
   const paths = (Array.isArray(filePaths) ? filePaths : []).filter((value) => typeof value === 'string' && value);
   if (paths.length === 0) return [];
 
-  const { directoryPath, directoryGit, repoRoot, git } = await createRepositoryGitContext(directory);
+  const { directoryPath, directoryGit, repoRoot } = await createRepositoryGitContext(directory);
   const results = new Array(paths.length).fill('');
   let cursor = 0;
 
@@ -2587,18 +2588,7 @@ export async function getUntrackedDiffs(directory, filePaths = [], { concurrency
       const index = cursor++;
       try {
         const fileContext = await resolveGitFileContext(directoryPath, directoryGit, paths[index], repoRoot);
-        const args = ['diff', '--no-color'];
-        if (typeof contextLines === 'number' && !Number.isNaN(contextLines)) {
-          args.push(`-U${Math.max(0, contextLines)}`);
-        }
-        args.push('--no-index', '--', '/dev/null', fileContext.repoPath);
-        try {
-          results[index] = await git.raw(args);
-        } catch (error) {
-          // `git diff --no-index` exits 1 whenever there are differences, which
-          // for a new file is always.
-          results[index] = error?.exitCode === 1 && error?.message ? error.message : '';
-        }
+        results[index] = await getNoIndexDiff(repoRoot, fileContext.repoPath, contextLines);
       } catch {
         results[index] = '';
       }

--- a/packages/web/server/lib/git/service.test.js
+++ b/packages/web/server/lib/git/service.test.js
@@ -29,6 +29,7 @@ import {
   unstageFiles,
   applyHunk,
   getDiff,
+  getUntrackedDiffs,
   getFileDiff,
   validateWorktreeCreate,
   parseBranchCreationSource,
@@ -354,6 +355,71 @@ describe('applyHunk', () => {
 
     const staged = (await git.raw(['show', `:${filePath}`])).replace(/\r\n/g, '\n');
     expect(staged).toBe(makeFile('TOP', 'line20'));
+  });
+});
+
+describe.runIf(canRunGit())('untracked diffs', () => {
+  it.each(['false', 'warn'])('returns only the patch with core.safecrlf=%s', async (safecrlf) => {
+    const { tmpDir, git } = await createTempRepo();
+    await git.addConfig('core.autocrlf', 'true');
+    await git.addConfig('core.safecrlf', safecrlf);
+    fs.writeFileSync(path.join(tmpDir, 'new file.txt'), 'first\nsecond\n');
+
+    // Confirm this fixture produces a real diff exit, including stderr in the warning case.
+    let expectedPatch;
+    try {
+      runGit(tmpDir, ['diff', '--no-color', '--no-index', '--', '/dev/null', 'new file.txt']);
+      throw new Error('Expected git diff to exit with differences');
+    } catch (error) {
+      expect(error.status).toBe(1);
+      expectedPatch = error.stdout;
+      if (safecrlf === 'warn') {
+        expect(error.stderr).toContain('LF will be replaced by CRLF');
+      }
+    }
+
+    const diff = await getDiff(tmpDir, { path: 'new file.txt' });
+    expect(diff).toBe(expectedPatch);
+    expect(diff).toContain('+first\n+second\n');
+    expect(diff).not.toContain('warning:');
+    expect(await getUntrackedDiffs(tmpDir, ['new file.txt'])).toEqual([diff]);
+  });
+
+  it('accepts an empty untracked file without a process error', async () => {
+    const { tmpDir } = await createTempRepo();
+    fs.writeFileSync(path.join(tmpDir, 'empty.txt'), '');
+    const diff = await getDiff(tmpDir, { path: 'empty.txt' });
+    expect(diff).toContain('new file mode 100644');
+    expect(diff).not.toContain('@@');
+    expect(await getUntrackedDiffs(tmpDir, ['empty.txt'])).toEqual([diff]);
+  });
+
+  it('rejects fatal conversion errors while preserving other batch entries', async () => {
+    const { tmpDir } = await createTempRepo();
+    runGit(tmpDir, ['config', 'diff.broken.textconv', 'false']);
+    fs.writeFileSync(path.join(tmpDir, '.gitattributes'), 'bad.txt diff=broken\n');
+    fs.writeFileSync(path.join(tmpDir, 'first.safe'), 'first\n');
+    fs.writeFileSync(path.join(tmpDir, 'bad.txt'), 'bad\n');
+    fs.writeFileSync(path.join(tmpDir, 'last.safe'), 'last\n');
+
+    await expect(getDiff(tmpDir, { path: 'bad.txt' })).rejects.toThrow('unable to read files to diff');
+    const diffs = await getUntrackedDiffs(tmpDir, ['first.safe', 'bad.txt', 'last.safe'], { concurrency: 1 });
+    expect(diffs).toHaveLength(3);
+    expect(diffs[0]).toContain('+first\n');
+    expect(diffs[1]).toBe('');
+    expect(diffs[2]).toContain('+last\n');
+  });
+
+  it('rejects truncated patches when the process output exceeds the buffer limit', async () => {
+    const { tmpDir } = await createTempRepo();
+    fs.writeFileSync(path.join(tmpDir, 'large.txt'), 'x'.repeat(21 * 1024 * 1024) + '\n');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(getDiff(tmpDir, { path: 'large.txt' })).rejects.toThrow('maxBuffer');
+      expect(await getUntrackedDiffs(tmpDir, ['large.txt'])).toEqual(['']);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
# fix(git): preserve untracked diffs when Git emits warnings

Fixes #3427

## Intent

Opening an untracked file's diff can fail when Git emits an LF-to-CRLF warning. The server treats the valid patch and warning as an exception, while batch requests can silently omit the file from a walkthrough.

Use one private helper for both untracked diff paths. It captures process status, stdout, and stderr separately, accepts `git diff --no-index` exit codes 0 and 1, and returns only stdout. Process failures without a numeric exit code now retain a null status instead of being mislabeled as exit 1.

Five regression cases exercise real Git processes: ordinary diffs, CRLF warnings, empty files, failed text conversion with batch isolation, and output exceeding the command runner's buffer limit.

## Non-goals

Changing Git line-ending configuration, tracked or staged diff behavior, UI rendering, or the VS Code Git implementation. No dependency, public export, route, or persisted-data changes.

## Affected surfaces

- `packages/web/server/lib/git/service.js`: single-file untracked patches and batch untracked patches used by diff walkthroughs.
- Web, Electron, hosted mobile, and Capacitor clients using this server receive valid patches when Git emits warnings. Electron continues to use the existing in-process backend.
- VS Code uses its own `gitService.ts` implementation and is unaffected.
- The single-file response remains `{ diff }`. Batch results remain ordered strings, with an empty string for a failed file.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` | Backend ownership, minimal scope, and validation | Keeps the fix in the owning Git service, preserves unrelated code, adds no dependencies, and leaves changelog files untouched. |
| `openchamber-change-discipline` | Executable server logic and process failure handling | Reuses the existing command runner and one private helper shared by both callers. Tests real subprocess behavior and preserves batch failure isolation. |
| `communication-style`, `unslop` | PR and module documentation | Explains the trigger, resulting behavior, and validation limits directly. |
| `writing-for-agents` | Owning module documentation | Adds the untracked patch contract beside staged and unstaged handling. |
| `packages/web/README.md`, `packages/web/server/lib/git/DOCUMENTATION.md` | Package and Git module ownership | Preserves explicit repository paths, Git binary/environment selection, and documented error behavior. |
| `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md` | Review handoff | Records affected runtimes, exact checks, remaining validation gaps, and failure behavior below. |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web test server/lib/git/service.test.js -t 'untracked diffs'` before the service fix | Reproduced the supplied CRLF warning and `simple-git` stack trace. The warning regression failed while the other three initial cases passed. |
| `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 bun run --cwd packages/web test server/lib/git/service.test.js` | All 97 tests passed, including the five added cases. An earlier run inherited local commit signing and failed on GPG access; the successful run isolated Git configuration without modifying user settings. |
| `node --check packages/web/server/lib/git/service.js` | Passed. |
| `bun run type-check:web` | Passed. |
| `bun run lint:web` | Passed. This package script checks client source, so the server also received the syntax check, real-process tests, and oxlint check. |
| `bun run build:web` | Passed. Reported font-resolution and large-chunk warnings. |
| `bunx oxlint packages/web/server/lib/git/service.js packages/web/server/lib/git/service.test.js` | Reports 46 existing findings in untouched service code. No findings in the new helper, changed exit-status handling, or tests. No rules were suppressed. |
| `bun run dead-code` | Completed and report inspected: 1 unused file, 269 unused exports, 159 unused exported types, and 1 duplicate export. Reported items are outside this change. |

Packaged Electron, Windows, browser/mobile interaction, and workspace-wide suites were not run. The runtime evidence above is from real Git subprocess tests on macOS, not from static checks alone.

## Visual evidence

No screenshots were captured because the reported packaged-app session was not available locally. The supplied failure trace is reproduced by the regression test before the fix. After the fix, that test verifies the returned patch exactly matches Git stdout and contains no warning, for both single-file and batch calls.

Users should now see the previously failing diff. No components, layout, themes, or responsive styles changed; visual confirmation in the packaged app remains outstanding.

## Risks and failure behavior

- Exit codes other than 0 or 1 still fail the single-file request. A failed batch entry remains empty, and later files still produce patches.
- Launch errors and buffer failures cannot masquerade as exit 1. These diff paths now use the existing command runner's 20 MiB output limit; larger patches fail instead of returning truncated content.
- Repository path validation, single-file symlink handling, argument separation, and configured Git environment remain in place. No shell command construction was added.
- These operations read diffs and do not modify repository configuration or files. No migration or data rollback is needed. Reverting the code restores the previous behavior.
