### PR TITLE
test(ui): fix session-routing test mock shapes (closes #3470)

### DIFF
--- a/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
@@ -94,7 +94,7 @@ beforeEach(() => {
   // exercised by `createSession` itself, only the directory getter is.
   setActionRefs(
     {} as never,
-    { children: new Map(), ensureChild: () => ({}), getChild: () => undefined } as never,
+    { children: new Map(), ensureChild: () => ({ getState: () => ({ session: [] }), setState: mock() }), getChild: () => undefined } as never,
     () => currentDirectory ?? "",
   )
 })

--- a/packages/ui/src/sync/__tests__/issue-2039.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-2039.test.ts
@@ -142,6 +142,7 @@ mock.module("@/stores/useGlobalSessionsStore", () => ({
     getState: () => ({
       activeSessions: [],
       archivedSessions: [],
+      entityById: new Map(),
     }),
   },
   resolveGlobalSessionDirectory: () => null,


### PR DESCRIPTION
## Intent

Fixes openchamber/openchamber#3470: the `pr checks` CI job fails on two session-routing test files on clean `main` (`store.getState is not a function` / `entityById.get` TypeError), blocking the checks job for every PR. Root cause is mock-shape drift in the tests — the mocks no longer match what the production code calls. No production code changes.

## Non-goals

- No production/source changes — this is a test-only fix.
- The cross-file mock pollution visible when running both files in one `bun test` process (`useSessionUIStore.setState is not a function` in `issue-2039.test.ts`) is intentionally **not** addressed here: CI runs each test file in its own process (`scripts/run-isolated-tests.mjs`), so it does not affect the `checks` job. It only affects the combined reproduction command from the issue.

## Affected surfaces

- `packages/ui` test suite only. No runtime, API, persisted, or external contracts touched. Web/desktop/VS Code runtimes unaffected (no shared code changed).

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md — keep diffs tight, no drive-by refactors | Test-only fix | Exactly two hunks in two test files |
| AGENTS.md — validation expectations | Test/type/lint changes require validation | Ran both test files, `type-check`, `lint` (see Validation) |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/sync/__tests__/issue-1637-2270.test.ts` | ✅ 9 pass, 0 fail (36 expect calls) |
| `bun test packages/ui/src/sync/__tests__/issue-2039.test.ts` | ✅ 10 pass, 0 fail (32 expect calls) |
| `bun run --cwd packages/ui type-check` | ✅ pass |
| `bun run --cwd packages/ui lint` | ✅ pass |
| Combined run (both files, one process) | ⚠️ `issue-2039` still fails with `useSessionUIStore.setState is not a function` — pre-existing cross-file mock pollution, out of scope (see Non-goals) |

## Visual evidence

No user-visible change: the diff touches only test mock shapes; it cannot affect rendered behavior.

## Risks and failure behavior

None identified for production. The only residual failure mode is the combined-process run documented above, which CI does not use.