### PR TITLE
fix(chat): reveal a sealed text part's held tail while a question pends

### DIFF
--- a/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
@@ -3,7 +3,7 @@ import type { Part } from '@opencode-ai/sdk/v2';
 import { MarkdownRenderer } from '../../MarkdownRenderer';
 import type { StreamPhase, ToolPopupContent } from '../types';
 import { useStreamingTextThrottle } from '../../hooks/useStreamingTextThrottle';
-import { resolveAssistantDisplayText, shouldRenderAssistantText } from './assistantTextVisibility';
+import { resolveAssistantDisplayText, resolveAssistantTextStreaming, shouldRenderAssistantText } from './assistantTextVisibility';
 import { streamPerfCount, streamPerfObserve } from '@/stores/utils/streamDebug';
 import { GeneratedJsonResultCard } from './GeneratedJsonResultCard';
 import { parseGeneratedJsonResult } from './generatedJsonResult';
@@ -35,9 +35,13 @@ const AssistantTextPart: React.FC<AssistantTextPartProps> = ({
     const textContent = [rawText, contentText, valueText].reduce((best, candidate) => {
         return candidate.length > best.length ? candidate : best;
     }, '');
-    const isStreamingPhase = streamPhase === 'streaming';
-    const isCooldownPhase = streamPhase === 'cooldown';
-    const isStreaming = chatRenderMode === 'live' && (isStreamingPhase || isCooldownPhase);
+    const time = partWithText.time;
+    const isFinalized = Boolean(time && typeof time.end !== 'undefined');
+    const isStreaming = resolveAssistantTextStreaming({
+        streamPhase,
+        chatRenderMode,
+        isFinalized,
+    });
 
     streamPerfCount('ui.assistant_text_part.render');
     if (isStreaming) {
@@ -57,9 +61,6 @@ const AssistantTextPart: React.FC<AssistantTextPartProps> = ({
     });
 
     streamPerfObserve('ui.assistant_text_part.display_len', displayTextContent.length);
-
-    const time = partWithText.time;
-    const isFinalized = Boolean(time && typeof time.end !== 'undefined');
 
     const isRenderableTextPart = part.type === 'text' || part.type === 'reasoning';
     if (!isRenderableTextPart) {

--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -175,6 +175,7 @@ tool patch is parsed while the turn streams.
 - Running bash output falls back to `state.metadata.output` until canonical `state.output` arrives. Its output viewport grows with the content up to `46vh`, then scrolls and follows new output until the user scrolls up; following resumes when the user returns to the bottom. Live output appends or replaces rewritten snapshots as plain text without worker highlighting; finalized output normalizes ANSI terminal controls with a bounded synthetic-cell budget, bypasses the throttle, and receives the normal one-time highlighted rendering.
 - Thinking/Justification duration is hidden in `sorted` mode (handled in `ReasoningPart.tsx` + `JustificationBlock.tsx`).
 - Reasoning streaming presentation derives from the live stream phase (`streaming`/`cooldown`), never from missing persisted timing: a cached part without `time.end` is not live, and a part whose `time.end` is set never streams (issue #2020).
+- Assistant text parts carry the same part-finalization gate (`assistantTextVisibility.ts`): live mode's block-commit reveal holds a still-growing part's trailing line, while a part sealed with `time.end` renders in full immediately — including while the turn stays blocked on a pending question or permission ask (#3277).
 
 ## "I want to change description for Perplexity" (example recipe)
 

--- a/packages/ui/src/components/chat/message/parts/assistantTextVisibility.test.ts
+++ b/packages/ui/src/components/chat/message/parts/assistantTextVisibility.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+    resolveAssistantDisplayText,
+    resolveAssistantTextStreaming,
+    shouldRenderAssistantText,
+} from './assistantTextVisibility';
+
+describe('resolveAssistantTextStreaming', () => {
+    test('streams live text whose part is not sealed', () => {
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'live',
+            isFinalized: false,
+        })).toBe(true);
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'cooldown',
+            chatRenderMode: 'live',
+            isFinalized: false,
+        })).toBe(true);
+    });
+
+    test('never streams in sorted mode', () => {
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'sorted',
+            isFinalized: false,
+        })).toBe(false);
+    });
+
+    test('releases a sealed part even while the turn stays blocked (#3277)', () => {
+        // A message blocked on a pending question keeps the stream phase
+        // forever; the pre-question text part is sealed (time.end is set the
+        // moment the model moves on to the question) and must render in full.
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'live',
+            isFinalized: true,
+        })).toBe(false);
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'cooldown',
+            chatRenderMode: 'live',
+            isFinalized: true,
+        })).toBe(false);
+    });
+});
+
+describe('resolveAssistantDisplayText', () => {
+    test('holds the trailing line while streaming', () => {
+        const text = 'line nine, fully written\nline ten, still held';
+        expect(resolveAssistantDisplayText({
+            textContent: text,
+            throttledTextContent: text,
+            isStreaming: true,
+        })).toBe('line nine, fully written\n');
+    });
+
+    test('reveals the full text once the part is not streaming', () => {
+        const text = 'one\ntwo\nsealed tail without trailing newline';
+        expect(resolveAssistantDisplayText({
+            textContent: text,
+            throttledTextContent: text,
+            isStreaming: false,
+        })).toBe(text);
+    });
+});
+
+describe('shouldRenderAssistantText', () => {
+    test('hides empty text until finalized', () => {
+        expect(shouldRenderAssistantText({ displayTextContent: '', isFinalized: false })).toBe(false);
+    });
+
+    test('renders non-empty display text', () => {
+        expect(shouldRenderAssistantText({ displayTextContent: 'content', isFinalized: false })).toBe(true);
+        expect(shouldRenderAssistantText({ displayTextContent: 'content', isFinalized: true })).toBe(true);
+    });
+});

--- a/packages/ui/src/components/chat/message/parts/assistantTextVisibility.ts
+++ b/packages/ui/src/components/chat/message/parts/assistantTextVisibility.ts
@@ -1,4 +1,24 @@
 import { commitStreamedText } from '../../lib/streamTextCommit';
+import type { StreamPhase } from '../types';
+
+// A text part sealed with `time.end` can no longer receive tokens, so the
+// block-commit hold — which exists to keep a growing paragraph from mutating
+// in place — has nothing left to protect for that part. Gating on part
+// finalization keeps the hold for genuinely streaming parts while releasing
+// sealed ones: a message blocked on a pending question (or permission ask)
+// never finishes, so its pre-question text would otherwise keep its last
+// line hidden until the user answers (#3277).
+export const resolveAssistantTextStreaming = (input: {
+    streamPhase: StreamPhase;
+    chatRenderMode: 'sorted' | 'live';
+    isFinalized: boolean;
+}): boolean => {
+    if (input.isFinalized) {
+        return false;
+    }
+    return input.chatRenderMode === 'live'
+        && (input.streamPhase === 'streaming' || input.streamPhase === 'cooldown');
+};
 
 export const resolveAssistantDisplayText = (input: {
     textContent: string;


### PR DESCRIPTION
Fixes #3277

## Intent

The reporter's scenario (reproduced on current `main`, evidence below): the model emits a multi-line text part, then calls the `question` tool. While the question card waits for the user, the assistant text renders **without its last line**; the missing line only appears after an option is selected — exactly when it is too late to inform the choice.

Root cause — the third rendering path behind this bug family:

- Live mode reveals streamed text block-by-block: `commitStreamedText` holds everything after the last complete line so a shown paragraph never mutates in place. The held tail normally lands "with the next line break (or the finalize pass)" (`assistantTextVisibility.ts`).
- A message blocked on a pending `question` never finishes — `finishReason` stays unset for as long as the question runs — so the finalize pass never comes, and the tail (≤ `HOLD_MAX_CHARS`) is held indefinitely.
- #2655 already fixed the sorted-mode paths (justification classification + `shouldDeferSortedInlineText`); the triage comment on #3277 suspected a different code path — it is this live-mode reveal gate. The same holds for any turn-blocking tool (permission asks).

The fix gates the hold on **part finalization**: a text part sealed with `time.end` can no longer receive tokens — the SDK stamps `time.end` the moment the model moves on to the question part (verified below) — so the block-commit hold has nothing left to protect for that part. `resolveAssistantTextStreaming` now returns `false` for sealed parts regardless of stream phase: sealed parts render in full immediately, genuinely streaming parts keep the block-commit behavior unchanged.

Reproduction measurements on `main` (same session, question pending throughout):

| Probe | Before | After (this branch) |
|---|---|---|
| Assistant text part via API | `len=233`, ends `…第9行：…。\n第10行：感谢阅读…选择。` | unchanged |
| Rendered text node in DOM | `len=208`, ends at 第9行 — **第10行 absent from the entire DOM tree** | `len=233`, full text, in viewport |
| Text part `time` | `{start: …, end: …}` set while `question` state is `running` | unchanged |

## Non-goals

- The block-commit reveal itself is untouched: a part still streaming (no `time.end`) still reveals whole lines only, with the long-tail sentence-boundary release.
- Sorted-mode behavior is untouched (#2655's guards remain the owners of that path).
- No scroll, overlay, or `QuestionCard` layout changes: the card is an in-flow list footer by design; nothing here is hidden *behind* anything — the line was absent from the DOM.
- No change to when the SDK stamps `time.end`; this consumes the existing part-completion semantics.

## Affected surfaces

- `packages/ui` assistant text rendering (`AssistantTextPart` + `assistantTextVisibility`), consumed by web, desktop, VS Code, hosted mobile, and Capacitor mobile — every surface that renders assistant text in live mode.
- Secondary alignment in the same component, both consequences of a sealed part no longer reporting `isStreaming`: `GeneratedJsonResultCard` parsing and `MarkdownRenderer`'s final-render path now apply to a part sealed mid-turn (previously they only applied after the message finished). For sealed parts this is strictly the final content — the part cannot change.
- No routes, persisted state, exports beyond the new `resolveAssistantTextStreaming` (consumed in-component), or runtime contracts.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` | Source change in one package | Classified as local implementation risk: one component's display gate + one pure helper; validated with focused tests, package-scoped type-check/lint, and a live before/after |
| `parts/DOCUMENTATION.md` | Assistant text part rendering ownership | The seam (`assistantTextVisibility.ts`) keeps the reveal policy in the module that owns it; the component stays a thin wiring |

## Validation

| Check | Result |
|---|---|
| `bun test src/components/chat/message/parts/assistantTextVisibility.test.ts` | 7/7 pass (new: sealed part releases while phase is streaming/cooldown; live unsealed streams; sorted never; hold/reveal behavior; render gate) |
| `bun test src/components/chat/message/` (packages/ui) | 135/135 pass |
| Live before/after on current `main` (dev build + real pending question) | Table above; same session, DOM re-probed after rebuild |
| `bun run type-check` (packages/ui) | pass |
| `eslint` on the three touched files | clean |
| `bunx oxlint` on the three touched files | findings pre-exist on untouched lines (`AssistantTextPart.tsx:32-34` typeof trio) and on the `isFinalized` expression relocated verbatim from the previous line 62; per the backlog rule they are not mass-fixed |
| `bun run dead-code` | no new findings (the new export is consumed in-component) |
| `bun test` full ui package | 3125 pass / 655 fail / 25 errors — the full-suite failures are a pre-existing parallel-run environment issue, none in the touched area: the largest failing file (`useConfigStore.test.ts`, 35 tests) passes 35/35 in isolation **both with and without this change** (stash-verified) |

Not verified by hand: a real permission-ask block (same mechanism, no reproduction attempted); desktop/VS Code/mobile packaging runs (no surface-specific code paths touched — the change is in shared UI).

## Visual evidence

Before (current `main`, question pending — the preamble ends at line 9; line 10 is absent from the DOM entirely, confirmed by tree walk, not a CSS/overlay effect):

![before: pending question on main hides the preamble's last line](https://raw.githubusercontent.com/ouyangjian28/openchamber/assets-3495-repro/before-main.png)

After (this branch, **same session, same pending question** — the full preamble including line 10 renders above the question card):

![after: same pending question with the fix shows the full preamble](https://raw.githubusercontent.com/ouyangjian28/openchamber/assets/3495-repro/after-fix.png)

Both screenshots are the same live session (`main` build replaced in place, page reloaded; the question card stayed pending throughout). The prompt asked for exactly ten numbered lines, the tenth beginning with a fixed marker phrase, so the missing "line 10" is unambiguous in the before shot. DOM text lengths 193 → 216 match the API text part exactly (216 chars, held tail 23 chars being precisely the last line). Screenshots live on a separate `assets/3495-repro` branch of the fork so they stay out of this PR's diff; both were captured at 1440×900 headless Chromium against a local dev build.

The parts documentation now notes the sealed-text-parts streaming gate beside the #2020 invariant (`packages/ui/src/components/chat/message/parts/DOCUMENTATION.md`).

## Risks and failure behavior

- The hold's invariant ("a shown paragraph never mutates in place") is preserved by construction: it now applies exactly while the part can still grow (`time.end` unset), and a sealed part is immutable by SDK semantics.
- A sealed part now renders its full text one commit earlier than before (immediately on seal instead of at finalize) — a strict latency improvement with no additional re-render risk, since the content cannot change.
- Behavior for reasoning parts in the same component inherits the same gate (same immutability argument).
- Rollback is a single revert of this commit; no persisted state, migration, or external contract is involved.