### PR TITLE
chore: upgrade Bun to 1.4.2

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.2
 
       - uses: actions/setup-java@v4
         with:
@@ -50,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -120,7 +120,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.2
 
       - uses: actions/setup-java@v4
         with:
@@ -194,7 +194,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.2
 
       - name: Install dependencies
         run: bun install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1.3.14 AS base
+FROM oven/bun:1.4.2 AS base
 WORKDIR /app
 
 FROM base AS deps
@@ -22,7 +22,7 @@ COPY . .
 RUN bunx patch-package
 RUN bun run build:web
 
-FROM oven/bun:1.3.14 AS runtime
+FROM oven/bun:1.4.2 AS runtime
 WORKDIR /home/openchamber
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenChamber monorepo workspace for web, ui, and desktop runtimes",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.2",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
## Intent

Upgrade Bun from 1.3.14 to 1.4.2 and keep Docker, local tooling, and mobile CI/release pins consistent.

## Non-goals

Application changes, other dependency updates, lockfile regeneration, or replacing Electron and VS Code's Node runtimes.

## Affected surfaces

Both Docker stages, root `packageManager`, and four mobile workflow pins. Application code, `bun.lock`, and persisted data formats are unchanged.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `openchamber-change-discipline` | Cross-workspace toolchain update | Version-only changes, frozen installs, paired baseline/candidate verification |
| `desktop-shell`, Electron README | Linux packaging and startup | Tested real AppImages and native Node-backed terminals with isolated profiles |
| VS Code README and runtime documentation | Extension-host and packaged behavior | Tested a real development host and separately installed VSIX profiles in Code OSS |
| `communication-style` | PR handoff | Concise claims limited to recorded checks |

## Validation

Compared `36327adc` using Bun 1.4.2 against `cab07805` using Bun 1.3.14 on Linux.

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | Passed on both |
| Root isolated test runner and package `bun run test` scripts | All 647 test files passed on both |
| Package `bun run type-check` and `bun run lint` | Passed on both |
| UI/web builds, Electron packaging, `vscode:package`, mobile `build:assets` | Built successfully on both |
| Docker and browser integration | Startup, authentication, real PTY, streaming, cancellation, permissions, uploads, Git operations and restart persistence confirmed |
| Packaged Linux Electron | Startup, native terminal, multiple windows, Mini Chat and renderer reload confirmed |
| VS Code integration | Development-host activation/chat; installed VSIX chat, session-in-editor, Reload Window and persistence confirmed |

Streaming checks used real OpenCode with a local deterministic model fixture.

## Visual evidence

Paired desktop and narrow-browser screenshots covered light/dark themes, chat, settings, dialogs and terminal states. Native captures and interaction recordings were also reviewed.

No intended UI change; application code and the lockfile are unchanged.

## Risks and failure behavior

No Bun 1.4.2-specific regression was identified in the tested Linux scenarios. These checks do not establish complete platform certification.

Rollback consists of reverting the version pins. Verification used isolated data and profiles; test processes and containers were stopped afterward.
