### PR TITLE
fix(desktop): keep bundled OpenCode paths out of update environment

### DIFF
--- a/packages/web/server/lib/opencode/DOCUMENTATION.md
+++ b/packages/web/server/lib/opencode/DOCUMENTATION.md
@@ -156,6 +156,7 @@ Managed health failures are classified as `timeout`, `connection_refused`, `conn
 ## Public exports (env-runtime.js)
 - `createOpenCodeEnvRuntime(dependencies)`: creates runtime that owns OpenCode CLI environment and binary discovery state.
 - OpenCode CLI resolution order is persisted settings, environment overrides, bundled Desktop CLI when available, PATH, known install locations, then platform shell discovery.
+- Automatic bundled resolution under `OPENCHAMBER_RUNTIME=desktop` stays in runtime state and is returned to the managed launch function, including on OpenCode restart. It does not populate `process.env.OPENCODE_BINARY`: AppImage updater relaunch inherits that environment and would mistake the previous bundle path for an explicit override. Explicit settings/env selections and non-desktop or non-bundled resolution retain their existing environment behavior. This prevents future inheritance; it does not reinterpret overrides already inherited from older releases.
 - Returned API:
   - `applyLoginShellEnvSnapshot()`
   - `getLoginShellEnvSnapshot()`

--- a/packages/web/server/lib/opencode/env-runtime.js
+++ b/packages/web/server/lib/opencode/env-runtime.js
@@ -1110,7 +1110,11 @@ export const createOpenCodeEnvRuntime = (deps) => {
         return resolved;
       }
 
-      process.env.OPENCODE_BINARY = resolved;
+      // AppImage updates inherit process.env. Keep automatic desktop bundle
+      // selection local so the next app does not treat the old mount as an override.
+      if (process.env.OPENCHAMBER_RUNTIME !== 'desktop' || state.resolvedOpencodeBinarySource !== 'bundled') {
+        process.env.OPENCODE_BINARY = resolved;
+      }
       prependToPath(path.dirname(resolved));
       ensureOpencodeShimRuntime(resolved);
       state.resolvedOpencodeBinary = resolved;

--- a/packages/web/server/lib/opencode/env-runtime.test.js
+++ b/packages/web/server/lib/opencode/env-runtime.test.js
@@ -14,6 +14,7 @@ const originalResourcesPath = process.resourcesPath;
 const originalWslBinary = process.env.WSL_BINARY;
 const originalOpenChamberWslBinary = process.env.OPENCHAMBER_WSL_BINARY;
 const originalPlatform = process.platform;
+const originalRuntime = process.env.OPENCHAMBER_RUNTIME;
 const tempDirs = [];
 const itIf = (condition) => condition ? it : it.skip;
 
@@ -30,6 +31,8 @@ const setPlatform = (platform) => {
 };
 
 afterEach(() => {
+  if (originalRuntime === undefined) delete process.env.OPENCHAMBER_RUNTIME;
+  else process.env.OPENCHAMBER_RUNTIME = originalRuntime;
   Object.defineProperty(process, 'platform', {
     value: originalPlatform,
   });
@@ -117,7 +120,76 @@ const createRuntime = (settings, options = {}) => {
   return { runtime, state };
 };
 
+const createBundledCli = () => {
+  const resourcesPath = createTempDir('openchamber-resources-');
+  const directory = path.join(resourcesPath, 'opencode-cli');
+  fs.mkdirSync(directory);
+  const binary = path.join(directory, process.platform === 'win32' ? 'opencode.exe' : 'opencode');
+  fs.writeFileSync(binary, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  Object.defineProperty(process, 'resourcesPath', { configurable: true, value: resourcesPath });
+  return binary;
+};
+
 describe('OpenCode env runtime', () => {
+  it.each(['linux', 'darwin', 'win32'])('keeps automatic desktop bundled resolution local across relaunch on %s', (platform) => {
+    setPlatform(platform);
+    process.env.OPENCHAMBER_RUNTIME = 'desktop';
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_BUNDLED_OPENCODE_CLI_DIR;
+
+    const oldBinary = createBundledCli();
+    const oldRuntime = createRuntime({});
+    expect(oldRuntime.runtime.ensureOpencodeCliEnv()).toBe(oldBinary);
+    expect(oldRuntime.runtime.ensureOpencodeCliEnv()).toBe(oldBinary);
+    expect(oldRuntime.state.resolvedOpencodeBinarySource).toBe('bundled');
+    expect(process.env.OPENCODE_BINARY).toBeUndefined();
+    expect(process.env.PATH.split(path.delimiter)[0]).toBe(path.dirname(oldBinary));
+
+    // The old binary remains executable and its directory is still in PATH.
+    const newBinary = createBundledCli();
+    const newRuntime = createRuntime({});
+    expect(newRuntime.runtime.ensureOpencodeCliEnv()).toBe(newBinary);
+    expect(newRuntime.state.resolvedOpencodeBinarySource).toBe('bundled');
+    expect(newRuntime.runtime.isBundledOpenCodeCliPath(newBinary)).toBe(true);
+    expect(process.env.OPENCODE_BINARY).toBeUndefined();
+  });
+
+  it.each(['web', 'ssh-remote'])('preserves automatic binary export outside desktop in %s', (runtimeName) => {
+    process.env.OPENCHAMBER_RUNTIME = runtimeName;
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_BUNDLED_OPENCODE_CLI_DIR;
+    const binary = createBundledCli();
+    const { runtime } = createRuntime({});
+    expect(runtime.ensureOpencodeCliEnv()).toBe(binary);
+    expect(process.env.OPENCODE_BINARY).toBe(binary);
+  });
+
+  it.each(['env', 'settings'])('preserves explicit desktop %s selection even when it points at a bundled CLI', async (source) => {
+    process.env.OPENCHAMBER_RUNTIME = 'desktop';
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_BUNDLED_OPENCODE_CLI_DIR;
+    const binary = createBundledCli();
+    if (source === 'env') process.env.OPENCODE_BINARY = binary;
+    const { runtime, state } = createRuntime(source === 'settings' ? { opencodeBinary: binary } : {});
+    await runtime.applyOpencodeBinaryFromSettings({ strict: true });
+    expect(runtime.ensureOpencodeCliEnv()).toBe(binary);
+    expect(state.resolvedOpencodeBinarySource).toBe(source);
+    expect(process.env.OPENCODE_BINARY).toBe(binary);
+  });
+
+  it('preserves automatic PATH binary export for desktop without a bundled CLI', () => {
+    process.env.OPENCHAMBER_RUNTIME = 'desktop';
+    delete process.env.OPENCODE_BINARY;
+    delete process.env.OPENCHAMBER_BUNDLED_OPENCODE_CLI_DIR;
+    const binary = createBundledCli();
+    Object.defineProperty(process, 'resourcesPath', { configurable: true, value: undefined });
+    process.env.PATH = path.dirname(binary);
+    const { runtime, state } = createRuntime({});
+    expect(runtime.ensureOpencodeCliEnv()).toBe(binary);
+    expect(state.resolvedOpencodeBinarySource).toBe('path');
+    expect(process.env.OPENCODE_BINARY).toBe(binary);
+  });
+
   it('searches an explicit PATH without mutating the process environment', () => {
     const defaultDir = createTempDir('openchamber-default-path-');
     const explicitDir = createTempDir('openchamber-explicit-path-');

--- a/packages/web/server/lib/opencode/lifecycle.js
+++ b/packages/web/server/lib/opencode/lifecycle.js
@@ -377,8 +377,8 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     return parts.length > 0 ? parts.join('\n\n') : 'No stdout/stderr captured';
   };
 
-  const createManagedOpenCodeServerProcess = async ({ hostname, port, timeout, cwd, env: processEnv, shellEnvKeysCount = 0 }) => {
-    let binary = (process.env.OPENCODE_BINARY || 'opencode').trim() || 'opencode';
+  const createManagedOpenCodeServerProcess = async ({ resolvedBinary, hostname, port, timeout, cwd, env: processEnv, shellEnvKeysCount = 0 }) => {
+    let binary = (resolvedBinary || process.env.OPENCODE_BINARY || 'opencode').trim() || 'opencode';
     const sourceBinary = binary;
     let args = ['serve', '--hostname', hostname, '--port', String(port)];
     let launchWrapperType = null;
@@ -694,7 +694,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
     );
 
     await applyOpencodeBinaryFromSettings({ strict: true });
-    ensureOpencodeCliEnv();
+    const resolvedBinary = ensureOpencodeCliEnv();
     recordStartupPerformance('opencode.binary.ready', {
       attempt,
       durationMs: performance.now() - phaseStartedAt,
@@ -721,6 +721,7 @@ export const createOpenCodeLifecycleRuntime = (deps) => {
 
     try {
       const serverInstance = await createManagedOpenCodeServerProcess({
+        resolvedBinary,
         hostname: env.ENV_CONFIGURED_OPENCODE_HOSTNAME,
         port: spawnPort,
         timeout: 30000,

--- a/packages/web/server/lib/opencode/lifecycle.test.js
+++ b/packages/web/server/lib/opencode/lifecycle.test.js
@@ -126,6 +126,35 @@ const createRuntime = (overrides = {}, stateOverrides = {}, envOverrides = {}) =
 };
 
 describe('OpenCode lifecycle', () => {
+  it('uses the resolved binary directly on startup and managed restart without an env override', async () => {
+    delete process.env.OPENCODE_BINARY;
+    const binaries = ['/bundle one/opencode-cli/opencode', '/bundle two/opencode-cli/opencode'];
+    const ensureOpencodeCliEnv = vi.fn()
+      .mockReturnValueOnce(binaries[0])
+      .mockReturnValueOnce(binaries[1]);
+    spawnMock.mockImplementation(() => {
+      const child = createMockChild();
+      queueMicrotask(() => child.stdout.emit('data', 'opencode server listening on http://127.0.0.1:45678\n'));
+      return child;
+    });
+    globalThis.fetch = vi.fn(async () => ({ ok: false }));
+    const runtime = createRuntime({ ensureOpencodeCliEnv });
+    const firstServer = await runtime.startOpenCode();
+    runtime.testState.openCodeProcess = firstServer;
+    try {
+      await runtime.restartOpenCode();
+      expect(firstServer.signalCode).toBe('SIGTERM');
+      expect(spawnMock.mock.calls.map(([binary]) => binary)).toEqual(binaries);
+      expect(runtime.testState.lastOpenCodeLaunchDiagnostics.sourceBinary).toBe(binaries[1]);
+      expect(process.env.OPENCODE_BINARY).toBeUndefined();
+      for (const [, , options] of spawnMock.mock.calls) {
+        expect(options.env).not.toHaveProperty('OPENCODE_BINARY');
+      }
+    } finally {
+      await runtime.testState.openCodeProcess.close();
+    }
+  });
+
   it('records an authoritative ready terminal event for external startup', async () => {
     globalThis.fetch = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Intent

After a Linux AppImage update, the new OpenChamber process could keep running OpenCode from the previous AppImage mount. The old path also stopped matching the current bundle, so the UI incorrectly offered an independent OpenCode upgrade.

The resolver wrote its automatic selection into `process.env.OPENCODE_BINARY`. The AppImage updater inherited that environment, and the next process treated the old path as an explicit override.

This PR keeps automatic desktop bundled selection in runtime state and passes the resolved path directly to managed process startup. Restart OpenCode uses the same path. The scope was agreed with @btriapitsyn and @yulia-ivashko.

Discovered while testing #3367, but this fixes the separate bundled-binary inheritance defect, not the remote-update waiting dialog.

## Non-goals

- No updater rewrite, new endpoint, dependency, configuration option, or relaunch environment transaction.
- No changes to explicit env/settings overrides, non-desktop binary export, or desktop PATH-based installations.
- No heuristic cleanup of overrides already inherited from older releases. A first upgrade from an unfixed version can still require a full quit and fresh launch.
- No changes to CLI, SSH, VS Code, or client reconnect behavior.

## Affected surfaces

`packages/web/server/lib/opencode`: binary resolution and managed startup/restart, plus tests and owning documentation.

The new condition applies only when `OPENCHAMBER_RUNTIME=desktop` and the selected source is `bundled`. It applies to packaged desktop runtimes across Linux, macOS, and Windows. Explicitly selecting a bundled file through settings or the environment remains an explicit override. Web/hosted mobile, Capacitor, SSH, and VS Code receive no new UI or API contract. PATH preparation and existing launch fallbacks remain intact.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `openchamber-change-discipline` | Source and runtime behavior | Two existing production modules, no dependency or exported API additions, regression tests first, no unrelated cleanup or changelog edits. |
| `desktop-shell`, `packages/electron/README.md` | Packaged AppImage inheritance | Keeps server in-process and updater unchanged; validated real AppImage replacement and isolated macOS startup/restart. |
| `packages/web/README.md`, OpenCode `DOCUMENTATION.md` | Owning server package and binary selection | Documents direct use of the resolver result and the old-release limitation. |
| `sync-state-invariants`, sync documentation | Restart lifecycle and state authority | Uses the existing resolver source and restart owner; adds no parallel state or guessed path ownership. |
| `ui-api-decoupling`, implementation-map reference | Runtime ownership and validation | No bridge, endpoint, auth, or UI changes. Binary ownership remains in server runtime logic. |
| `communication-style`, `writing-for-agents` | Documentation and handoff | Keeps the invariant in the owning module document and states validation limits explicitly. |

## Validation

Final commit: `e5e32e921`. The production files were unchanged between native validation and this commit.

| Check | Result |
|---|---|
| Regression tests before implementation | Four expected failures reproduced automatic env export and ignored resolver results. |
| `bun run --cwd packages/web test server/lib/opencode` | Rerun before commit: 44 files passed; 458 tests passed, one skipped. |
| Two modified suites on native Debian | 57 passed, one platform-specific test skipped. |
| `bun run type-check:web` and `bun run lint:web` | Passed. Package lint covers frontend TS/TSX; server JS was checked separately. |
| `node --check packages/web/server/lib/opencode/env-runtime.js` and equivalent for `lifecycle.js` | Passed. |
| `bunx oxlint` on the four changed JS files | Existing runtime-typeof and module-mocking findings remain; no findings in added code. No rules weakened. |
| `git diff --check origin/main...HEAD` | Passed. |
| Packaged Mac ARM64 smoke | Isolated ad-hoc-signed test app started bundled OpenCode and successfully restarted it through `/api/config/reload`; resolution and upgrade ownership remained bundled. |
| Real Debian 13 x64 AppImage update | PASS: fixed `1.22.92` to fixed `1.22.93` through the actual `electron-updater`, followed by Restart OpenCode. Details below. |

Native packages were built from isolated snapshot `3903bfad81d41d18e0dc32f96a53670d905beb88` with the exact final two production files copied in, not from the entire final branch. Both AppImages passed `verify:linux-appimage`, including bundled OpenCode 1.18.29 and four native modules. File hashes matched the working implementation:

```text
env-runtime.js d131773676b1f70dee7b27f0d09140e75a77aa670f621bf4ff968f1879fb33ec
lifecycle.js   128e90ccb5c6a0339e208bf9d12dc96d310d3895d98011155cafba2b508bae70
```

The existing loopback fixture served the target. One POST to the isolated embedded host update endpoint invoked the real updater. Assertions inspected `/proc` executables and verified:

| Stage | Desktop / OpenCode mount | Resolution | Independent upgrade |
|---|---|---|---|
| Before update | Both in initial mount | `bundled` | Unsupported, reason `bundled` |
| After update | Both in a different, new mount | `bundled` | Unsupported, reason `bundled` |
| After Restart OpenCode | New child PID, same new mount | `bundled` | Unsupported, reason `bundled` |

At all three stages the child environment lacked `OPENCODE_BINARY`. The installed target hash matched the prepared artifact:

```text
1.22.92 a24ae8480c97fa12c5eaf9f404ddd5b04626a001bf4efd2715cc369b45a9eeb0
1.22.93 4f26f7a6200ed8c83f3afa752be173a7f0b7c54d4999553fd1f1ae8539c51c0e
```

The fixture and test app were stopped afterward; test ports were confirmed closed. Working installations and profiles were not replaced.

Not run: native Windows, HMR, full workspace build/test matrix, production GitHub update feed, or Mac renderer reconnect interaction for this final fix. Platform-parameterized tests are not claimed as native Windows evidence.

## Visual evidence

No layout, styling, or copy changes. The visible effect is that bundled OpenCode no longer gets the incorrect independent-update offer after AppImage replacement. Before, live inspection showed a new desktop executable with an old-mount OpenCode and upgrade ownership reported as external to the current bundle. After, the native checks above confirmed a new-mount OpenCode and `available: false`, `upgrade.reason: bundled`, including after restart.

No before/after screenshot pair or recording was captured for the fixed artifacts. Evidence here is runtime/API and process verification, not a visual recording.

## Risks and failure behavior

- Explicit user configuration retains priority, even when it names a bundled file. The fix does not infer intent from path strings.
- Old releases can still pass their already-generated override into the first fixed version. A full quit and fresh launch may be needed once; no migration or destructive environment cleanup is attempted.
- No restart timing, retry, shutdown, authorization, or persistence behavior is changed. A missing resolver result retains the previous env/command fallback.
- The lifecycle now consumes the resolver result directly; tests cover both initial startup and managed restart, including cached resolution and non-bundled behavior.
- Reverting restores prior behavior without a data migration. Native tests used disposable profiles and verified the executable path, since matching version numbers alone can hide this defect.
