### PR TITLE
fix: keep a manual model selection when the provider list cannot confirm it

### DIFF
--- a/packages/ui/src/stores/DOCUMENTATION.md
+++ b/packages/ui/src/stores/DOCUMENTATION.md
@@ -320,6 +320,20 @@ the chat, the session list and the file tree.
 Failure is still not empty: a failed load restores that directory's previous
 list rather than clearing it.
 
+An incomplete list is not a removal either. A provider refresh can succeed and
+still omit providers — it reloads on reconnect re-bootstrap, on config refresh
+and on directory activation, and a directory scope need not carry every
+provider — so a list without the picked provider in it cannot disprove the
+pick. While `selectionSource` is `manual`, `loadProviders` and
+`resolveSelectionWithManualGuard` keep such a pick rather than re-resolving it;
+only a provider that is present and no longer offers the model counts as a real
+removal. `selectionSource` is persisted alongside the pick, so a reload cannot
+downgrade it to `auto` and hand the next refresh a selection to re-resolve. The
+accepted cost is that a provider removed for good keeps a stuck pick until the
+user chooses another model, and sends then fail visibly — preferred over
+silently substituting the configured default, which the user cannot see and
+which sends under a model they never chose.
+
 ## Selector Rules
 
 Use leaf selectors.

--- a/packages/ui/src/stores/useConfigStore.test.ts
+++ b/packages/ui/src/stores/useConfigStore.test.ts
@@ -1345,4 +1345,130 @@ describe('useConfigStore provider persistence', () => {
     expect(state.currentProviderId).toBe('manual');
     expect(state.selectionSource).toBe('manual');
   });
+
+  test('a manual model survives a provider refresh whose list omits its provider', async () => {
+    // The list reloads on reconnect, on config refresh and on directory
+    // activation, and a directory scope need not carry every provider. A pick
+    // the list cannot confirm used to fall through to the configured default,
+    // and the next send went out under that default as a deliberate choice.
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      currentProviderId: 'plugin-provider',
+      currentModelId: 'plugin-model',
+      selectedProviderId: 'plugin-provider',
+      selectionSource: 'manual',
+      settingsDefaultModel: 'live/live-model',
+      directoryScoped: {},
+    });
+
+    liveProviderId = 'live';
+    await useConfigStore.getState().loadProviders({ source: 'test:partial-provider-list' });
+
+    const state = useConfigStore.getState();
+    expect(state.providers.map((entry) => entry.id)).toEqual(['live']);
+    expect(state.currentProviderId).toBe('plugin-provider');
+    expect(state.currentModelId).toBe('plugin-model');
+    expect(state.directoryScoped[DIRECTORY]?.currentProviderId).toBe('plugin-provider');
+    expect(state.directoryScoped[DIRECTORY]?.currentModelId).toBe('plugin-model');
+  });
+
+  test('a manual model is re-resolved when its provider is present without it', async () => {
+    // The provider answered, so this is a real removal rather than a gap in the
+    // list, and re-resolving is the only way to reach a model that exists.
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      currentProviderId: 'live',
+      currentModelId: 'retired-model',
+      selectedProviderId: 'live',
+      selectionSource: 'manual',
+      directoryScoped: {},
+    });
+
+    liveProviderId = 'live';
+    await useConfigStore.getState().loadProviders({ source: 'test:removed-model' });
+
+    const state = useConfigStore.getState();
+    expect(state.currentProviderId).toBe('live');
+    expect(state.currentModelId).toBe('live-model');
+    expect(state.directoryScoped[DIRECTORY]?.currentModelId).toBe('live-model');
+  });
+
+  test('an empty provider list keeps the manual model while a removed agent re-resolves', async () => {
+    // An empty list confirms nothing about the model, so the pick stays; the
+    // agent list did answer, so a missing agent is a real removal.
+    liveAgents = [testAgent('build')];
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      providers: [],
+      agents: [],
+      currentProviderId: 'plugin-provider',
+      currentModelId: 'plugin-model',
+      currentAgentName: 'retired-agent',
+      selectedProviderId: 'plugin-provider',
+      selectionSource: 'manual',
+      directoryScoped: {
+        [DIRECTORY]: {
+          providers: [],
+          agents: [],
+          currentProviderId: 'plugin-provider',
+          currentModelId: 'plugin-model',
+          currentAgentName: 'retired-agent',
+          selectedProviderId: 'plugin-provider',
+          agentModelSelections: {},
+          defaultProviders: {},
+          selectionSource: 'manual',
+        },
+      },
+    });
+
+    await useConfigStore.getState().loadAgents({ directory: DIRECTORY, source: 'test:empty-provider-list' });
+
+    const state = useConfigStore.getState();
+    expect(state.selectionSource).toBe('manual');
+    expect(state.currentAgentName).toBe('build');
+    expect(state.directoryScoped[DIRECTORY]?.currentProviderId).toBe('plugin-provider');
+    expect(state.directoryScoped[DIRECTORY]?.currentModelId).toBe('plugin-model');
+  });
+
+  test('an automatic selection still re-resolves to the configured default', async () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      currentProviderId: 'plugin-provider',
+      currentModelId: 'plugin-model',
+      selectedProviderId: 'plugin-provider',
+      selectionSource: 'auto',
+      settingsDefaultModel: 'live/live-model',
+      directoryScoped: {},
+    });
+
+    liveProviderId = 'live';
+    await useConfigStore.getState().loadProviders({ source: 'test:auto-selection' });
+
+    const state = useConfigStore.getState();
+    expect(state.currentProviderId).toBe('live');
+    expect(state.currentModelId).toBe('live-model');
+  });
+
+  test('the selection source survives a persist and rehydrate cycle', async () => {
+    useConfigStore.setState({
+      activeDirectoryKey: DIRECTORY,
+      currentProviderId: 'manual',
+      currentModelId: 'manual-model',
+      selectedProviderId: 'manual',
+      selectionSource: 'manual',
+      directoryScoped: {},
+    });
+
+    const persisted = JSON.parse(storage.get(STORAGE_KEY) ?? '{}');
+    expect(persisted.state.selectionSource).toBe('manual');
+
+    // Restored from the top-level field alone: with no directory snapshot to
+    // lift it from, a reload that forgets the source lets the next provider
+    // refresh re-resolve a pick the user made.
+    useConfigStore.setState({ selectionSource: 'auto' });
+    storage.set(STORAGE_KEY, JSON.stringify(persisted));
+    await useConfigStore.persist.rehydrate();
+
+    expect(useConfigStore.getState().selectionSource).toBe('manual');
+  });
 });

--- a/packages/ui/src/stores/useConfigStore.ts
+++ b/packages/ui/src/stores/useConfigStore.ts
@@ -150,6 +150,38 @@ const hasProviderModel = (
     return provider.models.some((model) => model.id === modelId);
 };
 
+const hasProvider = (providers: ProviderWithModelList[], providerId: string): boolean => (
+    providers.some((item) => item.id === providerId)
+);
+
+/**
+ * Whether this list is unable to say anything about a picked model.
+ *
+ * The provider list is not always complete: it reloads on reconnect
+ * re-bootstrap, on config refresh, and on directory activation, and a
+ * directory scope need not carry every provider. `hasProviderModel` answers
+ * false for a missing provider and for a removed model alike, so on its own it
+ * cannot tell an incomplete list from a model the user really lost.
+ *
+ * The two are distinguishable by the provider:
+ *
+ * - provider absent, or list empty — the list is incomplete, keep the pick
+ * - provider present without the model — a real removal, re-resolve
+ *
+ * Deliberate trade-off: a provider that is gone for good now keeps a stuck pick
+ * until the user selects another model, and sends fail visibly. That is
+ * preferred over silently swapping in the configured default, which the user
+ * cannot see and which then sends under a model they never chose. Nothing here
+ * bounds or expires that state on the user's behalf.
+ */
+const isUnconfirmableSelection = (
+    providers: ProviderWithModelList[],
+    providerId: string,
+    modelId: string,
+): boolean => (
+    !!providerId && !!modelId && !hasProvider(providers, providerId)
+);
+
 const resolveProviderModelSelection = ({
     providers,
     currentProviderId,
@@ -946,10 +978,15 @@ const resolveSelectionWithManualGuard = ({
     const manualAgentName = currentAgentName && agents.some((agent) => agent.name === currentAgentName)
         ? currentAgentName
         : undefined;
-    const manualModelValid = !!currentProviderId
+    const manualModelConfirmed = !!currentProviderId
         && !!currentModelId
         && hasProviderModel(providers, currentProviderId, currentModelId)
         && hasValidVariant(providers, currentProviderId, currentModelId, currentVariant);
+    // A list that does not carry the picked provider at all cannot disprove the
+    // pick, so an unconfirmable one survives; only a provider that is present
+    // and no longer offers the model re-resolves.
+    const manualModelValid = manualModelConfirmed
+        || isUnconfirmableSelection(providers, currentProviderId, currentModelId);
     const preserveManual = selectionSource === "manual" && (!!manualAgentName || manualModelValid);
 
     return {
@@ -1609,14 +1646,25 @@ export const useConfigStore = create<ConfigStore>()(
                                 const currentVariant = state.activeDirectoryKey === directoryKey
                                     ? state.currentVariant
                                     : baseSnapshot.currentVariant;
-                                const resolvedModel = resolveProviderModelSelection({
-                                    providers: processedProviders,
-                                    currentProviderId,
-                                    currentModelId,
-                                    currentVariant,
-                                    settingsDefaultModel: state.settingsDefaultModel,
-                                    settingsDefaultVariant: state.settingsDefaultVariant,
-                                });
+                                const selectionSource = state.activeDirectoryKey === directoryKey
+                                    ? state.selectionSource
+                                    : (baseSnapshot.selectionSource ?? "auto");
+                                // A refresh that omits the picked provider entirely is an
+                                // incomplete list, not a removal. Re-resolving on it replaced a
+                                // deliberate choice with the configured default, and the next
+                                // send went out under that default as if the user had picked it.
+                                const keepUnconfirmedManualModel = selectionSource === "manual"
+                                    && isUnconfirmableSelection(processedProviders, currentProviderId, currentModelId);
+                                const resolvedModel = keepUnconfirmedManualModel
+                                    ? { providerId: currentProviderId, modelId: currentModelId, variant: currentVariant }
+                                    : resolveProviderModelSelection({
+                                        providers: processedProviders,
+                                        currentProviderId,
+                                        currentModelId,
+                                        currentVariant,
+                                        settingsDefaultModel: state.settingsDefaultModel,
+                                        settingsDefaultVariant: state.settingsDefaultVariant,
+                                    });
                                 const currentSelectedProviderId = state.activeDirectoryKey === directoryKey
                                     ? state.selectedProviderId
                                     : baseSnapshot.selectedProviderId;
@@ -3425,6 +3473,9 @@ export const useConfigStore = create<ConfigStore>()(
                     selectedProviderId: sanitizePersistedSelectedProviderId(state.selectedProviderId),
                     agentModelSelections: state.agentModelSelections,
                     defaultProviders: state.defaultProviders,
+                    // Persisted with the pick it describes: a reload that restores a manual
+                    // model but calls it "auto" lets the next provider refresh re-resolve it.
+                    selectionSource: state.selectionSource,
                     settingsDefaultModel: state.settingsDefaultModel,
                     settingsDefaultVariant: state.settingsDefaultVariant,
                     settingsDefaultAgent: state.settingsDefaultAgent,


### PR DESCRIPTION
## Intent

A manually chosen model could be replaced mid-session with the configured default, and the next message was then sent under that default as though the user had chosen it.

Nothing surfaced the substitution. The send path records the model on the user message, so after the fact the swapped turn is indistinguishable from a deliberate switch, and on a paid model the user is billed for a choice they never made. In one deployment this happened 23 times across the 300 most recent sessions, each time as a single message sent under the configured default while sitting between messages sent under a different, deliberately selected model. The user confirmed they had not touched the model picker.

After this change, a deliberate selection survives a provider list that cannot confirm it, and is re-resolved only when the provider is present and genuinely no longer offers the model.

## Non-goals

- **The `ModelControls` restore effect is unchanged.** It re-applies a session's saved model and can produce a similar symptom in the opposite direction. It is a separate mechanism and deserves its own change.
- **No bound or expiry on the preserved pick.** See the trade-off under Risk; adding machinery to age it out would be a design decision beyond this fix.
- **No change to the send path.** It already attaches the model synchronously at submit and refuses to send an empty selection; it was never the source of the wrong value.
- **`changelog/` untouched**, per `AGENTS.md`.

## Affected surfaces

- **Package:** `packages/ui` only. No web, electron, vscode or mobile code is touched.
- **Module:** `packages/ui/src/stores/useConfigStore.ts`, at two re-resolution sites and `partialize`.
- **Persisted contract:** `selectionSource` is added to the persisted state. This is forward and backward compatible: the reader is `merge`, so an older persisted blob without the key falls through to the current value, and the existing directory-snapshot lift still takes precedence where a snapshot carries it. No migration and no persist version bump is required, and this repo's persist config declares neither.
- **User-visible state:** the model shown in the picker, and the model a message is actually sent with, now agree after a provider refresh that omits the selected provider.

## Repository guidance

Read before editing, per `AGENTS.md`: `.agents/skills/openchamber-change-discipline/SKILL.md`, `.agents/skills/sync-state-invariants/SKILL.md`, `packages/ui/src/stores/DOCUMENTATION.md`, and `packages/ui/src/sync/DOCUMENTATION.md` (named as required context by `sync-state-invariants`).

Three Correctness Invariants apply directly:

- **"Never let fetch failure masquerade as authoritative empty success."** This is the bug, in a form the existing code did not cover. `loadProviders` already preserves the previous list on a failed load, but a *successful* response for a narrower scope was still being treated as proof that the pick is invalid. `sync-state-invariants` puts it more sharply: never infer a disappearance event from a filtered subset or a partially loaded scope. A directory-scoped provider list is exactly that.
- **"Prefer authoritative state over heuristics."** The change does not guess. `selectionSource === "manual"` is a recorded fact about who made the choice, and the incomplete-versus-removed distinction is structural rather than probabilistic. A provider that is present and no longer lists the model *is* authoritative within that scope, and that case still re-resolves.
- **"Scope temporary fallbacks narrowly and clear them when authoritative state arrives."** The keep requires manual source, a non-empty pick, and an absent provider together. It is not a latch: the first refresh whose list carries that provider resolves normally in either direction, so authoritative state ends it with no expiry machinery.

`openchamber-change-discipline` classifies this as local implementation plus a persisted-behaviour change, which is why the persisted contract is spelled out above. Its test-design guidance asks for observable contracts rather than internal shape, so every test drives `loadProviders`, `loadAgents` or `persist.rehydrate()` and none calls the new helpers directly. `stores/DOCUMENTATION.md` is updated because a store invariant changed, as `AGENTS.md` requires.

## Validation

Run in this worktree, with results:

| Command | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | exit 0, no output |
| `bunx eslint` on both changed source files | exit 0, no findings |
| `bun run --cwd packages/ui test` | **427/427 test files passed** |
| `bun test packages/ui/src/stores/useConfigStore.test.ts` | 40 pass, 0 fail |
| `bun test packages/ui/src/sync/session-actions.test.ts` | 93 pass, 0 fail |
| `bun test packages/ui/src/hooks/useQueuedMessageAutoSend.test.ts` | 16 pass, 0 fail |

Pristine `main` at `a4b65a44f` was measured on the same machine first: `packages/ui` 427/427, so the UI result above is unchanged from baseline rather than merely green.

**The new tests were mutation-tested**, because a passing suite proves nothing by itself. Reverting the guard widening in a working copy, with an assertion that the anchor text actually matched so the mutation could not be a silent no-op, failed exactly the discriminating test and left the rest passing; restoring returned 40/40. Reverting all three source sites failed three tests, and the two that pass either way are the ones that exist to prove a real removal and an `auto` selection still re-resolve normally.

**Not verified, stated plainly:**

- **No runtime or browser verification.** Static checks and unit tests do not prove the production symptom is gone. The reconnect and directory-activation sequences were not reproduced against a real server.
- **The stuck-pick failure mode is reasoned, not exercised.** No test drives a send under a permanently removed provider, so "sends fail visibly" rests on reading the send path, not on observing it.
- **No visual evidence.** The change has no static visual state to compare: the observable difference is which model identifier a later request carries. A screenshot of the model picker would look identical before and after, and staging the failure needs a provider list that transiently omits a provider, which cannot be captured honestly as a before/after image. The behavioural difference is covered by the tests above instead.

## Risk and failure behavior

**Accepted trade-off, deliberate and commented in the source.** A provider removed for good now keeps a stuck pick until the user selects another model, and sends then fail visibly against the missing provider. That is preferred over the current behaviour, where the selection is silently swapped for the configured default, the user cannot detect it, and the message goes out under a model they did not choose. Recovery is one interaction with the model picker, which sets the selection and clears the condition.

**Blast radius.** The store feeds every send, so the change is small on purpose: it only ever *widens* the branch that keeps an existing selection, and only when the list cannot speak to that selection. No path that previously kept a pick now discards one.

**Compatibility.** The added persisted key is additive, needs no migration, and an older client reading newer persisted state simply ignores it.

**Rollback.** Reverting the commit restores the previous behaviour exactly; the persisted key becomes inert rather than harmful.
