### PR TITLE
fix(chat): reset errors when sessions change

### DIFF
--- a/packages/ui/src/components/chat/ChatErrorBoundary.tsx
+++ b/packages/ui/src/components/chat/ChatErrorBoundary.tsx
@@ -28,7 +28,7 @@ interface ChatErrorBoundaryViewProps extends ChatErrorBoundaryProps {
   texts: ChatErrorBoundaryTexts;
 }
 
-class ChatErrorBoundaryView extends React.Component<ChatErrorBoundaryViewProps, ChatErrorBoundaryState> {
+export class ChatErrorBoundaryView extends React.Component<ChatErrorBoundaryViewProps, ChatErrorBoundaryState> {
   constructor(props: ChatErrorBoundaryViewProps) {
     super(props);
     this.state = { hasError: false };
@@ -43,6 +43,12 @@ class ChatErrorBoundaryView extends React.Component<ChatErrorBoundaryViewProps, 
 
     if (process.env.NODE_ENV === 'development') {
       console.error('Chat error caught by boundary:', error, errorInfo);
+    }
+  }
+
+  componentDidUpdate(previousProps: ChatErrorBoundaryViewProps) {
+    if (previousProps.sessionId !== this.props.sessionId && this.state.hasError) {
+      this.handleReset();
     }
   }
 

--- a/packages/ui/src/components/chat/__tests__/ChatErrorBoundary.test.ts
+++ b/packages/ui/src/components/chat/__tests__/ChatErrorBoundary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ChatErrorBoundaryView } from '../ChatErrorBoundary';
+
+const texts = {
+  title: 'Chat Error',
+  description: 'Description',
+  sessionLabel: 'Session',
+  detailsSummary: 'Error details',
+  resetAction: 'Reset chat',
+  persistentHint: 'Refresh the page',
+};
+
+describe('ChatErrorBoundaryView', () => {
+  test('resets a latched error when the selected session changes', () => {
+    const boundary = new ChatErrorBoundaryView({
+      children: null,
+      sessionId: 'next-session',
+      texts,
+    });
+    let resetCalls = 0;
+    boundary.state = { hasError: true, error: new Error('failed') };
+    boundary.handleReset = () => { resetCalls += 1; };
+
+    boundary.componentDidUpdate({
+      children: null,
+      sessionId: 'failed-session',
+      texts,
+    });
+
+    expect(resetCalls).toBe(1);
+  });
+
+  test('keeps the fallback mounted for the session that failed', () => {
+    const boundary = new ChatErrorBoundaryView({
+      children: null,
+      sessionId: 'failed-session',
+      texts,
+    });
+    let resetCalls = 0;
+    boundary.state = { hasError: true, error: new Error('failed') };
+    boundary.handleReset = () => { resetCalls += 1; };
+
+    boundary.componentDidUpdate({
+      children: null,
+      sessionId: 'failed-session',
+      texts,
+    });
+
+    expect(resetCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Intent

A chat error currently stays latched in `ChatErrorBoundary` when the selected session changes. After one session throws, selecting another session updates the displayed session ID but never renders that session, so every later chat appears to have the same error.

Reset the boundary only when `sessionId` changes. The session that threw keeps its fallback and Reset chat behavior, while selecting another session gets one clean render attempt.

This cross-session defect is tracked in #3492. It was observed while diagnosing #3186, but the original CRLF selection exception was already fixed on `main` by #3207. This PR does not duplicate that editor change.

Closes #3492

## Non-goals

- No change to CodeMirror document or selection handling; #3207 owns that fix.
- No automatic retry for the same failing session.
- No key-based remount during normal session switching.

## Affected surfaces

- `packages/ui` chat error handling in every runtime that renders `ChatView`: web, desktop, VS Code, hosted mobile, and Capacitor mobile.
- No persisted format, API, runtime bridge, authentication, or Electron main-process contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` correctness invariants | One session's fallback was blocking unrelated sessions | The fallback is scoped to the session that failed and clears when the authoritative selected session ID changes |
| `openchamber-change-discipline` | This changes shared UI runtime behavior | The implementation is one lifecycle guard with focused positive and negative regression tests |
| `theme-system` | The changed file is a UI component | No markup, tokens, controls, icons, or styles changed |
| `communication-style` | This PR and issue handoff are human-facing text | The report names the observed behavior and mechanism directly |

No changelog entry was added. Current repository guidance reserves `changelog/unreleased.md` for a maintainer-requested release update.

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/__tests__/ChatErrorBoundary.test.ts` | Pass, 2 tests and 2 assertions |
| Mutation: invert the session-change comparison | Caught by the focused test |
| `bun run --cwd packages/ui type-check` | Pass |
| `bun run --cwd packages/ui lint` | Pass |
| `bun run type-check` | Pass for all workspaces |
| `bun run lint` | Pass for all workspaces |
| `bunx --bun oxlint` on both changed files | Clean |
| `bun run dead-code` | Completed; the new test-only class export was not reported, existing repository backlog remains |
| `bun run build` | Pass for all workspaces |
| `bun run test` | Pass on the uncontended retry: UI 443/443 files, VS Code 40/40, Electron 23/23, Web 195/195 files with 2219 passed and 2 skipped |

The first full test run overlapped the full build and two unrelated UI tests hit their exact five-second timeout. Both passed alone, then the full suite passed when rerun without build contention.

Manual evidence: the Linux desktop package containing the same boundary change and the now-upstream CRLF fix was installed to `~/Applications/openchamber`; the reporter confirmed the original bug no longer appears. The exact rebased PR HEAD was not repackaged after duplicate editor changes were dropped.

## Visual evidence

No visual styling or layout changes. The existing error card is unchanged. The behavioral difference is that selecting another session no longer reuses the previous session's error state; the positive and negative lifecycle cases are covered by the regression test.

## Risks and failure behavior

- A session that still throws remains on its error card, preserving the current same-session behavior.
- Changing sessions clears the fallback after the prop update and gives the newly selected chat one render attempt. If that chat also throws, React captures its own error normally.
- The reset is conditional on `hasError`, so successful session switches do not add state updates or remount the chat tree.
- Rollback is a two-file revert with no persisted-data cleanup.
