### PR TITLE
test(sync): update stale createSession mocks for child store and global index

### DIFF
--- a/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-1637-2270.test.ts
@@ -90,11 +90,16 @@ beforeEach(() => {
   nextCreateSessionResponse = { id: "ses_default", time: { created: 1 } } as Session
   currentDirectory = null
 
-  // Initialize action refs. The first two args (sdk, childStores) are not
-  // exercised by `createSession` itself, only the directory getter is.
+  // Initialize action refs. `createSession` seeds the created session into its
+  // directory's child store, so the mock hands back an empty store; the sdk
+  // is not exercised, only the directory getter is.
   setActionRefs(
     {} as never,
-    { children: new Map(), ensureChild: () => ({}), getChild: () => undefined } as never,
+    {
+      children: new Map(),
+      ensureChild: () => ({ getState: () => ({ session: [] }), setState: () => undefined }),
+      getChild: () => undefined,
+    } as never,
     () => currentDirectory ?? "",
   )
 })

--- a/packages/ui/src/sync/__tests__/issue-2039.test.ts
+++ b/packages/ui/src/sync/__tests__/issue-2039.test.ts
@@ -142,6 +142,7 @@ mock.module("@/stores/useGlobalSessionsStore", () => ({
     getState: () => ({
       activeSessions: [],
       archivedSessions: [],
+      entityById: new Map(),
     }),
   },
   resolveGlobalSessionDirectory: () => null,


### PR DESCRIPTION
## Intent

The `checks` job has been red on `main` since 60ecaf5c6 ("fix(sync): avoid false session loading errors"). That commit made `createSession` seed the new session into its directory's child store and resolve a cold session's directory through the global session index. Two older tests mock those stores without the fields the new code reads, so they throw `store.getState is not a function` and `entityById.get` on undefined.

The production code is right and has its own coverage from the same commit. This PR updates the two stale mocks so the suite is green again and unrelated PRs stop needing an admin merge.

## Non-goals

- No change to `createSession`, `session-ui-store`, or any runtime behavior.
- No cleanup of the pre-existing `anti-slop` findings lower in `issue-1637-2270.test.ts`; they predate this PR and sit outside the edited lines.

## Affected surfaces

`packages/ui/src/sync/__tests__` only. Two test files, mocks only. No runtime is affected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md`, `openchamber-change-discipline` | Source change under `packages/ui` | Smallest fix on the side that was actually wrong (test doubles), no code or dependency changes, no changelog edit. |
| `sync-state-invariants`, `packages/ui/src/sync/DOCUMENTATION.md` | Tests exercise session creation and directory resolution | Confirmed the new reads are the authoritative sources the docs describe (child store for the live record, global index for a session known before its store bootstraps), so the mocks now hand back those shapes instead of hiding the calls. |

## Validation

| Check | Result |
|---|---|
| `node ../../scripts/run-isolated-tests.mjs src/sync/__tests__` from `packages/ui` (same runner as CI) | 19/19 test files passed. Before the fix the same run failed `issue-1637-2270` (5 fail) and `issue-2039` (5 fail). |
| `bun test` on each fixed file alone | `issue-2039`: 10 pass, 0 fail. `issue-1637-2270`: 9 pass, 0 fail. |
| `bunx oxlint --no-ignore` on both files | Five pre-existing `require-safety-comment-for-type-assertion` findings at lines 229 to 292 of `issue-1637-2270.test.ts`, all present on `main`, none in the edited hunks. |

Not run: full UI test suite, type-check, lint. The diff touches only mock objects inside two test files.

## Visual evidence

No user-visible change. Only test mocks changed.

## Risks and failure behavior

None identified: the two mocks now return the minimal store shapes the code under test already requires in production. If a future change reads another field, these tests fail the same loud way and point at the mock.
