### PR TITLE
fix(mac): add NSLocalNetworkUsageDescription for LAN access

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -93,7 +93,8 @@
       "icon": "resources/icons/icon.icns",
       "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
       "extendInfo": {
-        "CFBundleIconName": "AppIcon"
+        "CFBundleIconName": "AppIcon",
+        "NSLocalNetworkUsageDescription": "OpenChamber needs access to devices and services on your local network."
       },
       "hardenedRuntime": true,
       "gatekeeperAssess": false,


### PR DESCRIPTION
## Intent

Add `NSLocalNetworkUsageDescription` to mac `extendInfo` in `packages/electron/package.json` so macOS shows OpenChamber in Privacy and Security local network settings and allows agent shell traffic to LAN hosts.

Per Apple TN3179, outbound connections to local network hosts require local network permission and user consent ([[TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)).

Fixes #3489

## Non-goals

- No UI or rendering changes.
- No pairing, relay, Windows, or Linux changes.
- No network logic or permission handling changes.

## Affected surfaces

- macOS desktop packaging only via `packages/electron/package.json`.
- Runtime effect is limited to macOS local network permission prompting for LAN access.

## Repository guidance

| Guidance | Why it applies | How the change complies |
| --- | --- | --- |
| `desktop-shell` | Change is macOS `electron-builder` packaging (`mac.extendInfo`), which the skill owns | One key added under existing `mac.extendInfo`; no `main.mjs`, `preload.mjs`, IPC, window, updater, or lifecycle change |
| `openchamber-change-discipline` isolated-config validation | Source-adjacent config change with no executable-source or contract change | Minimal one-key diff; narrowest validation is plist syntax plus packaged-build check |
| `communication-style` | `NSLocalNetworkUsageDescription` is user-facing macOS privacy prompt text | One plain sentence, no puffery, AI vocabulary, em dashes, or chatbot phrasing |
| `packages/electron/README.md` Packaging + Platform Notes | Nearest package README owns the `electron:build` / macOS `dmg`+`zip` contract | Change stays inside documented packaging path (`extendInfo` into macOS `Info.plist`); no new build step or signing behavior |

## Validation

| Check | Result |
| --- | --- |
| Built app Info.plist contains NSLocalNetworkUsageDescription | Passed in local test build |
| First LAN nc triggers macOS local network prompt | Passed in local test build |
| LAN access after allowing the prompt | Passed in local test build |
| Internet access still works | Passed in local test build |
| bun run lint | Passed, all workspace lint jobs exit 0 |
| bun run --cwd packages/electron test | Passed, 23/23 test files |
| bun run build:electron | Passed, exit 0 |
| bun run type-check (root) | Failed to complete, timeout after 600s (mobile type-check exited 0 before hang) |
| bun run test (root) / bun run build (root) | Skipped, scoped electron checks used instead |
| Notarized and signed official build behavior | Not verified |

## Visual evidence

<img width="852" height="582" alt="Screenshot 2026-09-11 at 01 22 37" src="https://github.com/user-attachments/assets/f3bcb070-9d5c-4fdc-80c8-50e10b5020a3" />
<img width="912" height="632" alt="Screenshot 2026-09-11 at 01 20 54" src="https://github.com/user-attachments/assets/5d8406e7-9da0-4913-a614-994bb72f8fbb" />

## Risks and failure behavior

If the user denies local network access, LAN connections from the app can still fail with no route or timeout while internet access keeps working. If the string is missing in a future packaging change, macOS will again omit the app from local network settings and reproduce the original LAN failure.
