### PR TITLE
fix(ui): render sealed text parts in full while a question pends

### DIFF
--- a/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
+++ b/packages/ui/src/components/chat/message/parts/AssistantTextPart.tsx
@@ -3,7 +3,7 @@ import type { Part } from '@opencode-ai/sdk/v2';
 import { MarkdownRenderer } from '../../MarkdownRenderer';
 import type { StreamPhase, ToolPopupContent } from '../types';
 import { useStreamingTextThrottle } from '../../hooks/useStreamingTextThrottle';
-import { resolveAssistantDisplayText, shouldRenderAssistantText } from './assistantTextVisibility';
+import { resolveAssistantDisplayText, resolveAssistantTextStreaming, shouldRenderAssistantText } from './assistantTextVisibility';
 import { streamPerfCount, streamPerfObserve } from '@/stores/utils/streamDebug';
 import { GeneratedJsonResultCard } from './GeneratedJsonResultCard';
 import { parseGeneratedJsonResult } from './generatedJsonResult';
@@ -35,9 +35,13 @@ const AssistantTextPart: React.FC<AssistantTextPartProps> = ({
     const textContent = [rawText, contentText, valueText].reduce((best, candidate) => {
         return candidate.length > best.length ? candidate : best;
     }, '');
-    const isStreamingPhase = streamPhase === 'streaming';
-    const isCooldownPhase = streamPhase === 'cooldown';
-    const isStreaming = chatRenderMode === 'live' && (isStreamingPhase || isCooldownPhase);
+    const time = partWithText.time;
+    const isFinalized = Boolean(time && typeof time.end !== 'undefined');
+    const isStreaming = resolveAssistantTextStreaming({
+        streamPhase,
+        chatRenderMode,
+        isFinalized,
+    });
 
     streamPerfCount('ui.assistant_text_part.render');
     if (isStreaming) {
@@ -57,9 +61,6 @@ const AssistantTextPart: React.FC<AssistantTextPartProps> = ({
     });
 
     streamPerfObserve('ui.assistant_text_part.display_len', displayTextContent.length);
-
-    const time = partWithText.time;
-    const isFinalized = Boolean(time && typeof time.end !== 'undefined');
 
     const isRenderableTextPart = part.type === 'text' || part.type === 'reasoning';
     if (!isRenderableTextPart) {

--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -175,6 +175,7 @@ tool patch is parsed while the turn streams.
 - Running bash output falls back to `state.metadata.output` until canonical `state.output` arrives. Its output viewport grows with the content up to `46vh`, then scrolls and follows new output until the user scrolls up; following resumes when the user returns to the bottom. Live output appends or replaces rewritten snapshots as plain text without worker highlighting; finalized output normalizes ANSI terminal controls with a bounded synthetic-cell budget, bypasses the throttle, and receives the normal one-time highlighted rendering.
 - Thinking/Justification duration is hidden in `sorted` mode (handled in `ReasoningPart.tsx` + `JustificationBlock.tsx`).
 - Reasoning streaming presentation derives from the live stream phase (`streaming`/`cooldown`), never from missing persisted timing: a cached part without `time.end` is not live, and a part whose `time.end` is set never streams (issue #2020).
+- Assistant text parts carry the same part-finalization gate (`assistantTextVisibility.ts`): live mode's block-commit reveal holds a still-growing part's trailing line, while a part sealed with `time.end` renders in full immediately — including while the turn stays blocked on a pending question or permission ask (#3277).
 
 ## "I want to change description for Perplexity" (example recipe)
 

--- a/packages/ui/src/components/chat/message/parts/assistantTextVisibility.test.ts
+++ b/packages/ui/src/components/chat/message/parts/assistantTextVisibility.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+    resolveAssistantDisplayText,
+    resolveAssistantTextStreaming,
+    shouldRenderAssistantText,
+} from './assistantTextVisibility';
+
+describe('resolveAssistantTextStreaming', () => {
+    test('streams live text whose part is not sealed', () => {
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'live',
+            isFinalized: false,
+        })).toBe(true);
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'cooldown',
+            chatRenderMode: 'live',
+            isFinalized: false,
+        })).toBe(true);
+    });
+
+    test('never streams in sorted mode', () => {
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'sorted',
+            isFinalized: false,
+        })).toBe(false);
+    });
+
+    test('releases a sealed part even while the turn stays blocked (#3277)', () => {
+        // A message blocked on a pending question keeps the stream phase
+        // forever; the pre-question text part is sealed (time.end is set the
+        // moment the model moves on to the question) and must render in full.
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'streaming',
+            chatRenderMode: 'live',
+            isFinalized: true,
+        })).toBe(false);
+        expect(resolveAssistantTextStreaming({
+            streamPhase: 'cooldown',
+            chatRenderMode: 'live',
+            isFinalized: true,
+        })).toBe(false);
+    });
+});
+
+describe('resolveAssistantDisplayText', () => {
+    test('holds the trailing line while streaming', () => {
+        const text = 'line nine, fully written\nline ten, still held';
+        expect(resolveAssistantDisplayText({
+            textContent: text,
+            throttledTextContent: text,
+            isStreaming: true,
+        })).toBe('line nine, fully written\n');
+    });
+
+    test('reveals the full text once the part is not streaming', () => {
+        const text = 'one\ntwo\nsealed tail without trailing newline';
+        expect(resolveAssistantDisplayText({
+            textContent: text,
+            throttledTextContent: text,
+            isStreaming: false,
+        })).toBe(text);
+    });
+});
+
+describe('shouldRenderAssistantText', () => {
+    test('hides empty text until finalized', () => {
+        expect(shouldRenderAssistantText({ displayTextContent: '', isFinalized: false })).toBe(false);
+    });
+
+    test('renders non-empty display text', () => {
+        expect(shouldRenderAssistantText({ displayTextContent: 'content', isFinalized: false })).toBe(true);
+        expect(shouldRenderAssistantText({ displayTextContent: 'content', isFinalized: true })).toBe(true);
+    });
+});

--- a/packages/ui/src/components/chat/message/parts/assistantTextVisibility.ts
+++ b/packages/ui/src/components/chat/message/parts/assistantTextVisibility.ts
@@ -1,4 +1,24 @@
 import { commitStreamedText } from '../../lib/streamTextCommit';
+import type { StreamPhase } from '../types';
+
+// A text part sealed with `time.end` can no longer receive tokens, so the
+// block-commit hold — which exists to keep a growing paragraph from mutating
+// in place — has nothing left to protect for that part. Gating on part
+// finalization keeps the hold for genuinely streaming parts while releasing
+// sealed ones: a message blocked on a pending question (or permission ask)
+// never finishes, so its pre-question text would otherwise keep its last
+// line hidden until the user answers (#3277).
+export const resolveAssistantTextStreaming = (input: {
+    streamPhase: StreamPhase;
+    chatRenderMode: 'sorted' | 'live';
+    isFinalized: boolean;
+}): boolean => {
+    if (input.isFinalized) {
+        return false;
+    }
+    return input.chatRenderMode === 'live'
+        && (input.streamPhase === 'streaming' || input.streamPhase === 'cooldown');
+};
 
 export const resolveAssistantDisplayText = (input: {
     textContent: string;


### PR DESCRIPTION
Supersedes #3495 — same fix, resubmitted as a single clean commit with rendered evidence attached.

Fixes #3277

## Problem

While a `question` tool call pends, live mode's block-commit reveal keeps holding the text after the last committed line, and the turn never finalizes until the user answers. So the tail of the preamble — typically its final line — stays invisible for as long as the question card waits, even though the model already wrote it. #2655 fixed this class of hold for the `sorted` render mode; the live path kept the same gap.

## Fix

Gate the hold on **part** finalization instead of **message** streaming. The SDK stamps the text part's `time.end` as soon as the model moves on to the question part, so a sealed part is provably complete even though the turn is still open: it now renders in full immediately, while a part without `time.end` keeps the existing hold unchanged. This mirrors the reasoning-part gate from #2020. One behavior-note line added to `parts/DOCUMENTATION.md` beside that invariant.

## Evidence

Before (`main`, question pending — the list ends at `Line 9`; `Line 10` is absent from the DOM entirely, confirmed by tree walk — not a CSS/overlay effect):

![before: pending question on main hides the list's final line](https://raw.githubusercontent.com/ouyangjian28/openchamber/assets/3495-repro/v2-before-main.png)

After (this branch, **same session, same pending question** — the full list renders above the question card):

![after: same pending question with the fix shows the full list](https://raw.githubusercontent.com/ouyangjian28/openchamber/assets/3495-repro/v2-after-fix.png)

Both frames are the same session viewed at 1280×900, question card centered; the tenth line carries a fixed marker phrase so the difference is unambiguous. DOM list items on the same stored message: 9 → 10. Screenshots live on the fork's `assets/3495-repro` branch so this PR's diff stays code-only.

## Testing

- New `assistantTextVisibility.test.ts` (7 cases): sealed vs unsealed parts across live/sorted modes, pending-question turns, and the empty-tail edge.
- `packages/ui` type-check and eslint pass; the `chat/message` suite passes (135 tests).
