### PR TITLE
fix(chat): keep image export working with external links

### DIFF
--- a/packages/ui/src/components/chat/markdown/decorate.ts
+++ b/packages/ui/src/components/chat/markdown/decorate.ts
@@ -2,6 +2,7 @@ import { copyTextToClipboard } from '@/lib/clipboard';
 import { getExternalFaviconUrl, isExternalHttpUrl, isLoopbackHttpUrl } from '@/lib/url';
 import { dropdownMenuItemClass, dropdownMenuPopupClass } from '@/components/ui/dropdown-menu.styles';
 import type { IconName } from '@/components/icon/icons';
+import { MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE } from '../message/imageExport';
 import { getMermaidViewerController } from './mermaidViewer';
 
 // ---------------------------------------------------------------------------
@@ -581,6 +582,7 @@ const decorateLinks = (root: HTMLElement, ctx: DecorateContext): void => {
     const faviconUrl = getExternalFaviconUrl(href);
     if (faviconUrl) {
       const favWrap = document.createElement('span');
+      favWrap.setAttribute(MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE, 'true');
       favWrap.className =
         'mr-1 inline-flex size-[18px] items-center justify-center rounded border border-[var(--border)] bg-[var(--interactive-hover)] align-middle';
       const img = document.createElement('img');

--- a/packages/ui/src/components/chat/message/MessageBody.tsx
+++ b/packages/ui/src/components/chat/message/MessageBody.tsx
@@ -57,6 +57,7 @@ import { useProviderLogo } from '@/hooks/useProviderLogo';
 import { getAgentColor } from '@/lib/agentColors';
 import { isCapacitorMobileApp } from '@/apps/mobileNativeChrome';
 import { WorktreeRequiresGitRepositoryError } from '@/lib/worktrees/worktreeCreate';
+import { cloneMessageImageExportSource } from './imageExport';
 
 
 const CONTAIN_LAYOUT_STYLE = { contain: 'layout' as const, transform: 'translateZ(0)' };
@@ -1502,7 +1503,7 @@ const AssistantMessageBody = React.memo(({
                     display: inline-block;
                 `;
 
-                const clone = originalElement.cloneNode(true) as HTMLElement;
+                const clone = cloneMessageImageExportSource(originalElement);
                 clone.style.cssText = `
                     ${computedStyle.cssText}
                     transform: none;

--- a/packages/ui/src/components/chat/message/imageExport.test.ts
+++ b/packages/ui/src/components/chat/message/imageExport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { Window } from 'happy-dom';
+
+import { decorateMarkdown } from '../markdown/decorate';
+import { cloneMessageImageExportSource, MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE } from './imageExport';
+
+Object.assign(globalThis, { document: new Window().document });
+
+describe('message image export', () => {
+    test('marks external-link favicons as export-only decoration', () => {
+        const source = document.createElement('div');
+        source.innerHTML = '<p><a href="https://example.com/docs">Documentation</a></p>';
+
+        decorateMarkdown(source, {
+            labels: {
+                copy: 'Copy',
+                copied: 'Copied',
+                enableCodeWrap: 'Wrap',
+                disableCodeWrap: 'Do not wrap',
+                copyTable: 'Copy table',
+                downloadTable: 'Download table',
+                copyDiagram: 'Copy diagram',
+                downloadDiagram: 'Download diagram',
+                zoomInDiagram: 'Zoom in',
+                zoomOutDiagram: 'Zoom out',
+                resetDiagramView: 'Reset',
+                previewLabel: 'Preview',
+                previewTitle: 'Preview',
+            },
+            mermaidControls: { download: false, copy: false, showPanZoomControls: false },
+            codeBlockLineWrap: false,
+            renderMermaid: () => ({}),
+        });
+
+        const favicon = source.querySelector(`span[${MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE}="true"] > img`);
+        expect(favicon?.getAttribute('src')).toBe('https://icons.duckduckgo.com/ip3/example.com.ico');
+    });
+
+    test('omits marked decoration from the clone without removing content or mutating the source', () => {
+        const source = document.createElement('div');
+        source.innerHTML = `
+            <span ${MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE}="true">
+                <img src="https://icons.duckduckgo.com/ip3/example.com.ico" alt="">
+            </span>
+            <p>Message content</p>
+            <img src="data:image/png;base64,content" alt="Message image">
+        `;
+
+        const clone = cloneMessageImageExportSource(source);
+
+        expect(Boolean(clone.querySelector(`[${MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE}="true"]`))).toBe(false);
+        expect(Boolean(clone.querySelector('img[src^="https://icons.duckduckgo.com/"]'))).toBe(false);
+        expect(clone.textContent).toContain('Message content');
+        expect(Boolean(clone.querySelector('img[alt="Message image"]'))).toBe(true);
+        expect(Boolean(source.querySelector(`[${MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE}="true"]`))).toBe(true);
+    });
+});

--- a/packages/ui/src/components/chat/message/imageExport.ts
+++ b/packages/ui/src/components/chat/message/imageExport.ts
@@ -1,0 +1,10 @@
+export const MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE = 'data-message-image-export-exclude';
+
+export const cloneMessageImageExportSource = (source: HTMLElement): HTMLElement => {
+    // SAFETY: cloneNode preserves the concrete type of an HTMLElement source.
+    const clone = source.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll(`[${MESSAGE_IMAGE_EXPORT_EXCLUDE_ATTRIBUTE}="true"]`).forEach((element) => {
+        element.remove();
+    });
+    return clone;
+};


### PR DESCRIPTION
## Intent

<!-- What user or maintainer problem does this solve? What behavior changes? -->

Keep message image export working when rendered Markdown contains an external-link favicon. The export clone now drops that decorative remote image before `html-to-image` processes resources, so the browser does not attempt the CORS-blocked favicon fetch.

## Non-goals

<!-- What nearby behavior is intentionally outside this PR? Write "None" only when the scope is unambiguous. -->

- Do not change how favicons render in chat.
- Do not proxy or rewrite third-party image requests.
- Do not suppress failures from message images that are part of the exported content.

## Affected surfaces

<!-- Name affected packages, runtimes, user-visible states, and persisted/external contracts. Explain why an apparently applicable runtime is unaffected. -->

`packages/ui` message image export is affected. The clone preparation runs before the runtime-specific save or share branch, so web, desktop, VS Code, hosted mobile, and Capacitor use the same behavior. The on-screen message DOM, persisted data, API contracts, authentication, and runtime transports are unchanged. Exported images omit the decorative external-link favicon but retain message text and content images.

## Repository guidance

<!-- List the AGENTS.md rules, matching project skills, required skill references, and nearest README/DOCUMENTATION.md files used for this change. Explain why each applies and the important constraints you followed. Do not merely list filenames. -->

| Guidance | Why it applies | How the change complies |
|---|---|---|
|  |  |  |
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes executable shared UI source and adds a focused module. | The change stays in the owning UI code, adds no dependency or public package contract, and uses focused tests plus package-level static checks. |
| `ui-api-decoupling` and `references/browser-assets-and-auth.md` | The failure starts with a third-party browser image that JavaScript cannot read across origins. | The fix does not proxy the favicon, add credentials, rewrite runtime URLs, or weaken the browser security boundary. It removes only the marked decoration from the export clone. |
| `diagnose` | This is a reported export failure with a known external-resource trigger. | A regression test established the failing clone behavior before the fix. Two one-variable ablations confirmed that both the marker and clone cleanup are necessary. |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | `MessageBody.tsx` owns message-part rendering and documents how assistant Markdown handles images. | The fix preserves on-screen Markdown and gallery behavior. It changes only the temporary image-export clone. |
| `CONTRIBUTING.md` | The PR changes shared UI behavior. | The PR names affected runtimes, exact validation results, omitted checks, and failure behavior. |

## Validation

<!-- Report exact commands/manual checks and results. State what was not verified. Do not claim runtime behavior from type-check/lint alone. -->

| Check | Result |
|---|---|
|  |  |
| `bun test src/components/chat/message/imageExport.test.ts` from `packages/ui` | Passed: 2 tests and 6 expectations. The tests assert that Markdown favicons receive the export-only marker, the export clone omits the remote favicon, content images remain, and the original DOM is unchanged. |
| Ablation with the same focused test | Removing the favicon marker produced 1 failure. Restoring the marker and removing clone cleanup produced 1 failure. Restoring both produced 2 passing tests. |
| `bun run type-check` from `packages/ui` | Passed. |
| `bun run lint` from `packages/ui` | Passed with 0 errors. It reported one unrelated existing `react-hooks/exhaustive-deps` warning in `MobileChangesSurface.tsx:212`. |
| Targeted ESLint for the four changed files | Passed with no output. |
| `bunx oxlint packages/ui/src/components/chat/message/imageExport.ts packages/ui/src/components/chat/message/imageExport.test.ts` | Passed with no output. A broader changed-file run still reports existing anti-slop findings outside the changed lines in `MessageBody.tsx` and `decorate.ts`. |
| `bun run dead-code` | Completed. It reported no finding for the new `imageExport` module; the repository's existing non-blocking report remains. |
| Full workspace test/build and a real Chromium export | Not run. The focused DOM test proves that the CORS-triggering remote image is absent before `html-to-image` runs, but it is not an end-to-end browser export. |

## Visual evidence

<!-- User-visible change: attach current before/after screenshots or recordings for the affected desktop/mobile, narrow/wide, theme, and interaction states. No visible change: explain concretely why the diff cannot affect rendered behavior. -->

Not included. This changes export success or failure and removes a non-critical favicon only from the off-screen export clone. Deterministic DOM assertions prove the relevant contract better than a screenshot: the remote favicon is absent while message content, content images, and the on-screen source DOM remain intact.

## Risks and failure behavior

<!-- Cover relevant failure, rollback, cleanup, compatibility, security, performance, data-loss, and cross-runtime concerns. State "None identified" only with a concrete reason. -->

The exported PNG no longer includes external-link favicons. The selector only removes elements carrying the dedicated export-exclusion marker, so other images keep the existing `html-to-image` failure behavior rather than being silently ignored. On-screen favicons still load normally. The temporary wrapper cleanup remains in `MessageBody`'s existing `finally` block. There are no persisted-data, API, authentication, dependency, or migration changes. Reverting this commit restores the previous export behavior.
