### PR TITLE
fix(chat): preserve triple-click text selection

### DIFF
--- a/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
+++ b/packages/ui/src/components/chat/message/TextSelectionMenu.tsx
@@ -24,8 +24,11 @@ import { collectSelectionOverlayRects } from '@/lib/selectionOverlayRects';
 import {
   DESKTOP_MENU_FALLBACK_HEIGHT_PX,
   DESKTOP_MENU_FALLBACK_WIDTH_PX,
+  DESKTOP_MENU_SELECTION_GAP_PX,
+  DESKTOP_MENU_SIDE_MARGIN_PX,
   getDesktopClampedX,
   getDesktopClampedY,
+  getDesktopSelectionAnchorY,
 } from './selectionMenuPosition';
 
 interface TextSelectionMenuProps {
@@ -49,6 +52,17 @@ interface SelectionPayload {
 const normalizeDistilledInsight = (insight: string): string => (
   insight.trim().replace(/^[-*+]\s+/, '').slice(0, PROJECT_NOTE_BODY_MAX_LENGTH)
 );
+
+// The browser finalizes the selection just after mouseup, so the menu waits a
+// beat before it reads it.
+const REVEAL_DELAY_MS = 10;
+// A mouseup that closes the second click of a multi-click can still be followed
+// by a third one. Showing the menu between those clicks moves a button under the
+// pointer, where it swallows the click that would have grown the selection, so
+// the menu waits for the sequence to end instead.
+const MULTI_CLICK_REVEAL_DELAY_MS = 300;
+// Distance kept between the menu and the top edge of its container.
+const CONTAINER_TOP_MARGIN_PX = 4;
 
 export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerRef }) => {
   const { t } = useI18n();
@@ -215,6 +229,20 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
       : getDesktopClampedY(anchorY, window.innerHeight, menuHeightRef.current)
   ), []);
 
+  // Topmost screen Y the desktop menu may occupy. Staying inside the message
+  // also keeps a menu near the top of the chat clear of the app header, which
+  // is a window drag zone on the desktop shell. A message scrolled past the top
+  // of the viewport bounds nothing, so the viewport margin is the floor.
+  const getMenuMinTop = React.useCallback(() => {
+    const container = containerRef.current;
+    const containerTop = (container ? container.getBoundingClientRect().top : 0) + CONTAINER_TOP_MARGIN_PX;
+    return Math.max(containerTop, DESKTOP_MENU_SIDE_MARGIN_PX);
+  }, [containerRef]);
+
+  const getDesktopAnchorY = React.useCallback((selection: { top: number; bottom: number }) => (
+    getClampedY(getDesktopSelectionAnchorY(selection, menuHeightRef.current, getMenuMinTop()))
+  ), [getClampedY, getMenuMinTop]);
+
   const addMarkdownToChat = React.useCallback((markdownText: string) => {
     const markdownBlock = wrapMarkdownSelectionForChat(markdownText);
     setPendingInputText(markdownBlock, 'append');
@@ -244,8 +272,8 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
       ? rect.left + rect.width / 2
       : getClampedX(rect.left + rect.width / 2);
     const menuY = isMobile
-      ? rect.top - 10
-      : getClampedY(rect.top - 10);
+      ? rect.top - DESKTOP_MENU_SELECTION_GAP_PX
+      : getDesktopAnchorY(rect);
 
     setSelectedText(plainText);
     setSelectedTextMarkdown(markdownText);
@@ -267,7 +295,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
         openRafRef.current = null;
       });
     }
-  }, [addMarkdownToChat, getClampedX, getClampedY, hideMenu, isMobile, position.show]);
+  }, [addMarkdownToChat, getClampedX, getDesktopAnchorY, hideMenu, isMobile, position.show]);
 
   React.useLayoutEffect(() => {
     if (!position.show || isMobile || !menuRef.current) {
@@ -288,34 +316,17 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     if (heightChanged) {
       menuHeightRef.current = measuredHeight;
     }
+    const selectionRect = pendingSelectionRef.current?.rect;
     setPosition((prev) => ({
       ...prev,
       x: getClampedX(prev.x),
-      y: getClampedY(prev.y),
+      y: selectionRect ? getDesktopAnchorY(selectionRect) : getClampedY(prev.y),
     }));
     // Entering comment mode and typing into the comment box both grow the
-    // popup, so remeasuring on those keeps the cached height (and the Y clamp
-    // built from it) honest.
-  }, [commentMode, commentText, getClampedX, getClampedY, isMobile, position.show]);
-
-  // The desktop popup hangs above its anchor, so a tall comment box near the
-  // top of the chat can climb over the app header. On the desktop shell the
-  // header is a window drag zone, which makes the overlapped part of the
-  // textarea untouchable, so the popup is pushed down until its top edge stays
-  // inside the chat container.
-  React.useLayoutEffect(() => {
-    if (!position.show || isMobile || !menuRef.current) {
-      return;
-    }
-
-    const container = containerRef.current;
-    const minTop = (container ? container.getBoundingClientRect().top : 0) + 4;
-    const menuTop = menuRef.current.getBoundingClientRect().top;
-    if (menuTop < minTop) {
-      const delta = minTop - menuTop;
-      setPosition((prev) => ({ ...prev, y: prev.y + delta }));
-    }
-  }, [containerRef, isMobile, position.show, position.y, commentMode, commentText]);
+    // popup, so remeasuring on those keeps the cached height honest along with
+    // the placement built from it. A taller popup can stop fitting above the
+    // selection and has to move below it.
+  }, [commentMode, commentText, getClampedX, getClampedY, getDesktopAnchorY, isMobile, position.show]);
 
   React.useEffect(() => {
     if (!position.show || isMobile) {
@@ -409,19 +420,24 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
     };
 
     // Track when dragging stops
-    const handleMouseUp = () => {
+    const handleMouseUp = (event: MouseEvent) => {
       isDraggingRef.current = false;
       // Check if we have a pending selection to show
       if (pendingSelectionRef.current) {
         if (mouseUpTimeoutRef.current !== null) {
           window.clearTimeout(mouseUpTimeoutRef.current);
         }
-        // Small delay to ensure selection is finalized
+        const delay = event.detail >= 2 ? MULTI_CLICK_REVEAL_DELAY_MS : REVEAL_DELAY_MS;
         mouseUpTimeoutRef.current = window.setTimeout(() => {
           mouseUpTimeoutRef.current = null;
           // The click that opened the comment input cleared the selection on
           // purpose; the input must survive this deferred check.
           if (commentModeRef.current) {
+            return;
+          }
+          // A fresh drag can start inside the multi-click delay, and it owns
+          // the selection now.
+          if (isDraggingRef.current) {
             return;
           }
           const selection = window.getSelection();
@@ -430,7 +446,7 @@ export const TextSelectionMenu: React.FC<TextSelectionMenuProps> = ({ containerR
           } else {
             hideMenu();
           }
-        }, 10);
+        }, delay);
       }
     };
 

--- a/packages/ui/src/components/chat/message/__tests__/selectionMenuPosition.test.ts
+++ b/packages/ui/src/components/chat/message/__tests__/selectionMenuPosition.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import {
   DESKTOP_MENU_FALLBACK_HEIGHT_PX,
   DESKTOP_MENU_FALLBACK_WIDTH_PX,
+  DESKTOP_MENU_SELECTION_GAP_PX,
   DESKTOP_MENU_SIDE_MARGIN_PX,
   getDesktopClampedX,
   getDesktopClampedY,
+  getDesktopSelectionAnchorY,
 } from '../selectionMenuPosition';
 
 const VIEWPORT_WIDTH = 1024;
@@ -42,6 +44,45 @@ describe('getDesktopClampedY (issue #2257)', () => {
   test('falls back to the viewport middle when the viewport is shorter than the menu', () => {
     const tinyViewportHeight = MENU_HEIGHT;
     expect(getDesktopClampedY(10, tinyViewportHeight, MENU_HEIGHT)).toBe(tinyViewportHeight / 2);
+  });
+});
+
+// Regression coverage for issue #3416: the popup used to be pushed straight
+// down when it did not fit above the selection, which painted it over the
+// selected line. Triple-clicking the first line of a message then landed the
+// third click on a toolbar button instead of the text.
+describe('getDesktopSelectionAnchorY (issue #3416)', () => {
+  // A single line of chat text, and the container top the popup stays below.
+  const LINE = { top: 200, bottom: 226 };
+  const FITS_ABOVE = LINE.top - DESKTOP_MENU_SELECTION_GAP_PX - MENU_HEIGHT;
+  const ABOVE_ANCHOR = LINE.top - DESKTOP_MENU_SELECTION_GAP_PX;
+  const BELOW_ANCHOR = LINE.bottom + DESKTOP_MENU_SELECTION_GAP_PX + MENU_HEIGHT;
+
+  test('anchors above the selection when the popup fits there', () => {
+    expect(getDesktopSelectionAnchorY(LINE, MENU_HEIGHT, FITS_ABOVE)).toBe(ABOVE_ANCHOR);
+    expect(getDesktopSelectionAnchorY(LINE, MENU_HEIGHT, 0)).toBe(ABOVE_ANCHOR);
+  });
+
+  test('flips below the selection when the popup does not fit above it', () => {
+    // The first line of a message: its container starts at the line itself, so
+    // nothing fits in the gap above.
+    expect(getDesktopSelectionAnchorY(LINE, MENU_HEIGHT, LINE.top + 4)).toBe(BELOW_ANCHOR);
+    expect(getDesktopSelectionAnchorY(LINE, MENU_HEIGHT, FITS_ABOVE + 1)).toBe(BELOW_ANCHOR);
+  });
+
+  test('flips a popup that grew taller than the room above the selection', () => {
+    const tallMenu = MENU_HEIGHT * 4;
+    expect(getDesktopSelectionAnchorY(LINE, tallMenu, FITS_ABOVE)).toBe(
+      LINE.bottom + DESKTOP_MENU_SELECTION_GAP_PX + tallMenu,
+    );
+  });
+
+  test('never returns an anchor that paints the popup over the selection', () => {
+    for (const minTop of [-500, 0, 150, FITS_ABOVE, FITS_ABOVE + 1, LINE.top, LINE.bottom, 400]) {
+      const anchorY = getDesktopSelectionAnchorY(LINE, MENU_HEIGHT, minTop);
+      const menuTop = anchorY - MENU_HEIGHT;
+      expect(menuTop < LINE.bottom && anchorY > LINE.top).toBe(false);
+    }
   });
 });
 

--- a/packages/ui/src/components/chat/message/selectionMenuPosition.ts
+++ b/packages/ui/src/components/chat/message/selectionMenuPosition.ts
@@ -1,6 +1,7 @@
 export const DESKTOP_MENU_SIDE_MARGIN_PX = 8;
 export const DESKTOP_MENU_FALLBACK_WIDTH_PX = 280;
 export const DESKTOP_MENU_FALLBACK_HEIGHT_PX = 38;
+export const DESKTOP_MENU_SELECTION_GAP_PX = 10;
 
 export const getDesktopClampedX = (anchorX: number, viewportWidth: number, menuWidth: number): number => {
   const halfWidth = menuWidth / 2;
@@ -26,4 +27,23 @@ export const getDesktopClampedY = (anchorY: number, viewportHeight: number, menu
   }
 
   return Math.min(Math.max(anchorY, minY), maxY);
+};
+
+// The desktop menu prefers to hang above the selection. `minTop` is the topmost
+// screen Y it may occupy; when the menu does not fit above the selection it is
+// placed below it instead of over it. Painting the menu across the selected text
+// hides what the menu acts on and drops a button under the pointer, where it
+// swallows the next click of a multi-click sequence.
+export const getDesktopSelectionAnchorY = (
+  selection: { top: number; bottom: number },
+  menuHeight: number,
+  minTop: number,
+): number => {
+  const above = selection.top - DESKTOP_MENU_SELECTION_GAP_PX;
+
+  if (above - menuHeight >= minTop) {
+    return above;
+  }
+
+  return selection.bottom + DESKTOP_MENU_SELECTION_GAP_PX + menuHeight;
 };


### PR DESCRIPTION
## Intent

Fixes [#3416](https://github.com/openchamber/openchamber/issues/3416). On macOS, the second mouseup of a triple-click can reveal the selection toolbar before the third click. When the selection starts on the first line of a message, the placement clamp can also put the toolbar over that text, so the third click can trigger a toolbar action instead of extending the selection.

This change delays the toolbar during multi-click sequences and places it below the selection when it cannot fit above. A fresh drag also cancels any pending reveal.

## Non-goals

The setting to disable the selection toolbar and the separate `FilePreviewCommentMenu` behavior remain separate work.

## Affected surfaces

This changes the shared desktop selection toolbar in `packages/ui`, used by web, Electron, and the VS Code webview. Mobile keeps its existing bottom-bar placement. No persisted data, routes, package contracts, or external APIs change.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This is executable shared UI code | The change stays local to the owning component and existing positioning module, preserves runtime contracts, and adds focused regression tests for placement |
| `theme-system` | The change affects a UI component | The diff changes only event timing and geometry; existing tokens, controls, icons, and animations remain intact |
| `packages/ui/src/components/chat/message/parts/DOCUMENTATION.md` | It is the nearest chat-message documentation | It covers message part renderers rather than the selection toolbar, so its documented ownership remains accurate |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/message/__tests__/selectionMenuPosition.test.ts` | 12 pass, 0 fail |
| `node scripts/run-isolated-tests.mjs packages/ui/src/components/chat/message` | 15/15 test files passed |
| `bun test packages/ui/src/lib/ime.commentInputs.test.ts packages/ui/src/lib/addSelectionToChat.test.ts` | 15 pass, 0 fail |
| `bunx eslint` on the three changed files | Passed |
| `bunx oxlint` on the three changed files | No new findings; the same five existing `TextSelectionMenu.tsx` findings remain on `origin/main` |
| `bunx tsc --noEmit -p packages/ui/tsconfig.json` | No new errors; the same five existing duplicate-CodeMirror errors remain in `languageByExtension.ts` on `origin/main` |
| `bun run dead-code` | Passed; no changed-file or new-export findings |

## Visual evidence

The animation compares `origin/main` with the amended PR implementation in the same Chromium runtime. The orange ring marks the fixed pointer position. Before the fix, click 2 opens the toolbar under the pointer and click 3 activates it, clearing the selection. After the fix, click 2 keeps the toolbar hidden, click 3 selects the full sentence, and the settled toolbar appears below the text.

![Before and after triple-click behavior](https://github.com/user-attachments/assets/91193a3a-7f74-4c89-93e2-23ec991694ab)

## Risks and failure behavior

The 300 ms multi-click delay is a heuristic because browsers do not expose the macOS click interval. It adds latency after a double-click but leaves drag selection on the existing 10 ms path. The placement change keeps slower sequences safe by moving the toolbar away from the selected line. Tall selections can move the toolbar below the selection, with the existing viewport clamp keeping it visible.

## References

- [Issue #3416](https://github.com/openchamber/openchamber/issues/3416)
