### PR TITLE
fix: read a user message's model from its nested model field

### DIFF
--- a/packages/ui/src/components/chat/ChatMessage.tsx
+++ b/packages/ui/src/components/chat/ChatMessage.tsx
@@ -38,6 +38,7 @@ import { getContextObligatoryMessages } from '@/lib/contextObligatoryMessages';
 import { setContextObligatoryMessage } from '@/sync/session-actions';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { focusChatInput } from './composer/editor/dom';
+import { readUserMessageModelFields } from './userMessageModelFields';
 
 const ToolOutputDialog = lazyWithChunkRecovery(() => import('./message/ToolOutputDialog'));
 
@@ -236,16 +237,14 @@ const ChatMessage: React.FC<ChatMessageProps> = ({
 
         const mode = getMessageInfoProp(previousMessage.info, 'mode');
         const agent = getMessageInfoProp(previousMessage.info, 'agent');
-        const providerID = getMessageInfoProp(previousMessage.info, 'providerID');
-        const modelID = getMessageInfoProp(previousMessage.info, 'modelID');
-        const variant = getMessageInfoProp(previousMessage.info, 'variant');
+        const userModel = readUserMessageModelFields(previousMessage.info);
         const resolvedAgent =
             typeof mode === 'string' && mode.trim().length > 0
                 ? mode
                 : (typeof agent === 'string' && agent.trim().length > 0 ? agent : undefined);
-        const resolvedProvider = typeof providerID === 'string' && providerID.trim().length > 0 ? providerID : undefined;
-        const resolvedModel = typeof modelID === 'string' && modelID.trim().length > 0 ? modelID : undefined;
-        const resolvedVariant = typeof variant === 'string' && variant.trim().length > 0 ? variant : undefined;
+        const resolvedProvider = userModel.providerID;
+        const resolvedModel = userModel.modelID;
+        const resolvedVariant = userModel.variant;
 
         if (!resolvedAgent && !resolvedProvider && !resolvedModel && !resolvedVariant) {
             return null;

--- a/packages/ui/src/components/chat/userMessageModelFields.test.ts
+++ b/packages/ui/src/components/chat/userMessageModelFields.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { readUserMessageModelFields } from './userMessageModelFields';
+
+describe('readUserMessageModelFields', () => {
+    test('reads nested model fields from a server-confirmed user message', () => {
+        expect(readUserMessageModelFields({
+            providerID: 'ignored-provider',
+            modelID: 'ignored-model',
+            variant: 'ignored-variant',
+            model: {
+                providerID: 'anthropic',
+                modelID: 'claude-sonnet-4-6',
+                variant: 'high',
+            },
+        })).toEqual({
+            providerID: 'anthropic',
+            modelID: 'claude-sonnet-4-6',
+            variant: 'high',
+        });
+    });
+
+    test('falls back to top-level fields when model is a provider/model string', () => {
+        expect(readUserMessageModelFields({
+            providerID: 'anthropic',
+            modelID: 'claude-sonnet-4-6',
+            variant: 'high',
+            model: 'anthropic/claude-sonnet-4-6',
+        })).toEqual({
+            providerID: 'anthropic',
+            modelID: 'claude-sonnet-4-6',
+            variant: 'high',
+        });
+    });
+
+    test('does not throw when model is null, absent, or a non-object, and falls back', () => {
+        const topLevel = {
+            providerID: 'openai',
+            modelID: 'gpt-4.1',
+            variant: 'none',
+        };
+
+        expect(readUserMessageModelFields({ ...topLevel, model: null })).toEqual(topLevel);
+        expect(readUserMessageModelFields(topLevel)).toEqual(topLevel);
+        expect(readUserMessageModelFields({ ...topLevel, model: false })).toEqual(topLevel);
+    });
+});

--- a/packages/ui/src/components/chat/userMessageModelFields.ts
+++ b/packages/ui/src/components/chat/userMessageModelFields.ts
@@ -1,0 +1,47 @@
+type UserMessageModelFields = {
+    providerID?: string;
+    modelID?: string;
+    variant?: string;
+};
+
+type NestedUserModel = {
+    providerID?: string;
+    modelID?: string;
+    variant?: string;
+};
+
+type UserMessageModelSource = {
+    providerID?: string;
+    modelID?: string;
+    variant?: string;
+    model?: NestedUserModel | string | number | boolean | null;
+};
+
+const parseNonEmptyString = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+};
+
+const readNestedUserModel = (model: UserMessageModelSource['model']): NestedUserModel | undefined => {
+    if (model === null || model === undefined) return undefined;
+    if (Array.isArray(model)) return undefined;
+    if (model instanceof Object) return model;
+    return undefined;
+};
+
+/**
+ * Read providerID, modelID, and variant from a user message.
+ *
+ * Server-confirmed user messages nest these under `model`. Optimistic user
+ * messages set the same fields at the top level and set `model` to a
+ * "provider/model" string. Non-object `model` values are ignored so the
+ * top-level fallback wins.
+ */
+export const readUserMessageModelFields = (info: UserMessageModelSource): UserMessageModelFields => {
+    const nested = readNestedUserModel(info.model);
+    return {
+        providerID: parseNonEmptyString(nested?.providerID) ?? parseNonEmptyString(info.providerID),
+        modelID: parseNonEmptyString(nested?.modelID) ?? parseNonEmptyString(info.modelID),
+        variant: parseNonEmptyString(nested?.variant) ?? parseNonEmptyString(info.variant),
+    };
+};

--- a/packages/ui/src/components/chat/userMessageModelFields.ts
+++ b/packages/ui/src/components/chat/userMessageModelFields.ts
@@ -36,6 +36,11 @@ const readNestedUserModel = (model: UserMessageModelSource['model']): NestedUser
  * messages set the same fields at the top level and set `model` to a
  * "provider/model" string. Non-object `model` values are ignored so the
  * top-level fallback wins.
+ *
+ * `extractUserModelChoice` in `lib/messages/userModelChoice.ts` reads the same
+ * message shape for composer restore; keep both in step if that shape changes.
+ * This one stays separate because it also falls back to the top level for an
+ * unconfirmed optimistic message, which composer restore does not want.
  */
 export const readUserMessageModelFields = (info: UserMessageModelSource): UserMessageModelFields => {
     const nested = readNestedUserModel(info.model);

--- a/packages/ui/src/lib/messages/userModelChoice.ts
+++ b/packages/ui/src/lib/messages/userModelChoice.ts
@@ -18,6 +18,10 @@ type MessageLike = Message & {
 
 /**
  * Extract agent/model selection metadata from a user message, if present.
+ *
+ * `readUserMessageModelFields` in `components/chat/userMessageModelFields.ts`
+ * reads the same message shape for assistant footer attribution; keep both in
+ * step if that shape changes.
  */
 export const extractUserModelChoice = (message: MessageLike): UserModelChoice | null => {
   if (message.role !== 'user') {


### PR DESCRIPTION
## Intent

The assistant message footer names the model that produced the reply. When the assistant message carries no top-level `providerID`/`modelID`, it falls back to the previous user message's model through the `previousUserMetadata` memo in `ChatMessage.tsx`.

That fallback never fired. The memo read `providerID`, `modelID` and `variant` from the **top level** of the user message, but a server-confirmed user message nests them under `model`. All three resolved to `undefined`, the first branch of `contextModelSelection` was skipped every time, and the footer silently fell through to the agent or session selection instead. Those can name a different model than the turn was actually sent with, so the footer could confidently attribute a reply to the wrong model.

Nested-first already is the convention here: `MessageList.tsx` reads `info?.model?.variant ?? info?.variant`.

## Non-goals

- **No change to the assistant-metadata branch.** When an assistant message carries its own `providerID`/`modelID`, that still wins, so footers that were already correct are untouched.
- **No change to which model is selected or sent.** This is a display-attribution fix only.
- **`changelog/` untouched**, per `AGENTS.md`.

## Affected surfaces

- **Package:** `packages/ui` only.
- **Modules:** `packages/ui/src/components/chat/ChatMessage.tsx`, plus a new colocated `userMessageModelFields.ts` helper and its test.
- **User-visible state:** the model name shown in an assistant message footer, in the case where the assistant message has no model metadata of its own.
- No persisted, external or runtime contract changes.

## Repository guidance

Read before editing, per `AGENTS.md`: `.agents/skills/openchamber-change-discipline/SKILL.md`. Its "smallest complete change" and "test through a focused contract" guidance is why the read was extracted into a named helper with its own tests rather than expanded inline inside an already-long memo, and why nothing else in `ChatMessage.tsx` was touched.

There is no `DOCUMENTATION.md` covering `ChatMessage` (the nearest chat docs are under `work-status/`, `message/parts/` and `composer/`), and `packages/ui` has no package `README.md`, so no owning documentation needed updating. `theme-system` and `locale-ui-patterns` were considered and not loaded: this is metadata-read logic with no styling and no user-facing copy.

`AGENTS.md` requires `bun run dead-code` when adding source files and `bunx oxlint` on created TypeScript; both were run, see below.

`ChatMessage` has no existing component suite, so the new test file follows the colocated `bun:test` precedent already used by `chatPromptReadOnly.test.ts` and `PermissionCard.test.ts`.

## Validation

| Command | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | exit 0, no output |
| `bunx eslint` on all three changed files | exit 0, no findings |
| `bunx oxlint` on the new helper and test | exit 0, no findings |
| `bun run dead-code` | no new entries; the pre-existing backlog is unchanged |
| `bun run --cwd packages/ui test` | **428/428 test files passed** |
| `bun test src/components/chat/userMessageModelFields.test.ts` | 3 pass, 0 fail |

Pristine `main` at `a4b65a44f` was measured on the same machine first and passed 427/427, so 428/428 is the baseline plus this change's new file, not merely a green run.

**The new tests were mutation-tested.** Reverting the helper's `providerID` read to top-level-only, which reintroduces exactly this bug, with an assertion that the anchor text matched so the mutation could not silently no-op, failed the nested-message test and left the other two passing. Restoring returned 3/3. The two that pass either way are the optimistic-shape and non-object-`model` cases, which exist to protect the fallback rather than the fix.

**Not verified, stated plainly:**

- **The mounted footer was not rendered in a test.** `ChatMessage` has no component suite, so the tests cover the read contract rather than the rendered output.
- **No live payload round-trip** against a running server.
- **No workspace-wide check** beyond `packages/ui`.
- **No visual evidence.** A meaningful before/after image cannot be staged honestly: the difference only appears when an assistant message lacks its own model metadata, so the "before" state is a footer showing a plausible but wrong model name, which is indistinguishable in a screenshot from a correct one without also showing the underlying message record. The read contract is covered by the tests above instead.

## Risk and failure behavior

**Low.** The helper is pure, has no dependencies, and is called from one place. The fallback ordering means every shape that resolved before still resolves: nested wins when present, top level wins otherwise, and a non-object `model` (the optimistic `"provider/model"` string) is ignored rather than indexed.

**Failure mode if wrong:** a footer label names the wrong model, which is the current behaviour, so a regression cannot be worse than the status quo. No send path, selection, or persisted state depends on this value.

**Rollback:** reverting the commit restores the previous behaviour exactly; the new file is unreferenced after revert.
