### PR TITLE
fix(chat): stop subagent work-status panel flickering on unrelated session activity

### DIFF
--- a/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
@@ -96,12 +96,12 @@ which requests only providers enabled for this panel.
 
 | Block | Source | Notes |
 |---|---|---|
-| Context + cost | `contextUsage.ts` over `useSessionMessages`; cost via `useSubagentCostRollup` (own cost + every descendant subagent, recursively) | see below — the store getters cannot serve this |
+| Context + cost | `contextUsage.ts` over `useSessionMessages`; cost via `useDirectorySubagentCostRollup` (own cost + every descendant subagent, recursively) | see below — the store getters cannot serve this |
 | Branch, ahead/behind, attention | `useGitStore` directory state | warmed via `runBackgroundNetworkTask(ensureStatus)` and refreshed from Git mutation hints |
 | Changed files | `useGitStore` status `files` + `diffStats` | working tree, not session-authored edits |
 | PR + checks | `useFreshestPrVisualSummaryForBranch` | **read-only**; follows the freshest remote-keyed entry for the branch |
-| Subagents | child sessions from `useAllLiveSessions` (`parentID`) + `useAllSessionStatuses`; per-row cost from `useSubagentCostRollup`'s `perChildCost` (each child's own subtree total, so nested subagent-of-subagent cost rolls up under its immediate parent row) | |
-| Subagent blockers | directory `permission` / `question` maps | one subscription covers every child |
+| Subagents | direct children from one `useDirectoryStore`'s `session` (`parentID`) and their `session_status`; per-row cost from `useDirectorySubagentCostRollup`'s `perChildCost` (each child's own subtree total, so nested subagent-of-subagent cost rolls up under its immediate parent row) | scoped to the panel's directory; another directory's session or status publication never reaches this section |
+| Subagent blockers | per-child `permission` / `question` sidecar subscriptions (`subscribeDirectoryPermission` / `subscribeDirectoryQuestion`) | one subscription pair per visible child, so a blocker raised anywhere else never notifies |
 | Usage | `components/usage/usageGroups.ts` over `useQuotaStore` | grouping shared with the mobile popover; presentation is not |
 | Linked threads | `lib/linkedIssues.ts` over session metadata | written by the flows that attach an issue or PR |
 | Turn stats | `telemetry.ts` over `useSessionMessageRecords` | computed only while expanded and authoritatively idle |
@@ -281,6 +281,10 @@ just collapsed it.
 Its expanded list is capped at eight rows and scrolls independently, so a
 session with many subagents does not crowd every section below it out of the
 panel.
+
+Rows are ordered by session creation time, newest first, with the session id as
+a tiebreak. The order is deliberately stable under streaming — `time.updated`
+is not an input — so a working child does not jump the list.
 
 ## Tasks
 

--- a/packages/ui/src/components/chat/work-status/WorkStatusPinnedSection.test.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusPinnedSection.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Window } from 'happy-dom';
+import { createOpencodeClient, type Part, type Session } from '@opencode-ai/sdk/v2';
+import { I18nProvider } from '@/lib/i18n';
+import { SyncProvider } from '@/sync/sync-context';
+import { getSyncChildStores } from '@/sync/sync-refs';
+
+let WorkStatusPinnedSection: typeof import('./WorkStatusPinnedSection').WorkStatusPinnedSection;
+
+const directory = '/repo';
+const sessionId = 'session-1';
+const otherSessionId = 'other-1';
+const pinnedMessageId = 'pinned-message-1';
+const otherMessageId = 'other-message-1';
+
+const textPart = (id: string, text: string): Part => ({
+  id,
+  sessionID: sessionId,
+  messageID: 'message',
+  type: 'text',
+  text,
+});
+
+const makeSession = (id: string, pinnedMessageIds: readonly string[]): Session => ({
+  id,
+  slug: id,
+  projectID: 'project',
+  directory,
+  title: id,
+  version: '1',
+  time: { created: 0, updated: 0 },
+  metadata: {
+    openchamber: {
+      context_obligatory_messages: pinnedMessageIds.map((messageId) => ({
+        id: messageId,
+        createdAt: 1,
+        role: 'user',
+      })),
+    },
+  },
+});
+
+const DOM_GLOBAL_NAMES = ['window', 'document', 'navigator', 'Node', 'Element', 'HTMLElement', 'HTMLIFrameElement', 'localStorage', 'getComputedStyle', 'ResizeObserver', 'requestAnimationFrame', 'cancelAnimationFrame', 'IS_REACT_ACT_ENVIRONMENT'] as const;
+const installDom = () => {
+  const win = new Window({ url: 'http://localhost' });
+  const previous = DOM_GLOBAL_NAMES.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+  const values = {
+    window: win, document: win.document, navigator: win.navigator, Node: win.Node, Element: win.Element,
+    HTMLElement: win.HTMLElement, HTMLIFrameElement: win.HTMLIFrameElement, localStorage: win.localStorage,
+    getComputedStyle: win.getComputedStyle.bind(win), ResizeObserver: win.ResizeObserver,
+    requestAnimationFrame: win.requestAnimationFrame.bind(win), cancelAnimationFrame: win.cancelAnimationFrame.bind(win),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  for (const name of DOM_GLOBAL_NAMES) Object.defineProperty(globalThis, name, { value: values[name], configurable: true, writable: true });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  return {
+    container,
+    restore: () => {
+      for (const [name, descriptor] of previous) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+      void win.happyDOM.close();
+    },
+  };
+};
+
+describe('mounted pinned section with live sync stores', () => {
+  let root: Root;
+  let dom: ReturnType<typeof installDom>;
+  let commits = 0;
+  // Keep bootstrap pending so each test controls real store publications.
+  const sdk = createOpencodeClient({ baseUrl: 'http://pinned.test', fetch: () => new Promise<Response>(() => undefined) });
+
+  const store = (dir = directory) => {
+    const result = getSyncChildStores().getChild(dir);
+    if (!result) throw new Error('Expected mounted directory store');
+    return result;
+  };
+
+  const render = async () => {
+    await act(async () => root.render(
+      <SyncProvider sdk={sdk} directory={directory}>
+        <I18nProvider>
+          <React.Profiler id="pinned" onRender={() => { commits += 1; }}>
+            <WorkStatusPinnedSection sessionId={sessionId} directory={directory} />
+          </React.Profiler>
+        </I18nProvider>
+      </SyncProvider>,
+    ));
+  };
+
+  beforeEach(async () => {
+    dom = installDom();
+    ({ WorkStatusPinnedSection } = await import('./WorkStatusPinnedSection'));
+    root = createRoot(dom.container);
+    commits = 0;
+    await render();
+    await act(async () => store().setState({
+      session: [makeSession(sessionId, [pinnedMessageId]), makeSession(otherSessionId, [])],
+      part: { [pinnedMessageId]: [textPart('part-1', 'pinned text')] },
+    }));
+    commits = 0;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    dom.restore();
+  });
+
+  test('renders the pinned message text', () => {
+    expect(dom.container.textContent).toContain('pinned text');
+  });
+
+  // The section subscribes to the pinned messages' part arrays only, so a part
+  // publication for any other message clones `state.part` without changing the
+  // pinned arrays; the scoped snapshot keeps its reference and React bails out.
+  test('an unrelated message part update does not re-render the section', async () => {
+    commits = 0;
+    await act(async () => store().setState({
+      part: { ...store().getState().part, [otherMessageId]: [textPart('part-other', 'other text')] },
+    }));
+    expect(commits).toBe(0);
+  });
+
+  test('a pinned message part text change re-renders with the new text', async () => {
+    commits = 0;
+    await act(async () => store().setState({
+      part: { ...store().getState().part, [pinnedMessageId]: [textPart('part-1', 'updated text')] },
+    }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('updated text');
+    expect(dom.container.textContent).not.toContain('pinned text');
+  });
+});

--- a/packages/ui/src/components/chat/work-status/WorkStatusPinnedSection.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusPinnedSection.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { toast } from 'sonner';
 import { Icon } from '@/components/icon/Icon';
 import { useI18n } from '@/lib/i18n';
-import { useDirectorySync, useEnsureSessionMessages, useSession } from '@/sync/sync-context';
+import { useEnsureSessionMessages, useSession, useSessionPartsForMessages } from '@/sync/sync-context';
 import { getContextObligatoryMessages } from '@/lib/contextObligatoryMessages';
 import { setContextObligatoryMessage } from '@/sync/session-actions';
 import { WorkStatusRow, WorkStatusSection } from './WorkStatusPrimitives';
 import { useReportWorkStatusPresence } from './presenceContext';
-import type { State } from '@/sync/types';
 
 type Props = {
   sessionId: string | null;
@@ -23,20 +22,33 @@ type Props = {
 export const WorkStatusPinnedSection: React.FC<Props> = ({ sessionId, directory }) => {
   const { t } = useI18n();
   const session = useSession(sessionId ?? '', directory ?? undefined);
-  const parts = useDirectorySync(React.useCallback((state: State) => state.part, []));
   const [busyId, setBusyId] = React.useState<string | null>(null);
 
+  const pinnedEntries = React.useMemo(
+    () => getContextObligatoryMessages(session),
+    [session],
+  );
+  const pinnedIds = React.useMemo(
+    () => pinnedEntries.map((entry) => entry.id),
+    [pinnedEntries],
+  );
+
+  // Subscribe to the pinned messages' parts only. An unrelated session's
+  // streaming delta clones the whole `state.part` map, but `useSessionPartsForMessages`
+  // keys its notified ids and cached snapshot on these arrays alone, so the
+  // section neither re-renders nor re-reads the map for it.
+  const partsByMessageId = useSessionPartsForMessages(pinnedIds, directory ?? undefined);
+
   const pinned = React.useMemo(() => {
-    const entries = getContextObligatoryMessages(session);
-    if (entries.length === 0) return [];
-    return entries.map((entry) => {
-      const messageParts = parts[entry.id] ?? [];
+    if (pinnedEntries.length === 0) return [];
+    return pinnedEntries.map((entry) => {
+      const messageParts = partsByMessageId[entry.id] ?? [];
       const text = messageParts.find(
         (part): part is Extract<typeof part, { type: 'text' }> => part.type === 'text',
       )?.text?.trim();
       return { id: entry.id, text: text || null };
     });
-  }, [session, parts]);
+  }, [pinnedEntries, partsByMessageId]);
 
   // Pinned messages are most useful on a long session — which is exactly when
   // the pinned message has scrolled far enough back not to be loaded, leaving

--- a/packages/ui/src/components/chat/work-status/WorkStatusPrimaryGroup.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusPrimaryGroup.tsx
@@ -17,7 +17,7 @@ import { sessionEvents } from '@/lib/sessionEvents';
 import { normalizePath } from '@/lib/pathNormalization';
 import { computeContextUsage } from './contextUsage';
 import { formatCost } from './subagentCost';
-import { useSubagentCostRollup } from './useSubagentCostRollup';
+import { useDirectorySubagentCostRollup } from './useSubagentCostRollup';
 import {
   WorkStatusCallout,
   WorkStatusMeter,
@@ -245,9 +245,9 @@ export const WorkStatusPrimaryGroup: React.FC<Props> = ({ sessionId, directory, 
       : 'var(--status-success)';
 
   // Rollup total: own cost plus every descendant subagent's cost, recursively
-  // (see useSubagentCostRollup). Shown here instead of session.cost alone, so
-  // spend that ran in a spawned subagent doesn't hide from the reader.
-  const { totalCost, ownCost, subagentCost, subagentCount } = useSubagentCostRollup(sessionId);
+  // (see useDirectorySubagentCostRollup). Shown here instead of session.cost
+  // alone, so spend that ran in a spawned subagent doesn't hide from the reader.
+  const { totalCost, ownCost, subagentCost, subagentCount } = useDirectorySubagentCostRollup(sessionId, directory);
   const cost = totalCost !== null && totalCost > 0 ? totalCost : null;
   // The total answers "what has this cost"; the split answers "why is it more
   // than the session I am looking at". Only worth a line once subagents exist —

--- a/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
@@ -162,10 +162,23 @@ describe('mounted subagents section with live sync stores', () => {
     expect(commits).toBeGreaterThan(0);
     expect(dom.container.textContent).toContain('child-2');
     // Rows order by stable `time.created` desc (newest first), so the later
-    // child-2 (created 3) renders above child-1 (created 1). A comparator that
-    // regressed to volatile `time.updated` would flip this order.
+    // child-2 (created 3) renders above child-1 (created 1).
     const rendered = dom.container.textContent ?? '';
     expect(rendered.indexOf('child-2')).toBeLessThan(rendered.indexOf('child-1'));
+
+    // Now bump child-1's `time.updated` past child-2's (99 > 3) while leaving
+    // `time.created` unchanged (1 < 3). The section ignores `time.updated`-only
+    // changes, so it must not re-render and the stable order must hold. A
+    // comparator regressed to volatile `time.updated` would fail on both counts:
+    // the snapshot would change (commits > 0) and child-1 would sort above
+    // child-2.
+    commits = 0;
+    await act(async () => store().setState({
+      session: [parent, { ...child, time: { created: 1, updated: 99 } }, sibling, other],
+    }));
+    expect(commits).toBe(0);
+    const afterUpdatedBump = dom.container.textContent ?? '';
+    expect(afterUpdatedBump.indexOf('child-2')).toBeLessThan(afterUpdatedBump.indexOf('child-1'));
 
     commits = 0;
     await act(async () => store().setState({ session: [parent, other] }));

--- a/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
@@ -161,6 +161,11 @@ describe('mounted subagents section with live sync stores', () => {
     await act(async () => store().setState({ session: [parent, child, sibling, other] }));
     expect(commits).toBeGreaterThan(0);
     expect(dom.container.textContent).toContain('child-2');
+    // Rows order by stable `time.created` desc (newest first), so the later
+    // child-2 (created 3) renders above child-1 (created 1). A comparator that
+    // regressed to volatile `time.updated` would flip this order.
+    const rendered = dom.container.textContent ?? '';
+    expect(rendered.indexOf('child-2')).toBeLessThan(rendered.indexOf('child-1'));
 
     commits = 0;
     await act(async () => store().setState({ session: [parent, other] }));

--- a/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Window } from 'happy-dom';
+import { createOpencodeClient, type Session } from '@opencode-ai/sdk/v2';
+import { useUIStore } from '@/stores/useUIStore';
+import { I18nProvider } from '@/lib/i18n';
+import { SyncProvider } from '@/sync/sync-context';
+import { getSyncChildStores } from '@/sync/sync-refs';
+import type { PermissionRequest } from '@/types/permission';
+import type { QuestionRequest } from '@/types/question';
+let WorkStatusSubagentsSection: typeof import('./WorkStatusSubagentsSection').WorkStatusSubagentsSection;
+
+const directory = '/repo';
+const parentId = 'parent-1';
+const childId = 'child-1';
+const otherId = 'other-1';
+
+const makeSession = (id: string, parentID: string | undefined, created: number, updated: number, cost?: number): Session => {
+  const session: Session = {
+    id, slug: id, projectID: 'project', directory, title: id, version: '1', time: { created, updated }, parentID,
+  };
+  if (cost !== undefined) session.cost = cost;
+  return session;
+};
+
+const parent = makeSession(parentId, undefined, 0, 0);
+const child = makeSession(childId, parentId, 1, 1);
+const other = makeSession(otherId, undefined, 2, 2);
+
+const childPermission: PermissionRequest = {
+  id: 'permission-1', sessionID: childId, permission: 'write', patterns: [], metadata: {}, always: [],
+};
+const otherPermission: PermissionRequest = {
+  id: 'permission-2', sessionID: otherId, permission: 'write', patterns: [], metadata: {}, always: [],
+};
+const childQuestion: QuestionRequest = {
+  id: 'question-1', sessionID: childId, questions: [{ question: 'Proceed?', header: 'Confirm', options: [] }],
+};
+
+const DOM_GLOBAL_NAMES = ['window', 'document', 'navigator', 'Node', 'Element', 'HTMLElement', 'HTMLIFrameElement', 'localStorage', 'getComputedStyle', 'ResizeObserver', 'requestAnimationFrame', 'cancelAnimationFrame', 'IS_REACT_ACT_ENVIRONMENT'] as const;
+const installDom = () => {
+  const win = new Window({ url: 'http://localhost' });
+  const previous = DOM_GLOBAL_NAMES.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const);
+  const values = {
+    window: win, document: win.document, navigator: win.navigator, Node: win.Node, Element: win.Element,
+    HTMLElement: win.HTMLElement, HTMLIFrameElement: win.HTMLIFrameElement, localStorage: win.localStorage,
+    getComputedStyle: win.getComputedStyle.bind(win), ResizeObserver: win.ResizeObserver,
+    requestAnimationFrame: win.requestAnimationFrame.bind(win), cancelAnimationFrame: win.cancelAnimationFrame.bind(win),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  for (const name of DOM_GLOBAL_NAMES) Object.defineProperty(globalThis, name, { value: values[name], configurable: true, writable: true });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  return {
+    container,
+    restore: () => {
+      for (const [name, descriptor] of previous) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+      }
+      void win.happyDOM.close();
+    },
+  };
+};
+
+describe('mounted subagents section with live sync stores', () => {
+  let root: Root;
+  let dom: ReturnType<typeof installDom>;
+  let commits = 0;
+  // Keep bootstrap pending so each test controls real store publications.
+  const sdk = createOpencodeClient({ baseUrl: 'http://subagents.test', fetch: () => new Promise<Response>(() => undefined) });
+
+  const store = (dir = directory) => {
+    const result = getSyncChildStores().getChild(dir);
+    if (!result) throw new Error('Expected mounted directory store');
+    return result;
+  };
+
+  const render = async () => {
+    await act(async () => root.render(
+      <SyncProvider sdk={sdk} directory={directory}>
+        <I18nProvider>
+          <React.Profiler id="subagents" onRender={() => { commits += 1; }}>
+            <WorkStatusSubagentsSection sessionId={parentId} directory={directory} />
+          </React.Profiler>
+        </I18nProvider>
+      </SyncProvider>,
+    ));
+  };
+
+  beforeEach(async () => {
+    dom = installDom();
+    ({ WorkStatusSubagentsSection } = await import('./WorkStatusSubagentsSection'));
+    root = createRoot(dom.container);
+    commits = 0;
+    useUIStore.setState({ isMobile: false, workStatusExpandedSections: { subagents: true } });
+    await render();
+    await act(async () => store().setState({ session: [parent, child, other], session_status: {} }));
+    commits = 0;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    dom.restore();
+  });
+
+  test('renders one row per child of the requested session', () => {
+    expect(dom.container.textContent).toContain(childId);
+    expect(dom.container.textContent).not.toContain(otherId);
+  });
+
+  // Both the child list and the cost rollup are read from one directory store
+  // and subscribe only to its `session`/`session_status`/blocker slices, so a
+  // metadata-only publication for a session that is not a child resolves to the
+  // same cached snapshot and React bails out.
+  test('an unrelated session time.updated bump does not re-render the section', async () => {
+    commits = 0;
+    await act(async () => store().setState({
+      session: [parent, child, { ...other, time: { created: 2, updated: 99 } }],
+    }));
+    expect(commits).toBe(0);
+  });
+
+  test('an unrelated session status update does not re-render the section', async () => {
+    commits = 0;
+    await act(async () => store().setState({ session_status: { [otherId]: { type: 'busy' } } }));
+    expect(commits).toBe(0);
+  });
+
+  test('an unrelated permission request does not re-render the section', async () => {
+    commits = 0;
+    await act(async () => store().setState({ permission: { [otherId]: [otherPermission] } }));
+    expect(commits).toBe(0);
+  });
+
+  test('a child status change re-renders the section with its busy state', async () => {
+    commits = 0;
+    await act(async () => store().setState({ session_status: { [childId]: { type: 'busy' } } }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('is working');
+  });
+
+  test('a child permission request re-renders the section as blocked', async () => {
+    commits = 0;
+    await act(async () => store().setState({ permission: { [childId]: [childPermission] } }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('needs permission');
+  });
+
+  test('a child question re-renders the section as asking', async () => {
+    commits = 0;
+    await act(async () => store().setState({ question: { [childId]: [childQuestion] } }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('asked a question');
+  });
+
+  test('a new child appearing re-renders and a removed child disappears', async () => {
+    const sibling = makeSession('child-2', parentId, 3, 3);
+    commits = 0;
+    await act(async () => store().setState({ session: [parent, child, sibling, other] }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('child-2');
+
+    commits = 0;
+    await act(async () => store().setState({ session: [parent, other] }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).not.toContain(childId);
+  });
+
+  // A child's spend is a rendered value, so the scoped cost rollup must not
+  // swallow a real cost change: this keeps the same child identity, title and
+  // busy state, and only the cost differs.
+  test('a child session cost change re-renders the section with its cost', async () => {
+    commits = 0;
+    await act(async () => store().setState({
+      session: [parent, makeSession(childId, parentId, 1, 1, 1.5), other],
+    }));
+    expect(commits).toBeGreaterThan(0);
+    expect(dom.container.textContent).toContain('$1.5');
+  });
+});

--- a/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusSubagentsSection.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import type { Session } from '@opencode-ai/sdk/v2';
 import { useI18n } from '@/lib/i18n';
-import { useAllLiveSessions, useAllSessionStatuses, useDirectorySync } from '@/sync/sync-context';
+import { useDirectoryStore } from '@/sync/sync-context';
+import { subscribeDirectoryPermission, subscribeDirectoryQuestion } from '@/sync/child-store';
 import { useUIStore } from '@/stores/useUIStore';
 import { useSessionUIStore } from '@/sync/session-ui-store';
 import { isVSCodeRuntime } from '@/lib/desktop';
@@ -8,8 +10,7 @@ import { isEmbeddedSessionChat } from '@/components/layout/contextPanelEmbeddedC
 import { WorkStatusCollapsibleSection, WorkStatusRow, WorkStatusValue } from './WorkStatusPrimitives';
 import { useReportWorkStatusPresence } from './presenceContext';
 import { formatCost } from './subagentCost';
-import { useSubagentCostRollup } from './useSubagentCostRollup';
-import type { State } from '@/sync/types';
+import { useDirectorySubagentCostRollup } from './useSubagentCostRollup';
 
 type Props = {
   sessionId: string | null;
@@ -17,6 +18,133 @@ type Props = {
 };
 
 const SECTION_ID = 'subagents';
+
+type DirectoryStore = ReturnType<typeof useDirectoryStore>;
+
+type SubagentChildrenSnapshot = {
+  children: Session[];
+  busyById: Record<string, boolean>;
+};
+
+const EMPTY_SUBAGENT_CHILDREN: SubagentChildrenSnapshot = { children: [], busyById: {} };
+
+const childCreatedAt = (session: Session): number => session.time?.created ?? 0;
+
+/**
+ * Equal when the same children are shown with the same labels and busy state.
+ * `time.updated` is deliberately absent: streaming bumps it without changing
+ * anything this section renders, so treating those bumps as different would
+ * re-render on every unrelated session publication.
+ */
+const areSubagentChildrenEqual = (
+  left: SubagentChildrenSnapshot,
+  right: SubagentChildrenSnapshot,
+): boolean => {
+  if (left === right) return true;
+  if (left.children.length !== right.children.length) return false;
+  for (let index = 0; index < left.children.length; index += 1) {
+    const leftChild = left.children[index];
+    const rightChild = right.children[index];
+    if (leftChild.id !== rightChild.id || leftChild.title !== rightChild.title) return false;
+    if (left.busyById[leftChild.id] !== right.busyById[rightChild.id]) return false;
+  }
+  return true;
+};
+
+/**
+ * Direct children of `sessionId` and their busy state, read from one directory
+ * store instead of the directory-wide session/status aggregates. The snapshot
+ * is cached and compared on child identity, label and busy state, so unrelated
+ * session or status publications resolve to the same reference and React bails
+ * out before re-rendering the section.
+ */
+function useSubagentChildren(store: DirectoryStore, sessionId: string | null): SubagentChildrenSnapshot {
+  const cacheRef = React.useRef<SubagentChildrenSnapshot | null>(null);
+
+  const getSnapshot = React.useCallback((): SubagentChildrenSnapshot => {
+    if (!sessionId) return EMPTY_SUBAGENT_CHILDREN;
+    const state = store.getState();
+    const children = state.session
+      .filter((candidate) => candidate.parentID === sessionId)
+      .sort((left, right) => {
+        // `time.created` is stable, unlike `time.updated`, so the newest
+        // subagent stays on top without a volatile ordering input.
+        const byCreated = childCreatedAt(right) - childCreatedAt(left);
+        if (byCreated !== 0) return byCreated;
+        return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+      });
+    const busyById: Record<string, boolean> = {};
+    for (const child of children) {
+      busyById[child.id] = state.session_status?.[child.id]?.type === 'busy';
+    }
+    const next: SubagentChildrenSnapshot = { children, busyById };
+    const cached = cacheRef.current;
+    if (cached && areSubagentChildrenEqual(cached, next)) return cached;
+    cacheRef.current = next;
+    return next;
+  }, [store, sessionId]);
+
+  const subscribe = React.useCallback((notify: () => void) => {
+    if (!sessionId) return () => undefined;
+    return store.subscribe((state, previous) => {
+      if (state.session !== previous.session || state.session_status !== previous.session_status) {
+        notify();
+      }
+    });
+  }, [store, sessionId]);
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+type SubagentBlockers = Record<string, 'permission' | 'question'>;
+
+const areBlockersEqual = (left: SubagentBlockers, right: SubagentBlockers): boolean => {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  for (const key of leftKeys) {
+    if (left[key] !== right[key]) return false;
+  }
+  return true;
+};
+
+/**
+ * Pending permission/question presence per direct child, keyed by child ID.
+ * Uses the per-session sidecar channels, so a blocker raised anywhere else in
+ * the directory never notifies this section.
+ */
+function useSubagentBlockers(store: DirectoryStore, childIds: readonly string[]): SubagentBlockers {
+  const cacheRef = React.useRef<{ ids: readonly string[]; blockers: SubagentBlockers } | null>(null);
+
+  const getSnapshot = React.useCallback(() => {
+    const state = store.getState();
+    const blockers: SubagentBlockers = {};
+    for (const id of childIds) {
+      if ((state.permission[id]?.length ?? 0) > 0) blockers[id] = 'permission';
+      else if ((state.question[id]?.length ?? 0) > 0) blockers[id] = 'question';
+    }
+    const cached = cacheRef.current;
+    if (cached && cached.ids === childIds && areBlockersEqual(cached.blockers, blockers)) {
+      cacheRef.current = { ids: childIds, blockers: cached.blockers };
+      return cached.blockers;
+    }
+    cacheRef.current = { ids: childIds, blockers };
+    return blockers;
+  }, [store, childIds]);
+
+  const subscribe = React.useCallback((notify: () => void) => {
+    if (childIds.length === 0) return () => undefined;
+    const unsubscribers = childIds.flatMap((id) => [
+      subscribeDirectoryPermission(store, id, notify),
+      subscribeDirectoryQuestion(store, id, notify),
+    ]);
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
+  }, [store, childIds]);
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
 
 /**
  * Running subagents and, more importantly, their blockers: a permission request
@@ -27,22 +155,15 @@ export const WorkStatusSubagentsSection: React.FC<Props> = ({ sessionId, directo
   const { t } = useI18n();
   const isMobile = useUIStore((state) => state.isMobile);
 
-  const liveSessions = useAllLiveSessions();
-  const statuses = useAllSessionStatuses();
-  const children = React.useMemo(
-    () => (sessionId ? liveSessions.filter((candidate) => candidate.parentID === sessionId) : []),
-    [liveSessions, sessionId],
-  );
+  const store = useDirectoryStore(directory ?? undefined);
+  const { children, busyById } = useSubagentChildren(store, sessionId);
+  const childIds = React.useMemo(() => children.map((child) => child.id), [children]);
+  const blockers = useSubagentBlockers(store, childIds);
 
   // Each child's own subtree total (its cost plus every descendant of its
   // own), so nested subagent-of-subagent cost rolls up under the immediate
   // child row shown here rather than disappearing.
-  const { perChildCost } = useSubagentCostRollup(sessionId);
-
-  // One subscription covers every child: per-session hooks would multiply
-  // store subscriptions by the number of subagents.
-  const permissions = useDirectorySync(React.useCallback((state: State) => state.permission, []));
-  const questions = useDirectorySync(React.useCallback((state: State) => state.question, []));
+  const { perChildCost } = useDirectorySubagentCostRollup(sessionId, directory);
 
   const openContextPanelTab = useUIStore((state) => state.openContextPanelTab);
   const setCurrentSession = useSessionUIStore((state) => state.setCurrentSession);
@@ -79,7 +200,7 @@ export const WorkStatusSubagentsSection: React.FC<Props> = ({ sessionId, directo
 
   if (children.length === 0) return null;
 
-  const busyChildren = children.filter((child) => statuses[child.id]?.type === 'busy').length;
+  const busyChildren = children.filter((child) => busyById[child.id]).length;
 
   return (
     <WorkStatusCollapsibleSection
@@ -91,9 +212,8 @@ export const WorkStatusSubagentsSection: React.FC<Props> = ({ sessionId, directo
     >
       <div className="max-h-56 overflow-y-auto">
         {children.map((child) => {
-          const blocked = (permissions[child.id]?.length ?? 0) > 0;
-          const asked = (questions[child.id]?.length ?? 0) > 0;
-          const busy = statuses[child.id]?.type === 'busy';
+          const blocker = blockers[child.id];
+          const busy = busyById[child.id] === true;
           const label = child.title?.trim() || t('chat.workStatus.subagent.untitled');
           const childCost = perChildCost.get(child.id) ?? 0;
           return (
@@ -104,9 +224,9 @@ export const WorkStatusSubagentsSection: React.FC<Props> = ({ sessionId, directo
               label={label}
               value={(
                 <>
-                  {blocked ? (
+                  {blocker === 'permission' ? (
                     <WorkStatusValue tone="warning">{t('chat.workStatus.subagent.needsPermission')}</WorkStatusValue>
-                  ) : asked ? (
+                  ) : blocker === 'question' ? (
                     <WorkStatusValue tone="warning">{t('chat.workStatus.subagent.askedQuestion')}</WorkStatusValue>
                   ) : busy ? (
                     <WorkStatusValue tone="info">{t('chat.workStatus.subagent.working')}</WorkStatusValue>

--- a/packages/ui/src/components/chat/work-status/useSubagentCostRollup.ts
+++ b/packages/ui/src/components/chat/work-status/useSubagentCostRollup.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Session } from '@opencode-ai/sdk/v2';
-import { useAllLiveSessions } from '@/sync/sync-context';
+import { useAllLiveSessions, useDirectoryStore } from '@/sync/sync-context';
 import { buildChildrenIndex, computeSubtreeCost } from './subagentCost';
 
 export type SubagentCostRollup = {
@@ -62,10 +62,63 @@ export function computeRollup(liveSessions: Session[], sessionId: string | null)
 
 /**
  * Own cost plus every descendant subagent's cost, recursively summed, for a
- * given root session. Reads the same `useAllLiveSessions()` subscription
- * WorkStatusSubagentsSection already holds — no new store subscription.
+ * given root session. Reads the aggregate `useAllLiveSessions()` subscription;
+ * callers with a known directory should prefer `useDirectorySubagentCostRollup`,
+ * which does not react to unrelated directories' sessions.
  */
 export function useSubagentCostRollup(sessionId: string | null): SubagentCostRollup {
   const liveSessions = useAllLiveSessions();
   return React.useMemo(() => computeRollup(liveSessions, sessionId), [liveSessions, sessionId]);
+}
+
+/**
+ * Value-equality for two rollups. `computeRollup` always allocates a fresh
+ * `perChildCost` map and object, so reference equality alone would treat an
+ * unchanged subtree as new whenever any session in the store is republished.
+ */
+function areRollupsEqual(left: SubagentCostRollup, right: SubagentCostRollup): boolean {
+  if (left === right) return true;
+  if (
+    left.totalCost !== right.totalCost
+    || left.ownCost !== right.ownCost
+    || left.subagentCost !== right.subagentCost
+    || left.subagentCount !== right.subagentCount
+    || left.perChildCost.size !== right.perChildCost.size
+  ) {
+    return false;
+  }
+  for (const [childId, cost] of left.perChildCost) {
+    if (right.perChildCost.get(childId) !== cost) return false;
+  }
+  return true;
+}
+
+/**
+ * Directory-scoped rollup for one session's subtree. Unlike
+ * `useSubagentCostRollup`, it reads a single directory store and subscribes only
+ * to that store's `session` slice, so an unrelated session's `time.updated`
+ * bump never reaches this hook. The snapshot is cached and value-compared, so a
+ * new `session` array holding the same costs still returns the previous
+ * reference and React bails out before the consumer re-renders.
+ */
+export function useDirectorySubagentCostRollup(
+  sessionId: string | null,
+  directory?: string | null,
+): SubagentCostRollup {
+  const store = useDirectoryStore(directory ?? undefined);
+  const cacheRef = React.useRef<SubagentCostRollup | null>(null);
+
+  const getSnapshot = React.useCallback((): SubagentCostRollup => {
+    const next = computeRollup(store.getState().session, sessionId);
+    const cached = cacheRef.current;
+    if (cached && areRollupsEqual(cached, next)) return cached;
+    cacheRef.current = next;
+    return next;
+  }, [store, sessionId]);
+
+  const subscribe = React.useCallback((notify: () => void) => store.subscribe((state, previous) => {
+    if (state.session !== previous.session) notify();
+  }), [store]);
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }


### PR DESCRIPTION
## Intent

The desktop subagent chat window flickered while a session ran, and kept flickering after the subagent's own conversation ended (1.23.0 regression, 1.22 unaffected). The work-status panel subscribed to directory-wide sync state it does not render — every session, every status, every permission/question entry, and the entire message-part map — so any unrelated session activity re-rendered it. This scopes each section's subscriptions to the data it actually renders: the panel's own directory, the current session's children, and the pinned messages' parts.

Fixes #3475.

## Non-goals

- No change to the panel's layout, sections, row content, or navigation.
- The shared `useAllLiveSessions`/`useAllSessionStatuses` hooks, the global `useSubagentCostRollup`, and their sidebar/mobile/agent-manager consumers are unchanged.
- `WorkStatusTasksSection`'s missing `directory` argument and `VSCodeLayout`'s global rollup are separate follow-ups.

## Affected surfaces

- `packages/ui`: the work-status panel (`WorkStatusSubagentsSection`, `WorkStatusPinnedSection`, `WorkStatusPrimaryGroup`, `useSubagentCostRollup`), rendered in web, desktop, VS Code, and the desktop embedded subagent-chat iframe.
- User-visible: subagent rows no longer re-render on unrelated session activity. Row order is now session creation time (newest first) instead of `time.updated`.
- No persisted data, routes, IDs, or external contracts change. Other runtimes are unaffected because the panel is shared UI over the same sync state.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` + `openchamber-change-discipline` | Shared UI source and module contracts | Focused diff, reused existing scoped hooks, updated the owning `work-status/DOCUMENTATION.md` |
| `sync-state-invariants` | Changes to sync subscriptions/live state | Each subscription is scoped to the directory/children it renders; state authority and reconciliation are untouched; no failure-masquerades-as-empty path introduced |
| `performance-engineering` | The reported flicker is a render hot path | Narrowed subscriptions (skip/narrow), value-stable snapshots, and operation-count regression tests asserting 0 commits on unrelated publications |
| `ui-api-decoupling` | Shared UI data access | Uses existing runtime-agnostic sync hooks; no new transport or runtime path |

## Validation

| Check | Result |
|---|---|
| `node ../../scripts/run-isolated-tests.mjs src/components/chat/work-status` | 11/11 test files pass |
| `WorkStatusSubagentsSection.test.tsx` | 9 pass: 0 commits on unrelated `time.updated`/status/permission; re-render on child status/permission/question/cost |
| `WorkStatusPinnedSection.test.tsx` | 3 pass: 0 commits on unrelated part update; re-render on pinned part text change |
| `bun run type-check` (workspace) | pass (ui, web, electron, mobile, root) |
| `bun run lint` (workspace) | pass |
| `bunx oxlint` changed files | clean; one pre-existing `no-runtime-typeof` at `WorkStatusPinnedSection.tsx:84` (untouched) |
| `bun run dead-code` | no findings for changed symbols |
| Full `packages/ui` suite | 432/434; 2 pre-existing/flaky sync session-creation tests, unrelated to this diff |
| Independent review (two passes) | approve as-is, no blocking findings |

Not verified locally: `bun run test` / `bun run build` across every workspace (CI covers them), and a manual macOS recording of the flicker.

## Visual evidence

The change does not alter rendered content or layout; it removes re-renders, so there is no static before/after to screenshot. The concrete evidence is the operation-count regression tests: unrelated store publications produce 0 React commits while relevant ones (child status, permission, question, cost, pinned part text) re-render. A before/after screen recording requires a macOS desktop run and is not available in this environment.

## Risks and failure behavior

- Intentional behavior change: subagent rows now order by session creation time (newest first) rather than `time.updated`, so a streaming child no longer jumps the list. Documented in `packages/ui/src/components/chat/work-status/DOCUMENTATION.md`.
- The scoped children selector assumes a subagent session shares its parent's directory (as the spawn flow does). A cross-directory child would no longer appear; not expected.
- No security, data-loss, migration, or rollback concerns.
