### PR TITLE
fix(ui): bound runtime reads so a hung request cannot wedge caches

### DIFF
--- a/packages/ui/src/lib/opencode/client.ts
+++ b/packages/ui/src/lib/opencode/client.ts
@@ -31,6 +31,7 @@ export type FetchPermissionResult =
   | { state: "unknown" };
 import { getRuntimeUrlResolver } from "@/lib/runtime-url";
 import { runtimeFetch } from "@/lib/runtime-fetch";
+import { createTimeoutSignal, isEventStreamUrl, RUNTIME_READ_TIMEOUT_MS } from "@/lib/runtime-read-timeout";
 import { getRuntimeKey } from "@/lib/runtime-switch";
 import { getRegisteredRuntimeAPIs } from "@/contexts/runtimeAPIRegistry";
 import { markStartupTrace } from "@/lib/startupTrace";
@@ -170,44 +171,6 @@ const resolveRuntimeBaseUrl = (): string | null => {
   }
 };
 
-type AbortSignalConstructorWithTimeout = typeof AbortSignal & {
-  timeout?: (milliseconds: number) => AbortSignal;
-};
-
-const createTimeoutSignal = (timeoutMs: number): { signal: AbortSignal; cleanup: () => void } => {
-  const abortSignal = typeof AbortSignal !== 'undefined'
-    ? AbortSignal as AbortSignalConstructorWithTimeout
-    : undefined;
-  if (typeof abortSignal?.timeout === 'function') {
-    return { signal: abortSignal.timeout(timeoutMs), cleanup: () => undefined };
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  return {
-    signal: controller.signal,
-    cleanup: () => clearTimeout(timeoutId),
-  };
-};
-
-/**
- * Upper bound for non-streaming OpenCode read requests. Without it, a socket
- * that neither resolves nor rejects (the half-open state described in #2470)
- * keeps the bootstrap concurrency slot busy forever and the UI stays on
- * "loading sessions". Long-lived streams (POST prompts, the /event SSE) are
- * explicitly excluded in {@link createRuntimeOpencodeClient}.
- */
-const OPENCODE_REQUEST_TIMEOUT_MS = 30_000;
-
-const isEventStreamUrl = (input: string | URL | Request): boolean => {
-  const url = typeof input === 'string'
-    ? input
-    : input instanceof URL
-      ? input.toString()
-      : input.url;
-  return url.includes('/event');
-};
-
 type RuntimeOpencodeClientConfig = {
   baseUrl: string;
   directory?: string;
@@ -216,7 +179,7 @@ type RuntimeOpencodeClientConfig = {
 };
 
 export const createRuntimeOpencodeClient = (config: RuntimeOpencodeClientConfig): OpencodeClient => {
-  const requestTimeoutMs = config.requestTimeoutMs ?? OPENCODE_REQUEST_TIMEOUT_MS;
+  const requestTimeoutMs = config.requestTimeoutMs ?? RUNTIME_READ_TIMEOUT_MS;
   return createOpencodeClient({
     ...config,
     fetch: async (input: string | URL | Request, init?: RequestInit) => {

--- a/packages/ui/src/lib/runtime-fetch.test.ts
+++ b/packages/ui/src/lib/runtime-fetch.test.ts
@@ -393,6 +393,90 @@ describe('runtimeFetch read coalescing', () => {
   });
 });
 
+describe('runtimeFetch read timeout', () => {
+  // A read that neither resolves nor rejects (issue #3467: half-open socket, or
+  // a project directory on a stalled mount) used to pin the coalesce entry, the
+  // caller's in-flight map and a background slot until the app restarted.
+  const withShortReadTimeout = async (run: () => Promise<void>): Promise<void> => {
+    const originalTimeout = AbortSignal.timeout;
+    AbortSignal.timeout = () => originalTimeout.call(AbortSignal, 5);
+    try {
+      await run();
+    } finally {
+      AbortSignal.timeout = originalTimeout;
+    }
+  };
+
+  test('bounds a hung GET read and leaves the coalesce entry drained', async () => {
+    const previous = getRuntimeUrlResolver();
+    const abandon: Array<() => void> = [];
+    let calls = 0;
+    // Without the bound the request never settles, so race a watchdog: a
+    // regression must fail here rather than hang the suite.
+    const settle = (request: Promise<Response>) => Promise.race([
+      request.then(() => 'resolved', String),
+      new Promise<string>((resolve) => setTimeout(() => resolve('hung'), 1000)),
+    ]);
+    try {
+      configureRuntimeUrlResolver({ apiBaseUrl: 'https://api.example' });
+      const hungFetch: typeof fetch = async (_input, init) => {
+        calls += 1;
+        return new Promise<Response>((_resolve, reject) => {
+          const fail = () => reject(new DOMException('Aborted', 'AbortError'));
+          abandon.push(fail);
+          init?.signal?.addEventListener('abort', fail);
+        });
+      };
+      globalThis.fetch = hungFetch;
+
+      await withShortReadTimeout(async () => {
+        // "request timed out" keeps sync/retry.ts classifying it as transient.
+        expect(await settle(runtimeFetch('/api/config/commands/deploy'))).toContain('request timed out');
+        // The coalesce entry drained, so the next caller gets a fresh request
+        // instead of awaiting the dead one forever.
+        expect(await settle(runtimeFetch('/api/config/commands/deploy'))).toContain('request timed out');
+      });
+
+      expect(calls).toBe(2);
+    } finally {
+      for (const fail of abandon) fail();
+      setRuntimeUrlResolver(previous);
+      globalThis.fetch = originalFetch;
+      clearRuntimeAuthCredentialProvider();
+    }
+  });
+
+  test('bounds unsupervised reads only, and never event streams', async () => {
+    const previous = getRuntimeUrlResolver();
+    const signals: Array<AbortSignal | null | undefined> = [];
+    const callerSignal = new AbortController().signal;
+    try {
+      configureRuntimeUrlResolver({ apiBaseUrl: 'https://api.example' });
+      const recordingFetch: typeof fetch = async (_input, init) => {
+        signals.push(init?.signal);
+        return new Response('{}', { status: 200 });
+      };
+      globalThis.fetch = recordingFetch;
+
+      await runtimeFetch('/api/config/commands/deploy');
+      await runtimeFetch('/api/event');
+      await runtimeFetch('/api/openchamber/events');
+      await runtimeFetch('/api/session/ses_1/message', { method: 'POST', body: '{}' });
+      await runtimeFetch('/api/config/providers', { signal: callerSignal });
+
+      expect(signals[0]).toBeInstanceOf(AbortSignal);
+      expect(signals[1]).toBeUndefined();
+      expect(signals[2]).toBeUndefined();
+      expect(signals[3]).toBeUndefined();
+      expect(signals[4]).toBe(callerSignal);
+    } finally {
+      setRuntimeUrlResolver(previous);
+      globalThis.fetch = originalFetch;
+      clearRuntimeAuthCredentialProvider();
+    }
+  });
+});
+
 describe('runtimeFetch header sanitization', () => {
   test('isLatin1Safe returns true for Latin-1 strings', () => {
     expect(isLatin1Safe('hello')).toBe(true);

--- a/packages/ui/src/lib/runtime-fetch.ts
+++ b/packages/ui/src/lib/runtime-fetch.ts
@@ -2,6 +2,7 @@ import { getActiveRelayTunnel } from './relay/runtime-tunnel';
 import { TUNNEL_PARSE_BASE } from './relay/tunnel-payloads';
 import { buildRuntimeAuthHeaders } from './runtime-auth';
 import { observeRuntimeAuthResponse } from './runtime-auth-expiry';
+import { createTimeoutSignal, isEventStreamUrl, RUNTIME_READ_TIMEOUT_MS } from './runtime-read-timeout';
 import { getRuntimeUrlResolver, type RuntimeUrlQuery } from './runtime-url';
 
 export interface RuntimeFetchOptions extends RequestInit {
@@ -252,13 +253,36 @@ const READ_COALESCE = new Map<string, Promise<Response>>();
 const coalesceReadKey = (method: string, url: string, hasSignal: boolean): string | null => {
   if (hasSignal) return null;
   if (method !== 'GET') return null;
-  if (url.includes('/event')) return null;
+  if (isEventStreamUrl(url)) return null;
   if (!COALESCE_READ_PATH.test(url)) return null;
   return `GET ${url}`;
 };
 
+// ---------------------------------------------------------------------------
+// Read timeout
+//
+// A hang is not a rejection, so an unbounded read never releases what waits on
+// it — the coalesce entry above, the per-directory in-flight maps in the config
+// stores, background concurrency slots — and one half-open socket (#2470) or one
+// project directory on a stalled mount left that project's commands and skills
+// missing until the app restarted (#3467). So bound what we own: a GET with no
+// caller signal, excluding event streams. The coalesce key still reads only the
+// caller's signal, so the bound never disables deduplication.
+// ---------------------------------------------------------------------------
+
 export const runtimeFetch = async (input: string | URL | Request, init: RuntimeFetchOptions = {}): Promise<Response> => {
   const { query, ...requestInit } = init;
+
+  // A Request always carries a (possibly default) signal; treat any Request, or
+  // an explicit init.signal, as caller-supervised.
+  const hasSignal = requestInit.signal != null || input instanceof Request;
+  const method = String(
+    requestInit.method ?? (input instanceof Request ? input.method : 'GET'),
+  ).toUpperCase();
+  const timeout = !hasSignal && method === 'GET' && !isEventStreamUrl(input)
+    ? createTimeoutSignal(RUNTIME_READ_TIMEOUT_MS)
+    : null;
+  const readInit: RequestInit = timeout ? { ...requestInit, signal: timeout.signal } : requestInit;
 
   // Resolve the transport once — relay tunnel or network — then apply the SAME
   // read-coalescing to both. On a relay the tunnel is bandwidth/latency-bound, so
@@ -268,15 +292,13 @@ export const runtimeFetch = async (input: string | URL | Request, init: RuntimeF
 
   let doFetch: () => Promise<Response>;
   let url: string;
-  let method: string;
   if (relay && relayPath !== null) {
     const inputHeaders = input instanceof Request ? input.headers : undefined;
     const headers = await mergeHeaders(inputHeaders, requestInit.headers, true);
     doFetch = input instanceof Request
-      ? () => relay.fetch(input, { ...requestInit, headers })
-      : () => relay.fetch(relayPath, { ...requestInit, headers });
+      ? () => relay.fetch(input, { ...readInit, headers })
+      : () => relay.fetch(relayPath, { ...readInit, headers });
     url = relayPath;
-    method = String(requestInit.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
   } else {
     const resolvedInput = resolveRuntimeFetchInput(input, query);
     const inputHeaders = resolvedInput instanceof Request ? resolvedInput.headers : undefined;
@@ -287,12 +309,9 @@ export const runtimeFetch = async (input: string | URL | Request, init: RuntimeF
       : String(resolvedInput);
     addRuntimeProxyHeaders(resolvedUrl, headers);
     doFetch = resolvedInput instanceof Request
-      ? () => fetch(new Request(resolvedInput, { ...requestInit, headers }))
-      : () => fetch(resolvedInput, { ...requestInit, headers });
+      ? () => fetch(new Request(resolvedInput, { ...readInit, headers }))
+      : () => fetch(resolvedInput, { ...readInit, headers });
     url = resolvedUrl;
-    method = String(
-      requestInit.method ?? (resolvedInput instanceof Request ? resolvedInput.method : 'GET'),
-    ).toUpperCase();
   }
 
   // Session-expiry classification rides on responses that already flow
@@ -303,15 +322,31 @@ export const runtimeFetch = async (input: string | URL | Request, init: RuntimeF
     return response;
   });
 
-  // A Request always carries a (possibly default) signal; treat any Request, or
-  // an explicit init.signal, as "has signal" and skip coalescing for safety.
-  const hasSignal = requestInit.signal != null || input instanceof Request;
+  if (timeout) {
+    const boundedFetch = doFetch;
+    doFetch = async () => {
+      try {
+        return await boundedFetch();
+      } catch (error) {
+        // Normalized so retry classification reads a transient failure rather
+        // than a caller-initiated abort.
+        if (timeout.signal.aborted) throw new Error(`Runtime request timed out after ${RUNTIME_READ_TIMEOUT_MS}ms`);
+        throw error;
+      } finally {
+        timeout.cleanup();
+      }
+    };
+  }
 
   const key = coalesceReadKey(method, url, hasSignal);
   if (!key) return doFetch();
 
   const existing = READ_COALESCE.get(key);
-  if (existing) return existing.then((res) => res.clone());
+  if (existing) {
+    // Joining an in-flight read: this caller inherits its bound, so drop ours.
+    timeout?.cleanup();
+    return existing.then((res) => res.clone());
+  }
 
   const pending = doFetch();
   READ_COALESCE.set(key, pending);

--- a/packages/ui/src/lib/runtime-read-timeout.ts
+++ b/packages/ui/src/lib/runtime-read-timeout.ts
@@ -1,0 +1,40 @@
+/**
+ * Primitives for bounding runtime reads, shared by the transport
+ * (`runtime-fetch`) and the OpenCode SDK client wrapper (`opencode/client`).
+ *
+ * A leaf module with no imports: both consumers are mocked independently in
+ * tests, so these must resolve from somewhere neither of them owns.
+ */
+
+type TimeoutSignal = {
+  signal: AbortSignal;
+  cleanup: () => void;
+};
+
+/** `AbortSignal.timeout` is absent on iOS 15 and other pre-2022 engines. */
+type TimeoutCapableAbortSignal = {
+  timeout?: (milliseconds: number) => AbortSignal;
+};
+
+/** Upper bound for a non-streaming runtime read. */
+export const RUNTIME_READ_TIMEOUT_MS = 30_000;
+
+/** Long-lived streams must never be timed out or coalesced. */
+export const isEventStreamUrl = (input: string | URL | Request): boolean => {
+  const url = input instanceof Request ? input.url : String(input);
+  return url.includes('/event');
+};
+
+export const createTimeoutSignal = (timeoutMs: number): TimeoutSignal => {
+  const abortSignal: TimeoutCapableAbortSignal = AbortSignal;
+  if (abortSignal.timeout) {
+    return { signal: abortSignal.timeout(timeoutMs), cleanup: () => undefined };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeoutId),
+  };
+};

--- a/packages/ui/src/sync/retry.ts
+++ b/packages/ui/src/sync/retry.ts
@@ -7,9 +7,9 @@ export interface RetryOptions {
 }
 
 // undici tears down half-open upstream connection with `TypeError: terminated`
-// (exact failure from the #2470 logs); the SDK client also rejects reads with
-// normalized "request timed out" error after OPENCODE_REQUEST_TIMEOUT_MS.
-// Both are transient — managed process may be restarting.
+// (exact failure from the #2470 logs); the SDK client and the runtime transport
+// both reject reads with normalized "request timed out" error after
+// RUNTIME_READ_TIMEOUT_MS. Both are transient — managed process may be restarting.
 const TRANSIENT_MESSAGES = [
   "load failed",
   "network connection was lost",


### PR DESCRIPTION
## Intent

Fixes #3467. Slash-command autocomplete intermittently lost a project's commands, and only a full restart brought them back.

A read issued through `runtimeFetch` carried no timeout, so a request that neither resolves nor rejects stayed pending forever. A hang is not a rejection, so nothing downstream recovered. Three module-level caches release their entry when the request settles:

| Cache | Location | Effect while pinned |
|---|---|---|
| `READ_COALESCE` | `packages/ui/src/lib/runtime-fetch.ts:347` | Every later identical GET awaits the dead promise |
| `commandsLoadInFlight` | `packages/ui/src/stores/useCommandsStore.ts:339` | Every later `loadCommands(dir)` returns the dead promise |
| Background slot | `packages/ui/src/lib/background-network.ts:47` | Three hangs starve all background network work |

`loadCommands` fetches per-command scope metadata with `Promise.all`, so one pinned request pins the whole load, and its 3-attempt retry loop never advances because a hang never throws. The caches are module state, which is why quitting the app was the only cure. They key on the directory, which is why only some projects lost their commands while others kept a populated list.

Two triggers reach this on macOS desktop. The managed OpenCode connection goes half-open (the `socket hang up` / `TypeError: terminated` sequence logged in #2470), and `GET /api/config/commands/:name` awaits `resolveProjectDirectory`, which runs `fs.stat` plus `realpath` on the project path (`packages/web/server/lib/opencode/project-directory-runtime.js:41`). Neither is bounded.

#2470 was the same failure class one layer up. Commit b9f61dfc8 bounded SDK reads at 30s in `createRuntimeOpencodeClient`; direct `runtimeFetch` reads were left unbounded. This is the other half.

The fix bounds a GET with no caller signal, excludes event streams, and normalizes the rejection so `sync/retry.ts` classifies it as transient rather than a user cancellation. A caller that brings its own signal keeps control of cancellation. The coalesce key still reads only that caller's signal, so deduplication is unchanged.

`createTimeoutSignal` and `isEventStreamUrl` move into a new leaf module, `packages/ui/src/lib/runtime-read-timeout.ts`. Both the transport and the SDK client wrapper need them, and each is mocked independently in tests, so they cannot live in either one. `OPENCODE_REQUEST_TIMEOUT_MS` collapses into the shared `RUNTIME_READ_TIMEOUT_MS`; both were 30s with the same purpose.

## Non-goals

- Not changing the `useCommandsStore` cache, TTL, or in-flight map. Once every read settles, all three caches drain on their own, so the fix belongs at the transport that owns the request.
- Not bounding writes. A POST or PATCH is user-initiated and does not feed the shared read caches.
- Not fixing the server-side `fs.stat` hang. Bounding the client is what stops one stalled directory from wedging shared state.
- Not reducing the request fan-out in `loadCommands`, which issues one `/api/config/commands/:name` request per command. That is a real cost, and a separate change.

## Affected surfaces

- `packages/ui`: `runtime-fetch` (shared runtime transport), the SDK client wrapper, `sync/retry` comment, one new leaf module.
- Every runtime consumes the shared transport, so the bound applies to web, desktop, VS Code, hosted mobile, and Capacitor mobile alike. That is intentional: the wedge is transport-level, not platform-specific.
- Relay mode routes through the same function. The tunnel client honors `request.signal` (`packages/ui/src/lib/relay/tunnel-client.ts:710`), and the VS Code webview bridge forwards it through `proxyApiRequest`, so the bound actually cancels on both non-native transports rather than only rejecting the wrapper promise.
- No persisted data, route, ID, or public export contract changes. `runtimeFetch`'s signature is unchanged.

Excluded by construction: the `/event` SSE stream, `/api/openchamber/events`, POST prompts, and any request carrying a caller signal.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants | The wedge is a fetch failure that never surfaces as failure | The bound converts a silent hang into a retryable rejection; `loadCommands` already preserves the previous list, so failure never masquerades as an empty project |
| `openchamber-change-discipline` | Source change with a module-contract risk (new leaf module, moved helpers) | One owning layer fixed rather than three caches patched; new module exists because two independently-mocked consumers need the same primitive, not to make it reusable; `bun run dead-code` run because a file was added |
| `ui-api-decoupling` | Shared UI data access through `runtimeFetch` and the OpenCode SDK | SDK request fidelity preserved: the SDK already passes its own signal, so it keeps its own timeout and is untouched by the new bound. Authoritative failure stays a failure instead of becoming valid empty success |
| `relay-transport` | `runtime-fetch` is runtime transport internals with a relay branch | Both branches receive the same `readInit`; verified the tunnel honors `request.signal` so the relay path cancels rather than leaking; no wire format, frame type, or WS allowlist touched |
| `sync-state-invariants` | Directory-scoped caches and in-flight lifecycle | A hang is not a real failure signal, so the retry loop could not run; the bound restores that signal. Failure preserves prior authoritative state |
| `performance-engineering` (caching rules) | The change touches the read-coalescing cache | Invalidation stays explicit: a coalesced joiner inherits the first request's bound and releases its own timer, so no entry and no timer outlives its request |
| `.agents/skills/ui-api-decoupling/references/implementation-map.md` | Names the focused test file for HTTP fidelity | New tests live in `packages/ui/src/lib/runtime-fetch.test.ts` |

No `DOCUMENTATION.md` owns `packages/ui/src/lib`. `packages/web/server/lib/relay/DOCUMENTATION.md` describes `runtime-fetch`'s routing role, which is unchanged.

## Validation

| Check | Result |
|---|---|
| `bun test src/lib/runtime-fetch.test.ts` (before fix) | Both new tests fail as intended: hung read reports `hung` after the 1s watchdog, and no signal reaches `fetch` |
| `bun test src/lib/runtime-fetch.test.ts` | 26 pass, 0 fail |
| `bun test src/lib/opencode/client-timeout.test.ts` | 6 pass, 0 fail (the #2470 regression suite, which mocks `@/lib/runtime-fetch`) |
| `bun test src/lib/runtime-url.test.ts`, `runtime-auth.test.ts`, `relay/tunnel-client.test.ts` | 13, 9, 21 pass, 0 fail |
| `bun test src/sync/retry.test.ts`, `src/stores/useCommandsStore.test.ts`, `src/stores/useSkillsStore.test.ts` | 3, 2, 5 pass, 0 fail |
| `bun run --filter @openchamber/ui test` | 430/432 files pass. The 2 failures (`src/sync/__tests__/issue-2039.test.ts`, `issue-1637-2270.test.ts`) fail identically on a clean tree, verified by stashing |
| `bun run type-check` for `@openchamber/ui`, `@openchamber/web`, `openchamber` (VS Code) | Same 5 pre-existing `src/lib/codemirror/languageByExtension.ts` errors as the stashed baseline, from duplicate `@codemirror/state` versions. No error in any changed file |
| `bunx oxlint` on the 4 changed/added files | New module clean. Remaining findings are the pre-existing `anti-slop` backlog outside my changed line ranges (verified against `git diff -U0` hunks) |
| `bunx eslint` on the 4 changed/added files | Clean |
| `bun run dead-code` | Exit 0. No finding for the new module or its exports |

Not verified: no manual macOS desktop run, because the trigger is a half-open socket or a stalled mount that I cannot reproduce on demand. The 30s bound itself is platform `AbortSignal` behavior; the tests cover which requests get bounded, that the rejection is normalized, and that the coalesce entry drains so the next caller issues a fresh request.

## Visual evidence

No visual change. The diff adds an abort signal to unsupervised runtime GET reads and moves two helpers. No component, style, layout, or copy is touched. The user-visible effect is negative in nature: a project's commands stop disappearing, which needs the unreproducible trigger above to demonstrate.

## Risks and failure behavior

- **A legitimately slow GET now fails at 30s.** I checked every consumer that reaches `runtimeFetch` with a GET and no caller signal. The event streams (`/api/event`, `/api/openchamber/events`) are excluded by `isEventStreamUrl`, and `openchamberEvents.ts` and `useWebNotificationStream.ts` use native `EventSource` and never reach this path. The bound matches what the SDK client has applied to session and message reads since b9f61dfc8. A caller that needs longer passes its own signal, which also opts out of coalescing.
- **Recovery, not silent repair.** After a timeout, `loadCommands` retries 3 times, then keeps the previously loaded commands rather than showing an empty list. Worst case is up to 3 bounded attempts before the caches drain, after which the next `/` opens a fresh request. That replaces "broken until restart" with "self-heals".
- **Coalesced joiners.** A caller joining an in-flight read inherits the first request's remaining budget, so it can reject sooner than 30s. Its own retry then starts a fresh request. It releases its own timer on the early return, so no timer outlives its request.
- **Abort semantics.** The normalized message keeps `sync/retry.ts` treating a timeout as transient. A caller-initiated abort keeps its original `AbortError` shape and is still not retried.
- No security, data-loss, or persisted-state impact. No dependency change.
