### PR TITLE
test(ui): pin buffer reset when a project action reruns

### DIFF
--- a/packages/ui/src/stores/useTerminalStore.test.ts
+++ b/packages/ui/src/stores/useTerminalStore.test.ts
@@ -386,6 +386,25 @@ describe('terminal state reconciliation', () => {
     expect(tab.purpose).toEqual({ type: 'project-action', actionId: 'build', executionId: secondExecution });
   });
 
+  // Regression for openchamber/openchamber#3448: a rerun reuses the tab id as
+  // the server session id, and the recreated server session restarts its
+  // sequence counter at zero. If allocateActionExecution kept the old buffer,
+  // the stale lastSequence would reject the new run's attach snapshot and its
+  // later output would be appended over the previous run's screen.
+  test('starting a rerun drops prior output so its sequence-zero snapshot is accepted', () => {
+    const tabId = setup();
+    useTerminalStore.getState().setTabPurpose('/repo', tabId, { type: 'project-action', actionId: 'build', executionId: 'exec-old' });
+    useTerminalStore.getState().setTabSessionId('/repo', tabId, tabId, { expectedExecutionId: 'exec-old' });
+    useTerminalStore.getState().appendToBuffer('/repo', tabId, 'old output', 5);
+
+    useTerminalStore.getState().allocateActionExecution('/repo', tabId, 'build');
+
+    expect(buffer(tabId).chunks).toEqual([]);
+    useTerminalStore.getState().replaceBuffer('/repo', tabId, 'new snapshot', 0);
+    expect(buffer(tabId).chunks.map((chunk) => chunk.data)).toEqual(['new snapshot']);
+    expect(buffer(tabId).lastSequence).toBe(0);
+  });
+
   test('applies snapshots atomically and deduplicates output by sequence', () => {
     const tabId = setup();
     useTerminalStore.getState().replaceBuffer('/repo', tabId, 'prompt', 4);


### PR DESCRIPTION
## Intent

Closes #3448 with a regression test. The superimposed-output bug on action re-run (previous run's screen mixed into the new run) was fixed by #3362, but that PR shipped without a store-level test for the local re-run path. This adds one: starting a new execution drops the tab's old buffer, so the recreated session's sequence-zero attach snapshot is accepted instead of being rejected as stale and appended over the old screen.

The test pins the exact production shape: the tab id doubles as the server session id, so `setTabSessionId`'s change-of-id buffer reset never fires on a re-run and `allocateActionExecution` must do the drop itself.

## Non-goals

No source changes. Reconciliation-path buffer behavior (rebind drops, same-run preservation) is already covered by the tests #3362 added.

## Affected surfaces

`packages/ui` test code only (`useTerminalStore.test.ts`). No runtime, contract, or persisted behavior changes on any surface.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Any source modification | Smallest complete change: one test, no speculative source edits; an earlier draft broadened non-action rebind drops but was cut for lack of a reproducing scenario |
| `sync-state-invariants` | Terminal buffer lifecycle and sequence reconciliation | Test asserts the owner-side transition (`allocateActionExecution`) enforces the incarnation boundary, matching the documented invariant that buffers belong to the tab's current session |
| `packages/ui/src/stores/DOCUMENTATION.md` | Owning module docs | Test exercises `getBuffer`/`replaceBuffer`/`appendToBuffer` through the public store API, consistent with the documented buffer ownership invariants |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/stores/useTerminalStore.test.ts` | 42 pass, 0 fail |
| `bun run type-check:ui` | pass |
| `bunx oxlint packages/ui/src/stores/useTerminalStore.test.ts` | pass |
| Test fails without the #3362 fix | verified by analysis of the pre-#3362 code (`replaceBuffer` rejects `lastSequence > sequence`); the branch this was investigated on reproduced the user-visible superimposition |

## Visual evidence

No visible change; test-only diff cannot affect rendered behavior. The bug this guards against is pictured in #3448.

## Risks and failure behavior

None identified: the diff adds one deterministic store test with no shared fixtures or timing dependence.
