### PR TITLE
feat(sidebar): extend Recent worktree parity to subdirs and unify branch freshness

### DIFF
--- a/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
+++ b/packages/ui/src/components/session/sidebar/list/SessionProjectCollection.tsx
@@ -458,6 +458,7 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     !topology.isVSCode ? <RecentSessionSection
       projects={topology.projects}
       availableWorktreesByProject={topology.availableWorktreesByProject}
+      worktreeMetadata={topology.worktreeMetadata}
       gitBranches={topology.gitBranches}
       homeDirectory={view.homeDirectory}
       hasSessionSearchQuery={view.hasSessionSearchQuery}
@@ -519,6 +520,7 @@ const VisibleSessionProjects: React.FC<SessionProjectCollectionProps> = ({ topol
     topology.gitBranches,
     topology.isVSCode,
     topology.projects,
+    topology.worktreeMetadata,
     collection.chatSessions,
     view.hasSessionSearchQuery,
     view.homeDirectory,

--- a/packages/ui/src/components/session/sidebar/projects/useSessionGrouping.ts
+++ b/packages/ui/src/components/session/sidebar/projects/useSessionGrouping.ts
@@ -14,6 +14,7 @@ import { formatDirectoryName, formatPathForDisplay } from '@/lib/utils';
 import { useI18n } from '@/lib/i18n';
 import { resolveGlobalSessionDirectory } from '@/stores/useGlobalSessionsStore';
 import { getWorktreeFirstSeenAt } from './worktreeFirstSeen';
+import { buildProjectWorktreeIndex } from '../worktreeIndex';
 
 type Args = {
   homeDirectory: string | null;
@@ -99,13 +100,7 @@ export const useSessionGrouping = (args: Args) => {
         childrenMap.set(parentID, collection);
       });
 
-      const worktreeByPath = new Map<string, WorktreeMetadata>();
-      availableWorktrees.forEach((meta) => {
-        if (meta.path) {
-          const normalized = normalizePath(meta.path) ?? meta.path;
-          worktreeByPath.set(normalized, meta);
-        }
-      });
+      const worktreeByPath = buildProjectWorktreeIndex(availableWorktrees, normalizedProjectRoot);
 
       const getSessionWorktree = (session: Session): WorktreeMetadata | null => {
         const sessionDirectory = normalizePath((session as Session & { directory?: string | null }).directory ?? null);

--- a/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
@@ -69,22 +69,51 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
     showRecentSection,
   } = props;
   const { t } = useI18n();
+  // Canonical worktree index: linked worktrees often live outside the project
+  // root, so the prefix walk below can never own them. Mirror the project
+  // grouping contract — exact directory match, never the project root itself.
+  const worktreeByPath = React.useMemo(() => {
+    const byPath = new Map<string, { meta: WorktreeMetadata; project: Props['projects'][number] }>();
+    const projectByNormalizedPath = new Map<string, Props['projects'][number]>();
+    for (const project of projects) {
+      const normalized = normalizePath(project.normalizedPath);
+      if (normalized && !projectByNormalizedPath.has(normalized)) projectByNormalizedPath.set(normalized, project);
+    }
+    for (const [projectPath, worktrees] of availableWorktreesByProject) {
+      const project = projectByNormalizedPath.get(normalizePath(projectPath) ?? '') ?? null;
+      if (!project) continue;
+      const projectRoot = normalizePath(project.normalizedPath);
+      for (const entry of worktrees) {
+        const entryPath = normalizePath(entry.path);
+        if (!entryPath || entryPath === projectRoot || byPath.has(entryPath)) continue;
+        byPath.set(entryPath, { meta: entry, project });
+      }
+    }
+    return byPath;
+  }, [availableWorktreesByProject, projects]);
   const sessionLocationById = React.useMemo(() => {
     const locations = new Map<string, RecentSessionLocation>();
     for (const session of sessions) {
       const directory = normalizePath(session.directory ?? null);
       if (!directory) continue;
-      let owner: Props['projects'][number] | null = null;
-      let ownerLength = -1;
-      for (const project of projects) {
-        const projectPath = normalizePath(project.normalizedPath);
-        if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
-          owner = project;
-          ownerLength = projectPath.length;
+      // A worktree session outside its project root never matches the prefix
+      // walk; resolve it through the canonical worktree index first.
+      const worktreeHit = worktreeByPath.get(directory) ?? null;
+      let owner: Props['projects'][number] | null = worktreeHit?.project ?? null;
+      if (!owner) {
+        let ownerLength = -1;
+        for (const project of projects) {
+          const projectPath = normalizePath(project.normalizedPath);
+          if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
+            owner = project;
+            ownerLength = projectPath.length;
+          }
         }
       }
       if (!owner) continue;
-      const worktree = availableWorktreesByProject.get(owner.normalizedPath)?.find((entry) => normalizePath(entry.path) === directory);
+      // Single resolver: the canonical worktree index already excludes the
+      // project root and normalizes every key. No per-project find fallback.
+      const worktree = worktreeHit?.meta ?? null;
       const projectLabel = formatProjectLabel(owner.label?.trim() || formatDirectoryName(owner.normalizedPath, homeDirectory) || owner.normalizedPath);
       const branch = worktree?.branch?.trim() || gitBranches.get(directory)?.trim() || null;
       locations.set(session.id, {
@@ -95,22 +124,32 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
       });
     }
     return locations;
-  }, [availableWorktreesByProject, sessions, gitBranches, homeDirectory, projects]);
+  }, [sessions, gitBranches, homeDirectory, projects, worktreeByPath]);
   const getSessionLocation = React.useCallback(
     (sessionId: string) => sessionLocationById.get(sessionId) ?? null,
     [sessionLocationById],
   );
   const getSessionNode = React.useCallback(
-    (session: Session): SessionNode => ({
-      session,
-      children: (childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({
-        session: child,
-        children: [],
-        worktree: null,
-      })),
-      worktree: null,
-    }),
-    [childrenMap],
+    (session: Session): SessionNode => {
+      // Attach the canonical worktree per session (root and children alike),
+      // mirroring the project grouping contract. The row derives its branch
+      // line fallback and PR lookup key from node.worktree; leaving it null
+      // is what reduced worktree rows to title+date.
+      const resolveWorktree = (target: Session): WorktreeMetadata | null => {
+        const targetDirectory = normalizePath(target.directory ?? null);
+        return (targetDirectory ? worktreeByPath.get(targetDirectory)?.meta : undefined) ?? null;
+      };
+      return {
+        session,
+        children: (childrenMap.get(session.id) ?? []).filter((child) => !child.time?.archived).map((child) => ({
+          session: child,
+          children: [],
+          worktree: resolveWorktree(child),
+        })),
+        worktree: resolveWorktree(session),
+      };
+    },
+    [childrenMap, worktreeByPath],
   );
   const recentSections = React.useMemo(() => deriveRecentActivitySections({
     sessions: recentSessions,

--- a/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/RecentSessionSection.tsx
@@ -9,10 +9,16 @@ import type { ActivityItem } from './SidebarActivitySections';
 import type { SessionTreeItemProps } from '../sessions/SessionTreeItem';
 import type { SessionNode } from '../types';
 import { formatProjectLabel, normalizePath } from '../utils';
+import {
+  buildWorktreeByPathIndex,
+  findPrefixWorktreeEntry,
+  resolveBranchLiveFirst,
+} from '../worktreeIndex';
 
 type Props = {
   projects: { id: string; label?: string; normalizedPath: string }[];
   availableWorktreesByProject: Map<string, WorktreeMetadata[]>;
+  worktreeMetadata?: ReadonlyMap<string, WorktreeMetadata>;
   gitBranches: Map<string, string | null>;
   homeDirectory: string | null;
   hasSessionSearchQuery: boolean;
@@ -52,10 +58,17 @@ type Props = {
   | 'startSessionWorktreeMenuLoad'
 >;
 
+type RecentWorktreeResolution = {
+  owner: Props['projects'][number] | null;
+  worktree: WorktreeMetadata | null;
+  worktreePath: string | null;
+};
+
 export const RecentSessionSection: React.FC<Props> = (props) => {
   const {
     projects,
     availableWorktreesByProject,
+    worktreeMetadata,
     gitBranches,
     homeDirectory,
     hasSessionSearchQuery,
@@ -69,53 +82,74 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
     showRecentSection,
   } = props;
   const { t } = useI18n();
-  // Canonical worktree index: linked worktrees often live outside the project
-  // root, so the prefix walk below can never own them. Mirror the project
-  // grouping contract — exact directory match, never the project root itself.
-  const worktreeByPath = React.useMemo(() => {
-    const byPath = new Map<string, { meta: WorktreeMetadata; project: Props['projects'][number] }>();
-    const projectByNormalizedPath = new Map<string, Props['projects'][number]>();
-    for (const project of projects) {
-      const normalized = normalizePath(project.normalizedPath);
-      if (normalized && !projectByNormalizedPath.has(normalized)) projectByNormalizedPath.set(normalized, project);
-    }
-    for (const [projectPath, worktrees] of availableWorktreesByProject) {
-      const project = projectByNormalizedPath.get(normalizePath(projectPath) ?? '') ?? null;
-      if (!project) continue;
-      const projectRoot = normalizePath(project.normalizedPath);
-      for (const entry of worktrees) {
-        const entryPath = normalizePath(entry.path);
-        if (!entryPath || entryPath === projectRoot || byPath.has(entryPath)) continue;
-        byPath.set(entryPath, { meta: entry, project });
+  // Canonical worktree index shared with project grouping and the switcher
+  // (normalization, project-root exclusion, first-wins dedupe).
+  const worktreeByPath = React.useMemo(
+    () => buildWorktreeByPathIndex(availableWorktreesByProject, projects),
+    [availableWorktreesByProject, projects],
+  );
+  const findOwnerProject = React.useCallback(
+    (directory: string): Props['projects'][number] | null => {
+      let owner: Props['projects'][number] | null = null;
+      let ownerLength = -1;
+      for (const project of projects) {
+        const projectPath = normalizePath(project.normalizedPath);
+        if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
+          owner = project;
+          ownerLength = projectPath.length;
+        }
       }
-    }
-    return byPath;
-  }, [availableWorktreesByProject, projects]);
+      return owner;
+    },
+    [projects],
+  );
+  // Resolution order mirrors project grouping parity: session-keyed metadata
+  // first (trusted only inside its own worktree), then longest-prefix worktree
+  // match for `<worktree>/sub`, then the existing project prefix walk.
+  // The project root itself never resolves to a worktree.
+  const resolveOwnerAndWorktree = React.useCallback(
+    (sessionId: string, directory: string): RecentWorktreeResolution => {
+      const sessionMeta = worktreeMetadata?.get(sessionId) ?? null;
+      if (sessionMeta) {
+        const metaPath = normalizePath(sessionMeta.path);
+        if (metaPath && (directory === metaPath || directory.startsWith(`${metaPath}/`))) {
+          const indexed = worktreeByPath.get(metaPath) ?? null;
+          if (indexed) {
+            if (directory !== normalizePath(indexed.project.normalizedPath)) {
+              return { owner: indexed.project, worktree: sessionMeta, worktreePath: metaPath };
+            }
+          } else {
+            const owner = findOwnerProject(metaPath) ?? findOwnerProject(directory);
+            if (owner && directory !== normalizePath(owner.normalizedPath)) {
+              return { owner, worktree: sessionMeta, worktreePath: metaPath };
+            }
+          }
+        }
+      }
+      const prefixHit = findPrefixWorktreeEntry(directory, worktreeByPath);
+      if (prefixHit) {
+        if (directory !== normalizePath(prefixHit.project.normalizedPath)) {
+          return {
+            owner: prefixHit.project,
+            worktree: prefixHit.meta,
+            worktreePath: normalizePath(prefixHit.meta.path) ?? directory,
+          };
+        }
+      }
+      return { owner: findOwnerProject(directory), worktree: null, worktreePath: null };
+    },
+    [findOwnerProject, worktreeByPath, worktreeMetadata],
+  );
   const sessionLocationById = React.useMemo(() => {
     const locations = new Map<string, RecentSessionLocation>();
     for (const session of sessions) {
       const directory = normalizePath(session.directory ?? null);
       if (!directory) continue;
-      // A worktree session outside its project root never matches the prefix
-      // walk; resolve it through the canonical worktree index first.
-      const worktreeHit = worktreeByPath.get(directory) ?? null;
-      let owner: Props['projects'][number] | null = worktreeHit?.project ?? null;
-      if (!owner) {
-        let ownerLength = -1;
-        for (const project of projects) {
-          const projectPath = normalizePath(project.normalizedPath);
-          if (projectPath && (directory === projectPath || directory.startsWith(`${projectPath}/`)) && projectPath.length > ownerLength) {
-            owner = project;
-            ownerLength = projectPath.length;
-          }
-        }
-      }
+      const { owner, worktree, worktreePath } = resolveOwnerAndWorktree(session.id, directory);
       if (!owner) continue;
-      // Single resolver: the canonical worktree index already excludes the
-      // project root and normalizes every key. No per-project find fallback.
-      const worktree = worktreeHit?.meta ?? null;
       const projectLabel = formatProjectLabel(owner.label?.trim() || formatDirectoryName(owner.normalizedPath, homeDirectory) || owner.normalizedPath);
-      const branch = worktree?.branch?.trim() || gitBranches.get(directory)?.trim() || null;
+      // Live-first: live git status wins over discovered worktree metadata.
+      const branch = resolveBranchLiveFirst(directory, worktreePath, worktree?.branch, gitBranches);
       locations.set(session.id, {
         projectId: owner.id,
         groupDirectory: directory,
@@ -124,7 +158,7 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
       });
     }
     return locations;
-  }, [sessions, gitBranches, homeDirectory, projects, worktreeByPath]);
+  }, [sessions, gitBranches, homeDirectory, resolveOwnerAndWorktree]);
   const getSessionLocation = React.useCallback(
     (sessionId: string) => sessionLocationById.get(sessionId) ?? null,
     [sessionLocationById],
@@ -137,7 +171,8 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
       // is what reduced worktree rows to title+date.
       const resolveWorktree = (target: Session): WorktreeMetadata | null => {
         const targetDirectory = normalizePath(target.directory ?? null);
-        return (targetDirectory ? worktreeByPath.get(targetDirectory)?.meta : undefined) ?? null;
+        if (!targetDirectory) return null;
+        return resolveOwnerAndWorktree(target.id, targetDirectory).worktree;
       };
       return {
         session,
@@ -149,7 +184,7 @@ export const RecentSessionSection: React.FC<Props> = (props) => {
         worktree: resolveWorktree(session),
       };
     },
-    [childrenMap, worktreeByPath],
+    [childrenMap, resolveOwnerAndWorktree],
   );
   const recentSections = React.useMemo(() => deriveRecentActivitySections({
     sessions: recentSessions,

--- a/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, mock, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Session } from '@opencode-ai/sdk/v2';
+import type { WorktreeMetadata } from '@/types/worktree';
+import { installHookTestDom } from '../test-utils/testDom';
+import { I18nProvider } from '@/lib/i18n';
+import type { SessionTreeItemProps } from '../sessions/SessionTreeItem';
+
+type CapturedSectionItem = {
+  node: {
+    session: Session;
+    worktree: WorktreeMetadata | null;
+  };
+  projectId: string | null;
+  groupDirectory: string | null;
+  secondaryMeta: {
+    projectLabel?: string | null;
+    branchLabel?: string | null;
+  } | null;
+};
+
+type CapturedSection = {
+  key: string;
+  items: CapturedSectionItem[];
+};
+
+const capturedSections: CapturedSection[][] = [];
+
+mock.module('./SidebarActivitySections', () => ({
+  SidebarActivitySections: (props: { sections: CapturedSection[] }) => {
+    capturedSections.push(props.sections);
+    return null;
+  },
+}));
+
+// SAFETY: RecentSessionSection is imported after the SidebarActivitySections mock so the test observes the real resolver.
+const { RecentSessionSection } = await import('./RecentSessionSection');
+
+const noopStartSessionWorktreeMenuLoad: SessionTreeItemProps['startSessionWorktreeMenuLoad'] = () => ({
+  cachedTargets: [],
+  refreshTargets: Promise.resolve([]),
+});
+
+// SAFETY: fixtures use the minimal Session fields the Recent resolver reads (id/directory/title/time).
+const worktreeSession = (id: string, directory: string): Session => ({
+  id,
+  title: id,
+  directory,
+  time: { created: 1, updated: 1 },
+}) as Session;
+
+const worktreeMeta = (path: string, branch: string): WorktreeMetadata => ({
+  path,
+  projectDirectory: '/workspace/app',
+  branch,
+  label: branch,
+});
+
+describe('RecentSessionSection external worktree resolve', () => {
+  test('resolves sessions outside the project root via the worktree index and keeps filtered branches hidden without leaking into the worktree fallback', async () => {
+    capturedSections.length = 0;
+    const dom = installHookTestDom();
+    const root = createRoot(dom.container);
+    const noop = () => undefined;
+    const sessions = [
+      worktreeSession('visible-feature', '/tmp/wt-feature'),
+      worktreeSession('filtered-head', '/tmp/wt-detached'),
+      worktreeSession('filtered-redundant', '/tmp/wt-redundant'),
+    ];
+
+    try {
+      await act(async () => {
+        root.render(
+          <I18nProvider>
+            <RecentSessionSection
+              projects={[{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }]}
+              availableWorktreesByProject={new Map([
+                ['/workspace/app', [
+                  worktreeMeta('/tmp/wt-feature', 'feature-1'),
+                  worktreeMeta('/tmp/wt-detached', 'HEAD'),
+                  worktreeMeta('/tmp/wt-redundant', 'App'),
+                ]],
+              ])}
+              gitBranches={new Map()}
+              homeDirectory={null}
+              hasSessionSearchQuery={false}
+              normalizedSessionSearchQuery=""
+              isDesktopShellRuntime={false}
+              sessions={sessions}
+              childrenMap={new Map()}
+              pinnedSessionIds={new Set()}
+              recentSessions={sessions}
+              expandedParents={new Set()}
+              notifyOnSubtasks={false}
+              editingId={null}
+              editTitle=""
+              copiedSessionId={null}
+              openSidebarMenuKey={null}
+              mobileVariant={false}
+              alwaysShowActions={false}
+              chatSessions={[]}
+              renderChatsSection={() => null}
+              onNewChat={noop}
+              showRecentSection
+              setEditingId={noop}
+              setEditTitle={noop}
+              toggleParent={noop}
+              setOpenSidebarMenuKey={noop}
+              allowReselect={false}
+              isSessionSearchOpen={false}
+              sessionSearchQuery=""
+              setSessionSearchQuery={noop}
+              setIsSessionSearchOpen={noop}
+              deleteSessionConfirm={null}
+              setDeleteSessionConfirm={noop}
+              startFolderRename={noop}
+              setCopiedSessionId={noop}
+              startSessionWorktreeMenuLoad={noopStartSessionWorktreeMenuLoad}
+            />
+          </I18nProvider>,
+        );
+      });
+
+      const recent = capturedSections.at(-1)?.find((section) => section.key === 'active-now');
+      expect(recent?.items.map((item) => item.node.session.id)).toEqual([
+        'visible-feature',
+        'filtered-head',
+        'filtered-redundant',
+      ]);
+      const byId = new Map(recent?.items.map((item) => [item.node.session.id, item]));
+
+      // (a) Worktree outside the project root resolves through the worktreeByPath index.
+      const visible = byId.get('visible-feature');
+      expect(visible?.projectId).toBe('app');
+      expect(visible?.groupDirectory).toBe('/tmp/wt-feature');
+      expect(visible?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'feature-1' });
+      expect(visible?.node.worktree?.path).toBe('/tmp/wt-feature');
+      expect(visible?.node.worktree?.branch).toBe('feature-1');
+
+      // (b) Filtered branches stay hidden yet keep the raw worktree branch for the project-row fallback.
+      const head = byId.get('filtered-head');
+      expect(head?.projectId).toBe('app');
+      expect(head?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: null });
+      expect(head?.node.worktree?.branch).toBe('HEAD');
+
+      const redundant = byId.get('filtered-redundant');
+      expect(redundant?.projectId).toBe('app');
+      expect(redundant?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: null });
+      expect(redundant?.node.worktree?.branch).toBe('App');
+
+      // SessionNodeItem priority (SessionNodeItem.tsx:372-378): an explicit
+      // secondaryMeta wins, so deliberate null must not fall through to the raw branch.
+      const resolveTooltipBranchLabel = (
+        secondaryMeta: CapturedSectionItem['secondaryMeta'],
+        worktreeBranch: string | null,
+      ): string | null => (secondaryMeta ? (secondaryMeta.branchLabel ?? null) : (worktreeBranch ?? null));
+
+      expect(resolveTooltipBranchLabel(visible?.secondaryMeta ?? null, visible?.node.worktree?.branch ?? null)).toBe('feature-1');
+      expect(resolveTooltipBranchLabel(head?.secondaryMeta ?? null, head?.node.worktree?.branch ?? null)).toBeNull();
+      expect(resolveTooltipBranchLabel(redundant?.secondaryMeta ?? null, redundant?.node.worktree?.branch ?? null)).toBeNull();
+      // Project rows pass no secondaryMeta and keep the worktree fallback.
+      expect(resolveTooltipBranchLabel(null, head?.node.worktree?.branch ?? null)).toBe('HEAD');
+      expect(resolveTooltipBranchLabel(null, redundant?.node.worktree?.branch ?? null)).toBe('App');
+    } finally {
+      await act(async () => root.unmount());
+      capturedSections.length = 0;
+      dom.restore();
+    }
+  });
+});

--- a/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
+++ b/packages/ui/src/components/session/sidebar/recent/recentSessionWorktreeResolve.test.tsx
@@ -168,4 +168,182 @@ describe('RecentSessionSection external worktree resolve', () => {
       dom.restore();
     }
   });
+
+  test('resolves <worktree>/sub via prefix and session-keyed metadata without leaking the project root', async () => {
+    capturedSections.length = 0;
+    const dom = installHookTestDom();
+    const root = createRoot(dom.container);
+    const noop = () => undefined;
+    const sessions = [
+      worktreeSession('sub-outside', '/tmp/wt-feature/sub'),
+      worktreeSession('sub-inside', '/workspace/app/.worktrees/inner/sub'),
+      worktreeSession('sub-keyed', '/tmp/wt-feature/nested'),
+      worktreeSession('root-session', '/workspace/app'),
+    ];
+
+    try {
+      await act(async () => {
+        root.render(
+          <I18nProvider>
+            <RecentSessionSection
+              projects={[{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }]}
+              availableWorktreesByProject={new Map([
+                ['/workspace/app', [
+                  worktreeMeta('/tmp/wt-feature', 'feature-1'),
+                  worktreeMeta('/workspace/app/.worktrees/inner', 'inner-1'),
+                ]],
+              ])}
+              worktreeMetadata={new Map([
+                ['sub-keyed', worktreeMeta('/tmp/wt-feature', 'feature-keyed')],
+              ])}
+              gitBranches={new Map()}
+              homeDirectory={null}
+              hasSessionSearchQuery={false}
+              normalizedSessionSearchQuery=""
+              isDesktopShellRuntime={false}
+              sessions={sessions}
+              childrenMap={new Map()}
+              pinnedSessionIds={new Set()}
+              recentSessions={sessions}
+              expandedParents={new Set()}
+              notifyOnSubtasks={false}
+              editingId={null}
+              editTitle=""
+              copiedSessionId={null}
+              openSidebarMenuKey={null}
+              mobileVariant={false}
+              alwaysShowActions={false}
+              chatSessions={[]}
+              renderChatsSection={() => null}
+              onNewChat={noop}
+              showRecentSection
+              setEditingId={noop}
+              setEditTitle={noop}
+              toggleParent={noop}
+              setOpenSidebarMenuKey={noop}
+              allowReselect={false}
+              isSessionSearchOpen={false}
+              sessionSearchQuery=""
+              setSessionSearchQuery={noop}
+              setIsSessionSearchOpen={noop}
+              deleteSessionConfirm={null}
+              setDeleteSessionConfirm={noop}
+              startFolderRename={noop}
+              setCopiedSessionId={noop}
+              startSessionWorktreeMenuLoad={noopStartSessionWorktreeMenuLoad}
+            />
+          </I18nProvider>,
+        );
+      });
+
+      const recent = capturedSections.at(-1)?.find((section) => section.key === 'active-now');
+      const byId = new Map(recent?.items.map((item) => [item.node.session.id, item]));
+
+      // Prefix match outside the project root owns the session and its worktree.
+      const outside = byId.get('sub-outside');
+      expect(outside?.projectId).toBe('app');
+      expect(outside?.groupDirectory).toBe('/tmp/wt-feature/sub');
+      expect(outside?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'feature-1' });
+      expect(outside?.node.worktree?.path).toBe('/tmp/wt-feature');
+
+      // Prefix match inside the project root resolves the inner worktree.
+      const inside = byId.get('sub-inside');
+      expect(inside?.projectId).toBe('app');
+      expect(inside?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'inner-1' });
+      expect(inside?.node.worktree?.path).toBe('/workspace/app/.worktrees/inner');
+
+      // Session-keyed metadata wins over the indexed worktree branch.
+      const keyed = byId.get('sub-keyed');
+      expect(keyed?.projectId).toBe('app');
+      expect(keyed?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'feature-keyed' });
+      expect(keyed?.node.worktree?.path).toBe('/tmp/wt-feature');
+      expect(keyed?.node.worktree?.branch).toBe('feature-keyed');
+
+      // The project root itself never resolves to a worktree.
+      const rootSession = byId.get('root-session');
+      expect(rootSession?.projectId).toBe('app');
+      expect(rootSession?.node.worktree).toBeNull();
+    } finally {
+      await act(async () => root.unmount());
+      capturedSections.length = 0;
+      dom.restore();
+    }
+  });
+
+  test('prefers live git branch over stored worktree metadata, including <worktree>/sub', async () => {
+    capturedSections.length = 0;
+    const dom = installHookTestDom();
+    const root = createRoot(dom.container);
+    const noop = () => undefined;
+    const sessions = [
+      worktreeSession('desync-exact', '/tmp/wt-feature'),
+      worktreeSession('desync-sub', '/tmp/wt-feature/sub'),
+    ];
+
+    try {
+      await act(async () => {
+        root.render(
+          <I18nProvider>
+            <RecentSessionSection
+              projects={[{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }]}
+              availableWorktreesByProject={new Map([
+                ['/workspace/app', [worktreeMeta('/tmp/wt-feature', 'stored-1')]],
+              ])}
+              gitBranches={new Map([
+                ['/tmp/wt-feature', 'live-1'],
+              ])}
+              homeDirectory={null}
+              hasSessionSearchQuery={false}
+              normalizedSessionSearchQuery=""
+              isDesktopShellRuntime={false}
+              sessions={sessions}
+              childrenMap={new Map()}
+              pinnedSessionIds={new Set()}
+              recentSessions={sessions}
+              expandedParents={new Set()}
+              notifyOnSubtasks={false}
+              editingId={null}
+              editTitle=""
+              copiedSessionId={null}
+              openSidebarMenuKey={null}
+              mobileVariant={false}
+              alwaysShowActions={false}
+              chatSessions={[]}
+              renderChatsSection={() => null}
+              onNewChat={noop}
+              showRecentSection
+              setEditingId={noop}
+              setEditTitle={noop}
+              toggleParent={noop}
+              setOpenSidebarMenuKey={noop}
+              allowReselect={false}
+              isSessionSearchOpen={false}
+              sessionSearchQuery=""
+              setSessionSearchQuery={noop}
+              setIsSessionSearchOpen={noop}
+              deleteSessionConfirm={null}
+              setDeleteSessionConfirm={noop}
+              startFolderRename={noop}
+              setCopiedSessionId={noop}
+              startSessionWorktreeMenuLoad={noopStartSessionWorktreeMenuLoad}
+            />
+          </I18nProvider>,
+        );
+      });
+
+      const recent = capturedSections.at(-1)?.find((section) => section.key === 'active-now');
+      const byId = new Map(recent?.items.map((item) => [item.node.session.id, item]));
+      // Live-first: the stored branch is visible only through node.worktree,
+      // never as the displayed branch label.
+      expect(byId.get('desync-exact')?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'live-1' });
+      expect(byId.get('desync-exact')?.node.worktree?.branch).toBe('stored-1');
+      // Subdirectory sessions reuse the worktree-root live branch.
+      expect(byId.get('desync-sub')?.secondaryMeta).toEqual({ projectLabel: 'App', branchLabel: 'live-1' });
+      expect(byId.get('desync-sub')?.node.worktree?.path).toBe('/tmp/wt-feature');
+    } finally {
+      await act(async () => root.unmount());
+      capturedSections.length = 0;
+      dom.restore();
+    }
+  });
 });

--- a/packages/ui/src/components/session/sidebar/sessions/SessionNodeItem.tsx
+++ b/packages/ui/src/components/session/sidebar/sessions/SessionNodeItem.tsx
@@ -369,7 +369,13 @@ function SessionNodeItemComponent(props: SessionNodeItemProps): React.ReactNode 
   );
   const tooltipProjectLabel = secondaryMeta?.projectLabel
     ?? (projectLabelFromStore ? formatProjectLabel(projectLabelFromStore) : null);
-  const tooltipBranchLabel = secondaryMeta?.branchLabel ?? node.worktree?.branch ?? null;
+  const tooltipBranchLabel = secondaryMeta
+    // Recent rows carry an explicit secondaryMeta: a null branchLabel there
+    // is a deliberate filter (HEAD/redundant with the project label), not a
+    // missing value, so it must not fall through to the raw worktree branch.
+    // Project rows pass no secondaryMeta and keep the worktree fallback.
+    ? (secondaryMeta.branchLabel ?? null)
+    : (node.worktree?.branch ?? null);
   const prLookupKey = React.useMemo(() => {
     if (isVSCode) return null;
     const branch = node.worktree?.branch?.trim();

--- a/packages/ui/src/components/session/sidebar/shell/useSwitcherItems.ts
+++ b/packages/ui/src/components/session/sidebar/shell/useSwitcherItems.ts
@@ -12,6 +12,8 @@ import { compareSessionsByLifecycleOrder, useSessionOrderingStore } from '@/sync
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { isVSCodeRuntime } from '@/lib/desktop';
 import { isChatDirectoryPath } from '@/lib/chatDirectories';
+import { buildWorktreeByPathIndex } from '../worktreeIndex';
+import { normalizePath } from '../utils';
 
 export type SwitcherItem = {
   node: SessionNode;
@@ -30,13 +32,6 @@ type SwitcherItemsOptions = {
   currentSessionId?: string | null;
   /** How many parent sessions to return (default 7 — the desktop dropdown). */
   maxParents?: number;
-};
-
-const normalize = (value: string | null | undefined): string | null => {
-  if (!value) return null;
-  const replaced = value.replace(/\\/g, '/');
-  if (replaced === '/') return '/';
-  return replaced.length > 1 ? replaced.replace(/\/+$/, '') : replaced;
 };
 
 const formatProjectLabel = (project: { label?: string | null; path: string } | null): string | null => {
@@ -118,45 +113,35 @@ export const useSwitcherItems = (enabled: boolean, options: SwitcherItemsOptions
   const availableWorktreesByProject = useSessionUIStore((state) => state.availableWorktreesByProject);
   const isVSCode = React.useMemo(() => isVSCodeRuntime(), []);
 
+  const normalizedProjects = React.useMemo(
+    () => projects
+      .map((project) => ({ ...project, normalizedPath: normalizePath(project.path) }))
+      .filter((project) => project.normalizedPath),
+    [projects],
+  );
+
   // Worktree sessions live OUTSIDE their project's path, so prefix matching
   // can't resolve their project — and their branch is known from worktree
   // discovery long before any git status is fetched for that directory.
-  const worktreeInfoByPath = React.useMemo(() => {
-    const map = new Map<string, { projectPath: string; branch: string | null }>();
-    for (const [projectPath, worktrees] of availableWorktreesByProject) {
-      const normalizedProjectPath = normalize(projectPath);
-      if (!normalizedProjectPath) continue;
-      for (const worktree of worktrees) {
-        const worktreePath = normalize(worktree.path);
-        if (!worktreePath) continue;
-        map.set(worktreePath, { projectPath: normalizedProjectPath, branch: worktree.branch?.trim() || null });
-      }
-    }
-    return map;
-  }, [availableWorktreesByProject]);
-
-  const normalizedProjects = React.useMemo(
-    () => projects
-      .map((project) => ({ ...project, normalizedPath: normalize(project.path) }))
-      .filter((project) => project.normalizedPath),
-    [projects],
+  // Shared exact index: normalized keys, project-root exclusion, first-wins.
+  // Already live-first below (`liveBranch ?? stored`), so no branch change.
+  const worktreeByPath = React.useMemo(
+    () => buildWorktreeByPathIndex(availableWorktreesByProject, normalizedProjects),
+    [availableWorktreesByProject, normalizedProjects],
   );
 
   const findProjectForDirectory = React.useCallback(
     (directory: string | null) => {
       if (!directory) return null;
       // Known worktree → its project, regardless of where the worktree lives.
-      const worktreeInfo = worktreeInfoByPath.get(normalize(directory) ?? directory);
-      if (worktreeInfo) {
-        const byPath = normalizedProjects.find((project) => project.normalizedPath === worktreeInfo.projectPath);
-        if (byPath) return byPath;
-      }
+      const worktreeHit = worktreeByPath.get(normalizePath(directory) ?? directory);
+      if (worktreeHit) return worktreeHit.project;
       const matches = normalizedProjects
         .filter((project) => isPathWithinProject(directory, project.normalizedPath))
         .sort((a, b) => (b.normalizedPath?.length ?? 0) - (a.normalizedPath?.length ?? 0));
       return matches[0] ?? null;
     },
-    [normalizedProjects, worktreeInfoByPath],
+    [normalizedProjects, worktreeByPath],
   );
 
   const items = React.useMemo<SwitcherItem[]>(() => {
@@ -205,9 +190,9 @@ export const useSwitcherItems = (enabled: boolean, options: SwitcherItemsOptions
       const projectLabel = formatProjectLabel(matchedProject);
       // Live git branch when available; the discovered worktree branch fills
       // in for directories whose git status hasn't been fetched yet.
-      const worktreeInfo = directory ? worktreeInfoByPath.get(normalize(directory) ?? directory) : null;
+      const worktreeHit = directory ? worktreeByPath.get(normalizePath(directory) ?? directory) : null;
       const liveBranch = directory ? branchesByDirectory.get(directory) : undefined;
-      const branchLabel = liveBranch ?? worktreeInfo?.branch ?? null;
+      const branchLabel = liveBranch ?? worktreeHit?.meta.branch?.trim() ?? null;
       return {
         node: buildNode(session),
         projectId: matchedProject?.id ?? null,
@@ -218,7 +203,7 @@ export const useSwitcherItems = (enabled: boolean, options: SwitcherItemsOptions
         },
       };
     });
-  }, [activeSessions, branchesByDirectory, currentSessionId, enabled, findProjectForDirectory, isVSCode, maxParents, pinnedSessionIds, scopeProjectId, sessionOrderRanks, worktreeInfoByPath]);
+  }, [activeSessions, branchesByDirectory, currentSessionId, enabled, findProjectForDirectory, isVSCode, maxParents, pinnedSessionIds, scopeProjectId, sessionOrderRanks, worktreeByPath]);
 
   return items;
 };

--- a/packages/ui/src/components/session/sidebar/worktreeIndex.test.ts
+++ b/packages/ui/src/components/session/sidebar/worktreeIndex.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import type { WorktreeMetadata } from '@/types/worktree';
+import {
+  buildProjectWorktreeIndex,
+  buildWorktreeByPathIndex,
+  findPrefixWorktreeEntry,
+  resolveBranchLiveFirst,
+} from './worktreeIndex';
+
+const meta = (path: string, branch: string): WorktreeMetadata => ({
+  path,
+  projectDirectory: '/workspace/app',
+  branch,
+  label: branch,
+});
+
+describe('worktreeIndex shared exact index', () => {
+  test('normalizes keys, excludes the owning project root, and keeps the first duplicate', () => {
+    const index = buildWorktreeByPathIndex(
+      new Map([
+        ['/workspace/app', [
+          meta('/workspace/app', 'root-branch'),
+          meta('/tmp/wt-feature/', 'feature-1'),
+          meta('/tmp/wt-feature', 'feature-duplicate'),
+        ]],
+      ]),
+      [{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }],
+    );
+    expect(index.has('/workspace/app')).toBe(false);
+    expect(index.get('/tmp/wt-feature')?.meta.branch).toBe('feature-1');
+    expect(index.get('/tmp/wt-feature')?.project.id).toBe('app');
+  });
+
+  test('per-project index excludes its root and keeps the first duplicate', () => {
+    const index = buildProjectWorktreeIndex(
+      [meta('/workspace/app', 'root'), meta('/tmp/wt-a', 'a-first'), meta('/tmp/wt-a', 'a-second')],
+      '/workspace/app',
+    );
+    expect(index.has('/workspace/app')).toBe(false);
+    expect(index.get('/tmp/wt-a')?.branch).toBe('a-first');
+  });
+
+  test('prefix lookup prefers the longest containing worktree and includes exact matches', () => {
+    const index = buildWorktreeByPathIndex(
+      new Map([
+        ['/workspace/app', [
+          meta('/tmp/wt', 'outer'),
+          meta('/tmp/wt/nested', 'inner'),
+        ]],
+      ]),
+      [{ id: 'app', label: 'App', normalizedPath: '/workspace/app' }],
+    );
+    expect(findPrefixWorktreeEntry('/tmp/wt', index)?.meta.branch).toBe('outer');
+    expect(findPrefixWorktreeEntry('/tmp/wt/sub', index)?.meta.branch).toBe('outer');
+    expect(findPrefixWorktreeEntry('/tmp/wt/nested/sub', index)?.meta.branch).toBe('inner');
+    expect(findPrefixWorktreeEntry('/tmp/other', index)).toBeNull();
+    expect(findPrefixWorktreeEntry('/tmp/wt-other', index)).toBeNull();
+  });
+
+  test('live branch wins over stored metadata, with worktree-root fallback for subdirectories', () => {
+    const gitBranches = new Map<string, string | null>([['/tmp/wt-feature', 'live-1']]);
+    expect(resolveBranchLiveFirst('/tmp/wt-feature', '/tmp/wt-feature', 'stored-1', gitBranches)).toBe('live-1');
+    expect(resolveBranchLiveFirst('/tmp/wt-feature/sub', '/tmp/wt-feature', 'stored-1', gitBranches)).toBe('live-1');
+    expect(resolveBranchLiveFirst('/tmp/wt-feature/sub', '/tmp/wt-feature', 'stored-1', new Map())).toBe('stored-1');
+    expect(resolveBranchLiveFirst('/tmp/wt-feature', '/tmp/wt-feature', '  ', new Map())).toBeNull();
+  });
+});

--- a/packages/ui/src/components/session/sidebar/worktreeIndex.ts
+++ b/packages/ui/src/components/session/sidebar/worktreeIndex.ts
@@ -1,0 +1,103 @@
+import type { WorktreeMetadata } from '@/types/worktree';
+import { normalizePath } from './utils';
+
+export type WorktreeIndexProject = {
+  id: string;
+  normalizedPath: string | null | undefined;
+  label?: string | null;
+};
+
+export type WorktreeIndexEntry<P extends WorktreeIndexProject = WorktreeIndexProject> = {
+  meta: WorktreeMetadata;
+  project: P;
+};
+
+/**
+ * Canonical exact worktree index shared by Recent, project grouping, and the
+ * session switcher. Normalizes every key, excludes the owning project root,
+ * and keeps the first entry on duplicate paths so repeated topology publishes
+ * cannot flip ownership.
+ */
+export const buildWorktreeByPathIndex = <P extends WorktreeIndexProject>(
+  availableWorktreesByProject: ReadonlyMap<string, readonly WorktreeMetadata[]>,
+  projects: readonly P[],
+): Map<string, WorktreeIndexEntry<P>> => {
+  const byPath = new Map<string, WorktreeIndexEntry<P>>();
+  const projectByNormalizedPath = new Map<string, P>();
+  for (const project of projects) {
+    const normalized = normalizePath(project.normalizedPath ?? null);
+    if (normalized && !projectByNormalizedPath.has(normalized)) projectByNormalizedPath.set(normalized, project);
+  }
+  for (const [projectPath, worktrees] of availableWorktreesByProject) {
+    const project = projectByNormalizedPath.get(normalizePath(projectPath) ?? '') ?? null;
+    if (!project) continue;
+    const projectRoot = normalizePath(project.normalizedPath ?? null);
+    for (const entry of worktrees) {
+      const entryPath = normalizePath(entry.path);
+      if (!entryPath || entryPath === projectRoot || byPath.has(entryPath)) continue;
+      byPath.set(entryPath, { meta: entry, project });
+    }
+  }
+  return byPath;
+};
+
+/**
+ * Per-project exact worktree index for `useSessionGrouping`. Same contract as
+ * the global index: normalized keys, project-root exclusion, first-wins
+ * dedupe. Previously the grouping map kept the last duplicate; unifying on
+ * first-wins matches Recent and keeps repeated publishes stable.
+ */
+export const buildProjectWorktreeIndex = (
+  availableWorktrees: readonly WorktreeMetadata[],
+  projectRoot: string | null,
+): Map<string, WorktreeMetadata> => {
+  const byPath = new Map<string, WorktreeMetadata>();
+  for (const meta of availableWorktrees) {
+    if (!meta.path) continue;
+    const normalized = normalizePath(meta.path) ?? meta.path;
+    if (!normalized || normalized === projectRoot || byPath.has(normalized)) continue;
+    byPath.set(normalized, meta);
+  }
+  return byPath;
+};
+
+/**
+ * Longest-prefix worktree lookup for sessions inside `<worktree>/sub`.
+ * Exact matches are included (`directory === path`). Returns null when no
+ * indexed worktree contains the directory.
+ */
+export const findPrefixWorktreeEntry = <T>(
+  directory: string,
+  index: ReadonlyMap<string, T>,
+): T | null => {
+  let best: T | null = null;
+  let bestLength = -1;
+  for (const [path, entry] of index) {
+    if (path.length <= bestLength) continue;
+    if (directory === path || directory.startsWith(`${path}/`)) {
+      best = entry;
+      bestLength = path.length;
+    }
+  }
+  return best;
+};
+
+/**
+ * Live-first branch invariant: live git status wins over discovered worktree
+ * metadata when they disagree. The worktree-root live lookup covers sessions
+ * in `<worktree>/sub`, whose own directory rarely has a git-status entry.
+ */
+export const resolveBranchLiveFirst = (
+  directory: string,
+  worktreePath: string | null,
+  worktreeBranch: string | null | undefined,
+  gitBranches: ReadonlyMap<string, string | null>,
+): string | null => {
+  const liveAtDirectory = gitBranches.get(directory)?.trim() || null;
+  if (liveAtDirectory) return liveAtDirectory;
+  if (worktreePath && worktreePath !== directory) {
+    const liveAtWorktree = gitBranches.get(worktreePath)?.trim() || null;
+    if (liveAtWorktree) return liveAtWorktree;
+  }
+  return worktreeBranch?.trim() || null;
+};


### PR DESCRIPTION
## Intent

Follow-up to #3476 / #3481, closes #3483. Three deferred items: sessions in a worktree subdirectory now resolve owner, worktree and branch in Recent (session-keyed metadata with longest-prefix fallback); branch display is live-first everywhere with stored metadata as fallback only; the exact-match worktree index is extracted into sidebar/worktreeIndex and shared by grouping, switcher and Recent. Stacked on #3481, merge after it.

## Non-goals

- No changes to Projects exact-only grouping keys beyond the index builder swap; subdir sessions without session metadata still bucket as before there (known gap, future follow-up).
- No switcher project-resolution change beyond the same index swap; switcher subdir-without-metadata parity also future follow-up.
- No dependency, config, migration or persisted-contract changes.

## Affected surfaces

- packages/ui sidebar only: Recent rows, shared SessionNodeItem tooltip input, switcher items, grouping index builder, plus two test files and one new owning module. Web, desktop and hosted mobile share these paths. VS Code gates unchanged. No persisted or external contracts.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root AGENTS.md instruction order plus module DOCUMENTATION | Source change in sidebar ownership area | Read root guide, sidebar docs and neighboring tests before editing |
| openchamber-change-discipline | Shared-data change across three consumers | One owning helper module, single resolver order, no new deps or configs |
| sync-state-invariants | Worktree resolution and branch freshness from live and stored state | Session-keyed metadata with containment check, longest-prefix fallback, root exclusion, HEAD filter kept |
| ui-api-decoupling | Same PR-key and store reads as Projects | No store contract changes, metadata prop threaded from existing topology |

## Validation

| Check | Result |
|---|---|
| bun test, 8 sidebar suites | 31 pass, 0 fail |
| bun run type-check in packages/ui | PASS, exit 0 |
| bunx oxlint on authored code | PASS, no findings; 9 anti-slop hits in untouched lines are known backlog, left alone |
| Independent tester, full boundary | PASS with the same evidence |
| Independent reviewer, whole-PR | READY-GO, no blockers, Coverage full PR |
| Remote CI | Green on this HEAD (checks, automation, label) |
| Full workspace build | Not run, out of scope for this diff |

## Visual evidence

No screenshots attached yet. The change is data resolution for tooltip rows, covered by unit suites plus two reviewer passes. Recent vs Projects hover shots to be attached before merge.

## Risks and failure behavior

Risk is Recent rows and switcher labels. Root is never a worktree, HEAD and label-equal branches stay hidden, archived/chats/VS Code paths untouched. Grouping dedupe moved last-wins to first-wins with no observed duplicates. Rollback is a single-commit revert.