### PR TITLE
fix(agent-tool): drop the redundant enum from the action schema

### DIFF
--- a/packages/web/server/lib/agent-tool/DOCUMENTATION.md
+++ b/packages/web/server/lib/agent-tool/DOCUMENTATION.md
@@ -48,6 +48,9 @@ both settings are `false`.
 - The tool exposes one shared parameter object rather than repeating parameters
   in a large per-action union. Action descriptions carry only required inputs,
   defaults, or one non-obvious semantic detail.
+- The action schema carries `oneOf` and no `enum`. A node combining `enum` and
+  `oneOf` is valid JSON Schema, but some OpenAI-compatible gateways reject it
+  and answer with an empty completion instead of an error.
 - Obvious fields rely on their names and JSON types. Parameter descriptions are
   reserved for formats, dependencies, scope, and behavior that cannot be safely
   inferred from the field name.

--- a/packages/web/server/lib/agent-tool/runtime.js
+++ b/packages/web/server/lib/agent-tool/runtime.js
@@ -143,11 +143,16 @@ const isLoopbackAddress = (value) => {
  * set, the inputs and the description differ. Generating them from one template
  * keeps the transport, metadata and failure handling identical, which is what
  * the caller depends on.
+ *
+ * The action schema carries `oneOf` only. A node combining `enum` and `oneOf`
+ * is valid JSON Schema, but some OpenAI-compatible gateways reject it and
+ * answer with an empty completion instead of an error, and the `oneOf` branches
+ * are what carry the per-action descriptions the model reads.
  */
-const createToolEntry = ({ name, description, actions, definitions, parameters }) => String.raw`    ${name}: {
+const createToolEntry = ({ name, description, definitions, parameters }) => String.raw`    ${name}: {
       description: ${JSON.stringify(description)},
       args: {
-        action: { type: "string", enum: ${JSON.stringify(actions)}, oneOf: ${JSON.stringify(definitions.map((entry) => ({ const: entry.action, description: entry.description })))}, description: "OpenChamber action to perform" },
+        action: { type: "string", oneOf: ${JSON.stringify(definitions.map((entry) => ({ const: entry.action, description: entry.description })))}, description: "OpenChamber action to perform" },
         parameters: { type: "object", properties: ${JSON.stringify(parameters)}, additionalProperties: false, description: "Inputs for the action; use an empty object when none are needed" },
       },
       async execute(input, context) {
@@ -221,7 +226,6 @@ const createPluginSource = ({ includeControl, includeWeb, includeMemory }) => {
     entries.push(createToolEntry({
       name: 'openchamber',
       description: CONTROL_TOOL_DESCRIPTION,
-      actions: OPENCHAMBER_AGENT_TOOL_ACTIONS,
       definitions: OPENCHAMBER_AGENT_TOOL_ACTION_DEFINITIONS,
       parameters: CONTROL_PARAMETER_PROPERTIES,
     }));
@@ -230,7 +234,6 @@ const createPluginSource = ({ includeControl, includeWeb, includeMemory }) => {
     entries.push(createToolEntry({
       name: 'openchamber_web',
       description: WEB_TOOL_DESCRIPTION,
-      actions: OPENCHAMBER_WEB_ACTIONS,
       definitions: OPENCHAMBER_WEB_ACTION_DEFINITIONS,
       parameters: WEB_PARAMETER_PROPERTIES,
     }));
@@ -239,7 +242,6 @@ const createPluginSource = ({ includeControl, includeWeb, includeMemory }) => {
     entries.push(createToolEntry({
       name: 'openchamber_memory',
       description: MEMORY_TOOL_DESCRIPTION,
-      actions: OPENCHAMBER_MEMORY_ACTIONS,
       definitions: OPENCHAMBER_MEMORY_ACTION_DEFINITIONS,
       parameters: MEMORY_PARAMETER_PROPERTIES,
     }));

--- a/packages/web/server/lib/agent-tool/runtime.test.js
+++ b/packages/web/server/lib/agent-tool/runtime.test.js
@@ -121,8 +121,8 @@ describe('managed agent tool runtime', () => {
     const pluginModule = await import(`${pathToFileURL(pluginPath).href}?both=${Date.now()}`);
     const { tool } = await pluginModule.OpenChamberPlugin();
 
-    const controlActions = tool.openchamber.args.action.enum;
-    const webActions = tool.openchamber_web.args.action.enum;
+    const controlActions = tool.openchamber.args.action.oneOf.map((entry) => entry.const);
+    const webActions = tool.openchamber_web.args.action.oneOf.map((entry) => entry.const);
     expect(webActions).toContain('browser.open');
     expect(controlActions).not.toContain('browser.open');
     expect(webActions).not.toContain('session.create');
@@ -131,6 +131,23 @@ describe('managed agent tool runtime', () => {
     expect(Object.keys(tool.openchamber_web.args.parameters.properties)).toContain('url');
     expect(Object.keys(tool.openchamber.args.parameters.properties)).not.toContain('url');
     expect(Object.keys(tool.openchamber.args.parameters.properties)).toContain('sessionId');
+  });
+
+  it('keeps the action schema to one validator keyword', async () => {
+    // A node carrying both `enum` and `oneOf` is valid JSON Schema, but some
+    // OpenAI-compatible gateways reject it and answer with an empty completion
+    // instead of an error. `oneOf` is the keyword that stayed. Its branches
+    // carry the per-action descriptions the model reads.
+    const { runtime, dataDir } = await createRuntime();
+    await runtime.prepareManagedOpenCodeEnv();
+    const pluginPath = path.join(dataDir, 'agent-tool', 'openchamber-plugin.js');
+    const pluginModule = await import(`${pathToFileURL(pluginPath).href}?validator=${Date.now()}`);
+    const { tool } = await pluginModule.OpenChamberPlugin();
+
+    for (const entry of Object.values(tool)) {
+      expect(entry.args.action.oneOf).toBeInstanceOf(Array);
+      expect(entry.args.action).not.toHaveProperty('enum');
+    }
   });
 
   it('accepts inputs passed beside the action, not only inside parameters', async () => {


### PR DESCRIPTION
## Intent

The generated OpenChamber tools put both `enum` and `oneOf` on the `action` field. The two lists are the same values, so the `enum` is leftover. JSON Schema allows both on one node. Several OpenAI-compatible backends do not.

What you see depends on the gateway. Kilo returns a server error. OpenRouter returns a 502. The Codex backend returns an empty `incomplete` response. Command Code, the path in #3182 and the one I hit, answers HTTP 200 with `finish_reason: "length"` and zeros on every usage counter, input tokens included. OpenCode treats that as a successful empty turn. Nothing in the UI or the logs. The agent just doesn't answer.

I ran the same request against Command Code `provider/v1` with `gpt-5.6-luna`, three times each way. Plugin generated from HEAD: empty, 3 of 3. Plugin with `enum` removed: a normal answer, 3 of 3. A request with a single tool is enough, as long as that tool's `action` carries both keywords. Take either keyword off and the answer comes back. Built-in OpenCode tools were never in this schema, which is why they kept working and why the bisection in #3182 landed here.

This PR keeps `oneOf` and drops `enum`. That is Option A from #3182. `oneOf` is the useful one: each branch has the description the model reads, and the consts already name every allowed action.

Fixes #3182, #3299, and #3407.

## Non-goals

- Action allowlists, parameter schemas, and the loopback callback are unchanged. Only how `action` is written in the schema changes.
- No retry or detection on the OpenChamber side for gateways that turn a rejected schema into an empty 200. That behavior belongs to the gateway. This change stops sending the schema they reject.
- `mcp-reconnect` and `system-prompt` define no tool schemas, so they are untouched.

## Affected surfaces

- `packages/web/server/lib/agent-tool/runtime.js`: the plugin template, and the `actions` argument that existed only to fill `enum`.
- `packages/web/server/lib/agent-tool/runtime.test.js`: tests now read the action list from `oneOf`. A new regression test fails if `enum` and `oneOf` sit on the same node again.
- `packages/web/server/lib/agent-tool/DOCUMENTATION.md`: the invariant is recorded there.
- The generated plugin at `<data-dir>/agent-tool/openchamber-plugin.js` is rewritten on every managed OpenCode start, so the next launch picks this up. No persisted data, routes, or settings change.
- Web, desktop, and VS Code share this generator. The UI, the relay, CLI output, and mobile never render or parse the generated schema, so they are unaffected.

## Repository guidance

| Guidance | Why it applies | How the change complies |
| --- | --- | --- |
| `AGENTS.md` | Always-on repository rules | Diff stays in the owning module and its docs. `changelog/` is untouched. Validation is for the touched surface. |
| `.agents/skills/openchamber-change-discipline/SKILL.md` | Source change in `packages/web`, plus a generated plugin | Local implementation plus generated asset: smallest complete change, focused tests, oxlint on the two files, package-scoped type-check and lint. |
| `.agents/skills/communication-style/SKILL.md` | PR text is human-facing writing | Checklist applied. |
| `packages/web/server/lib/agent-tool/DOCUMENTATION.md` | Owning documentation | Read before editing. The schema invariant is now in there. |

## Validation

| Check | Result |
| --- | --- |
| `bun test packages/web/server/lib/agent-tool/runtime.test.js` | 33 pass, 0 fail |
| `bun run type-check:web` | pass |
| `bun run lint:web` | pass. It only covers `src/**/*.{ts,tsx}`, so it does not cover server JS. The focused tests and oxlint below do. |
| `bunx oxlint packages/web/server/lib/agent-tool/runtime.js packages/web/server/lib/agent-tool/runtime.test.js` | No findings on changed lines. Pre-existing findings on untouched lines (`runtime.js` 118-133 and 312-322) left alone. |
| Live A/B through OpenCode against Command Code `provider/v1`, model `gpt-5.6-luna`, plugins generated from HEAD and from this branch, 3 runs each | HEAD: empty 3/3. Branch: normal answer 3/3. |
| Inspected the plugin generated by this branch | All three tools emit `action: { type: "string", oneOf: [...] }`. Remaining `enum` uses are parameter enums (`role`, `direction`, `viewport`, `scope`, `type`) and did not change. |

Not verified: providers and proxies beyond the ones in the linked issues. `oneOf` was already in the schema before this change, so removing `enum` cannot make fewer backends accept it.

## Visual evidence

No rendered UI changed. The user-visible effect is a chat turn that used to come back blank now getting an answer. I did not screenshot that. The A/B runs in Validation are the evidence.

## Risks and failure behavior

- The generated file is overwritten on every managed start, so there is nothing to migrate. Rollback is reverting this commit.
- The schema the model sees stays equivalent: the removed `enum` and the remaining `oneOf` consts listed the same values, and every parameter schema is unchanged.
- Action allowlist, per-child token, loopback check, and abort propagation are untouched.
