### PR TITLE
fix(sidebar): show project, branch and PR in Recent tooltips

### DIFF
--- a/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
@@ -69,22 +69,51 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
     showRecentSection,
   } = props;
   const { t } = useI18n();
+  // Canonical worktree index: linked worktrees often live outside the project
+  // root, so the prefix walk below can never own them. Mirror the project
+  // grouping contract — exact directory match, never the project root itself.
+  const worktreeByPath = React.useMemo(() => {
+    const byPath = new Map<string, { meta: WorktreeMetadata; project: Props['projects'][number] }>();
+    const projectByNormalizedPath = new Map<string, Props['projects'][number]>();
+    for (const project of projects) {
+      const normalized = normalizePath(project.normalizedPath);
+      if (normalized && !projectByNormalizedPath.has(normalized)) projectByNormalizedPath.set(normalized, project);
+    }
+    for (const [projectPath, worktrees] of availableWorktreesByProject) {
+      const project = projectByNormalizedPath.get(normalizePath(projectPath) ?? '') ?? null;
+      if (!project) continue;
+      const projectRoot = normalizePath(project.normalizedPath);
+      for (const entry of worktrees) {
+        const entryPath = normalizePath(entry.path);
+        if (!entryPath || entryPath === projectRoot || byPath.has(entryPath)) continue;
+        byPath.set(entryPath, { meta: entry, project });
+      }
+    }
+    return byPath;
+  }, [availableWorktreesByProject, projects]);
   const sessionLocationById = React.useMemo(() => {
     const locations = new Map<string, RecentSessionLocation>();
     for (const session of sessions) {
       const directory = normalizePath(session.directory ?? null);
       if (!directory) continue;
-      let owner: Props['projects'][number] | null = null;
-      let ownerLength = -1;
-      for (const project of projects) {
-        const projectPath = normalizePath(project.normalizedPath);
-        if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
-          owner = project;
-          ownerLength = projectPath.length;
+      // A worktree session outside its project root never matches the prefix
+      // walk; resolve it through the canonical worktree index first.
+      const worktreeHit = worktreeByPath.get(directory) ?? null;
+      let owner: Props['projects'][number] | null = worktreeHit?.project ?? null;
+      if (!owner) {
+        let ownerLength = -1;
+        for (const project of projects) {
+          const projectPath = normalizePath(project.normalizedPath);
+          if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
+            owner = project;
+            ownerLength = projectPath.length;
+          }
         }
       }
       if (!owner) continue;
-      const worktree = availableWorktreesByProject.get(owner.normalizedPath)?.find((entry) => normalizePath(entry.path) === directory);
+      // Single resolver: the canonical worktree index already excludes the
+      // project root and normalizes every key. No per-project find fallback.
+      const worktree = worktreeHit?.meta ?? null;
       const projectLabel = formatProjectLabel(owner.label?.trim() || formatDirectoryName(owner.normalizedPath, homeDirectory) || owner.normalizedPath);
       const branch = worktree?.branch?.trim() || gitBranches.get(directory)?.trim() || null;
       locations.set(session.id, {
@@ -95,22 +124,32 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
       });
     }
     return locations;
-  }, [availableWorktreesByProject, sessions, gitBranches, homeDirectory, projects]);
+  }, [sessions, gitBranches, homeDirectory, projects, worktreeByPath]);
   const getSessionLocation = React.useCallback(
     (sessionId: string) => sessionLocationById.get(sessionId) ?? null,
     [sessionLocationById],
   );
   const getSessionNode = React.useCallback(
-    (session: Session): SessionNode => ({
-      session,
-      children: (childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({
-        session: child,
-        children: [],
-        worktree: null,
-      })),
-      worktree: null,
-    }),
-    [childrenMap],
+    (session: Session): SessionNode => {
+      // Attach the canonical worktree per session (root and children alike),
+      // mirroring the project grouping contract. The row derives its branch
+      // line fallback and PR lookup key from node.worktree; leaving it null
+      // is what reduced worktree rows to title+date.
+      const resolveWorktree = (target: Session): WorktreeMetadata | null => {
+        const targetDirectory = normalizePath(target.directory ?? null);
+        return (targetDirectory ? worktreeByPath.get(targetDirectory)?.meta : undefined) ?? null;
+      };
+      return {
+        session,
+        children: (childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({
+          session: child,
+          children: [],
+          worktree: resolveWorktree(child),
+        })),
+        worktree: resolveWorktree(session),
+      };
+    },
+    [childrenMap, worktreeByPath],
   );
   const recentSections = React.useMemo(() => deriveRecentActivitySections({
     sessions: recentSessions,

--- a/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Session } from '@opencode-ai/sdk/v2';
+import type { WorktreeMetadata } from '@/types/worktree';
+import { installHookTestDom } from '../test-utils/testDom';
+import { I18nProvider } from '@/lib/i18n';
+import type { SessionTreeItemProps } from '../sessions/SessionTreeItem';
+
+type CapturedSectionItem = {
+  node: {
+    session: Session;
+    worktree: WorktreeMetadata | null;
+  };
+  projectId: string | null;
+  groupDirectory: string | null;
+  secondaryMeta: {
+    projectLabel?: string | null;
+    branchLabel?: string | null;
+  } | null;
+};
+
+type CapturedSection = {
+  key: string;
+  items: CapturedSectionItem[];
+};
+
+const capturedSections: CapturedSection[][] = [];
+
+mock.module('./SidebarActivitySections', () => ({
+  SidebarActivitySections: (props: { sections: CapturedSection[] }) => {
+    capturedSections.push(props.sections);
+    return null;
+  },
+}));
+
+// SAFETY: RecentSessionSection is imported after the SidebarActivitySections mock so the test observes the real resolver.
+const { RecentSessionSection } = await import('./RecentSessionSection');
+
+const noopStartSessionWorktreeMenuLoad: SessionTreeItemProps['startSessionWorktreeMenuLoad'] = () => ({
+  cachedTargets: [],
+  refreshTargets: Promise.resolve([]),
+});
+
+// SAFETY: fixtures use the minimal Session fields the Recent resolver reads (id/directory/title/time).
+const worktreeSession = (id: string, directory: string): Session => ({
+  id,
+  title: id,
+  directory,
+  time: { created: 1, updated: 1 },
+}) as Session;
+
+const worktreeMeta = (path: string, branch: string): WorktreeMetadata => ({
+  path,
+  projectDirectory: '/workspace/app',
+  branch,
+  label: branch,
+});
+
+describe('RecentSessionSection external worktree resolve', () => {
+  test('resolves sessions outside the project root via the worktree index and keeps filtered branches hidden without leaking into the worktree fallback', async () => {
+    capturedSections.length = 0;
+    const dom = installHookTestDom();
+    const root = createRoot(dom.container);
+    const noop = () => undefined;
+    const sessions = [
+      worktreeSession('visible-feature', '/tmp/wt-feature'),
+      worktreeSession('filtered-head', '/tmp/wt-detached'),
+      worktreeSession('filtered-redundant', '/tmp/wt-redundant'),
+    ];
+
+    try {
+      await act(async () => {
+        root.render(
+          <I18nProvider>
+            <RecentSessionSection
+              projects={[{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }]}
+              availableWorktreesByProject={new Map([
+                ['/workspace/app', [
+                  worktreeMeta('/tmp/wt-feature', 'feature-1'),
+                  worktreeMeta('/tmp/wt-detached', 'HEAD'),
+                  worktreeMeta('/tmp/wt-redundant', 'App'),
+                ]],
+              ])}
+              gitBranches={new Map()}
+              homeDirectory={null}
+              hasSessionSearchQuery={false}
+              normalizedSessionSearchQuery=""
+              isDesktopShellRuntime={false}
+              sessions={sessions}
+              childrenMap={new Map()}
+              pinnedSessionIds={new Set()}
+              recentSessions={sessions}
+              expandedParents={new Set()}
+              notifyOnSubtasks={false}
+              editingId={null}
+              editTitle=""
+              copiedSessionId={null}
+              openSidebarMenuKey={null}
+              mobileVariant={false}
+              alwaysShowActions={false}
+              chatSessions={[]}
+              renderChatsSection={() => null}
+              onNewChat={noop}
+              showRecentSection
+              setEditingId={noop}
+              setEditTitle={noop}
+              toggleParent={noop}
+              setOpenSidebarMenuKey={noop}
+              allowReselect={false}
+              isSessionSearchOpen={false}
+              sessionSearchQuery=""
+              setSessionSearchQuery={noop}
+              setIsSessionSearchOpen={noop}
+              deleteSessionConfirm={null}
+              setDeleteSessionConfirm={noop}
+              startFolderRename={noop}
+              setCopiedSessionId={noop}
+              startSessionWorktreeMenuLoad={noopStartSessionWorktreeMenuLoad}
+            />
+          </I18nProvider>,
+        );
+      });
+
+      const recent = capturedSections.at(-1)?.find((section) => section.key === 'active-now');
+      expect(recent?.items.map((item) => item.node.session.id)).toEqual([
+        'visible-feature',
+        'filtered-head',
+        'filtered-redundant',
+      ]);
+      const byId = new Map(recent?.items.map((item) => [item.node.session.id, item]));
+
+      // (a) Worktree outside the project root resolves through the worktreeByPath index.
+      const visible = byId.get('visible-feature');
+      expect(visible?.projectId).toBe('app');
+      expect(visible?.groupDirectory).toBe('/tmp/wt-feature');
+      expect(visible?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'feature-1' });
+      expect(visible?.node.worktree?.path).toBe('/tmp/wt-feature');
+      expect(visible?.node.worktree?.branch).toBe('feature-1');
+
+      // (b) Filtered branches stay hidden yet keep the raw worktree branch for the project-row fallback.
+      const head = byId.get('filtered-head');
+      expect(head?.projectId).toBe('app');
+      expect(head?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: null });
+      expect(head?.node.worktree?.branch).toBe('HEAD');
+
+      const redundant = byId.get('filtered-redundant');
+      expect(redundant?.projectId).toBe('app');
+      expect(redundant?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: null });
+      expect(redundant?.node.worktree?.branch).toBe('App');
+
+      // SessionNodeItem priority (SessionNodeItem.tsx:372-378): an explicit
+      // secondaryMeta wins, so deliberate null must not fall through to the raw branch.
+      const resolveTooltipBranchLabel = (
+        secondaryMeta: CapturedSectionItem['secondaryMeta'],
+        worktreeBranch: string | null,
+      ): string | null => (secondaryMeta ? (secondaryMeta.branchLabel ?? null) : (worktreeBranch ?? null));
+
+      expect(resolveTooltipBranchLabel(visible?.secondaryMeta ?? null, visible?.node.worktree?.branch ?? null)).toBe('feature-1');
+      expect(resolveTooltipBranchLabel(head?.secondaryMeta ?? null, head?.node.worktree?.branch ?? null)).toBeNull();
+      expect(resolveTooltipBranchLabel(redundant?.secondaryMeta ?? null, redundant?.node.worktree?.branch ?? null)).toBeNull();
+      // Project rows pass no secondaryMeta and keep the worktree fallback.
+      expect(resolveTooltipBranchLabel(null, head?.node.worktree?.branch ?? null)).toBe('HEAD');
+      expect(resolveTooltipBranchLabel(null, redundant?.node.worktree?.branch ?? null)).toBe('App');
+    } finally {
+      await act(async () => root.unmount());
+      capturedSections.length = 0;
+      dom.restore();
+    }
+  });
+});

--- a/packages/ui/src/components/session/sidebar/sessions/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/sessions/SessionNodeItem.tsx
@@ -369,7 +369,13 @@ function SessionNodeItemComponent(props: SessionNodeItemProps): React.ReactNode 
   );
   const tooltipProjectLabel = secondaryMeta?.projectLabel
     ?? (projectLabelFromStore ? formatProjectLabel(projectLabelFromStore) : null);
-  const tooltipBranchLabel = secondaryMeta?.branchLabel ?? node.worktree?.branch ?? null;
+  const tooltipBranchLabel = secondaryMeta
+    // Recent rows carry an explicit secondaryMeta: a null branchLabel there
+    // is a deliberate filter (HEAD/redundant with the project label), not a
+    // missing value, so it must not fall through to the raw worktree branch.
+    // Project rows pass no secondaryMeta and keep the worktree fallback.
+    ? (secondaryMeta.branchLabel ?? null)
+    : (node.worktree?.branch ?? null);
   const prLookupKey = React.useMemo(() => {
     if (isVSCode) return null;
     const branch = node.worktree?.branch?.trim();


### PR DESCRIPTION
## Intent

Hovering the same worktree session in Recent showed only title and date, while Projects showed project, branch and PR status. This PR brings Recent to parity and closes #3476. Recent now resolves the session owner through the canonical worktree index first, attaches the canonical worktree to Recent nodes, and renders the same tooltip rows as Projects. The per-project find fallback is removed in favor of the single normalized index. A focused test locks the new resolution and the branch-label precedence.

## Non-goals

- Branch freshness order (stored worktree.branch vs live gitBranches) intentionally unchanged; tracked as follow-up.
- No shared worktree-index helper extraction; the same exact-match index now lives in three places, also follow-up.
- Sessions in a worktree subdirectory (not the worktree root itself) stay title-plus-date in Recent; follow-up.
- No changes to Projects grouping, switcher, archived and chats handling, or the VS Code tooltip gate.

## Affected surfaces

- packages/ui sidebar only: Recent section rows and the shared SessionNodeItem tooltip content, plus one new test file. Web, desktop and hosted mobile share this component. VS Code suppresses row tooltips entirely, so it is unaffected. No persisted or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root AGENTS.md instruction order plus module DOCUMENTATION | Source change in sidebar ownership area | Read root guide, sidebar docs and local test precedent before editing |
| openchamber-change-discipline | Source change with shared-data implications | One resolver at data level, no new deps or configs, two source files plus one test |
| sync-state-invariants | Worktree and branch resolution from live and stored state | Exact-match index mirrors grouping contract, root excluded, HEAD filter kept |
| ui-api-decoupling | Tooltip reads project, branch and PR stores | Same directory-plus-branch PR key as Projects, same store entries |

## Validation

| Check | Result |
|---|---|
| bun run type-check in packages/ui | PASS, exit 0, no output |
| bunx oxlint on changed source files | PASS, no findings |
| bun run lint in packages/ui | PASS, exit 0 |
| bun test, 12 sidebar and store files | 77 pass, 0 fail |
| New recentSessionWorktreeResolve test | PASS, 1 pass 17 expects, plus type-check and oxlint clean |
| Independent reviewer, whole-PR pass | READY-GO, no blockers, Coverage full PR |
| Automation review | NEEDS_EVIDENCE, code correct, screenshots pending |
| Full workspace build | Not run, out of scope for this diff |

## Visual evidence

No screenshots attached yet. The user-visible tooltip change is covered by unit suites and static prop-chain review only, plus two reviewer passes. Screenshots of Recent vs Projects hovers to be attached before merge.

## Risks and failure behavior

Risk is limited to Recent rows. Root sessions resolve worktree null and fall back to gitBranches as before. HEAD and branch-equals-label filters are preserved. Rollback is a revert of two commits. No migrations, secrets, or perf-sensitive paths; the index is memoized.