### PR TITLE
feat(ui): search sessions in the VS Code sessions list

### DIFF
--- a/packages/ui/src/components/session/sidebar/shell/SidebarHeader.test.tsx
+++ b/packages/ui/src/components/session/sidebar/shell/SidebarHeader.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Window } from 'happy-dom';
+import { I18nProvider } from '@/lib/i18n';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { SidebarHeader } from './SidebarHeader';
+
+const baseProps = {
+  hideDirectoryControls: false,
+  showProjectDisplayControls: true,
+  showRecentControls: true,
+  handleOpenDirectoryDialog: () => undefined,
+  onOpenScheduled: () => undefined,
+  onOpenMultiRun: () => undefined,
+  canOpenMultiRun: true,
+  onOpenArchive: () => undefined,
+  headerActionIconClass: 'h-4.5 w-4.5',
+  headerActionButtonClass: 'inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-md leading-none text-foreground hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:cursor-not-allowed',
+  isSessionSearchOpen: false,
+  setIsSessionSearchOpen: () => undefined,
+  sessionSearchInputRef: React.createRef<HTMLInputElement | null>(),
+  sessionSearchQuery: '',
+  setSessionSearchQuery: () => undefined,
+  hasSessionSearchQuery: false,
+  searchMatchCount: 0,
+  collapseAllProjects: () => undefined,
+  expandAllProjects: () => undefined,
+};
+
+function StatefulHeader({
+  initialQuery = '',
+  ...props
+}: Omit<React.ComponentProps<typeof SidebarHeader>, 'sessionSearchQuery' | 'setSessionSearchQuery' | 'hasSessionSearchQuery'> & { initialQuery?: string }) {
+  const [query, setQuery] = React.useState(initialQuery);
+  return (
+    <SidebarHeader
+      {...props}
+      sessionSearchQuery={query}
+      setSessionSearchQuery={setQuery}
+      hasSessionSearchQuery={query.trim().toLowerCase().length > 0}
+    />
+  );
+}
+
+let browser: Window;
+let root: Root;
+const descriptors = new Map<string, PropertyDescriptor | undefined>();
+
+beforeEach(() => {
+  browser = new Window({ url: 'http://localhost' });
+  for (const [key, value] of Object.entries({
+    window: browser,
+    document: browser.document,
+    navigator: browser.navigator,
+    Element: browser.Element,
+    HTMLElement: browser.HTMLElement,
+    InputEvent: browser.InputEvent,
+    KeyboardEvent: browser.KeyboardEvent,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) {
+    descriptors.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { value, configurable: true });
+  }
+  const host = document.createElement('div');
+  document.body.append(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  await browser.happyDOM.close();
+  for (const [key, descriptor] of descriptors) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+describe('SidebarHeader', () => {
+  test('compact variant renders a persistent search input and no directory controls', async () => {
+    await act(async () => root.render(
+      <I18nProvider>
+        <TooltipProvider>
+          <StatefulHeader {...baseProps} hideDirectoryControls />
+        </TooltipProvider>
+      </I18nProvider>,
+    ));
+
+    const inputs = document.querySelectorAll('input');
+    expect(inputs.length).toBe(1);
+    expect(inputs[0]?.getAttribute('placeholder')).toBe('Search sessions...');
+
+    expect(document.querySelector('[aria-label="Search sessions"]')).toBeNull();
+    expect(document.querySelector('[aria-label="Add project"]')).toBeNull();
+    expect(document.querySelector('[aria-label="Display mode"]')).toBeNull();
+  });
+
+  test('compact variant clears the search query with the clear button', async () => {
+    await act(async () => root.render(
+      <I18nProvider>
+        <TooltipProvider>
+          <StatefulHeader {...baseProps} hideDirectoryControls initialQuery="draft" />
+        </TooltipProvider>
+      </I18nProvider>,
+    ));
+
+    const input = document.querySelector('input')!;
+    expect(input.value).toBe('draft');
+
+    const clearButton = document.querySelector<HTMLButtonElement>('[aria-label="Clear search"]');
+    expect(clearButton).not.toBeNull();
+    await act(async () => clearButton!.click());
+    expect(input.value).toBe('');
+  });
+
+  test('full variant renders directory controls and hides the search input until opened', async () => {
+    await act(async () => root.render(
+      <I18nProvider>
+        <TooltipProvider>
+          <SidebarHeader {...baseProps} />
+        </TooltipProvider>
+      </I18nProvider>,
+    ));
+
+    expect(document.querySelector('input')).toBeNull();
+    expect(document.querySelector('[aria-label="Search sessions"]')).not.toBeNull();
+    expect(document.querySelector('[aria-label="Add project"]')).not.toBeNull();
+    expect(document.querySelector('[aria-label="Display mode"]')).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/session/sidebar/shell/SidebarHeader.tsx
+++ b/packages/ui/src/components/session/sidebar/shell/SidebarHeader.tsx
@@ -78,7 +78,43 @@ export function SidebarHeader(props: Props): React.ReactNode {
   const isSingleProjectMode = showProjectDisplayControls && projectDisplayMode === 'single';
 
   if (hideDirectoryControls) {
-    return null;
+    // VS Code: the sidebar is always a single workspace, so project/directory
+    // controls stay hidden, but session search is still useful. Show a compact,
+    // always-visible search input at the top of the sessions list.
+    return (
+      <div className="select-none flex-shrink-0 px-2.5 py-1.5">
+        <div className="relative">
+          <Icon name="search" className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            ref={sessionSearchInputRef}
+            value={sessionSearchQuery}
+            onChange={(event) => setSessionSearchQuery(event.target.value)}
+            placeholder={t('sessions.sidebar.header.search.placeholder')}
+            className="h-8 w-full rounded-md border border-border bg-transparent pl-8 pr-8 typography-ui-label text-foreground outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.stopPropagation();
+                if (hasSessionSearchQuery) {
+                  setSessionSearchQuery('');
+                } else {
+                  setIsSessionSearchOpen(false);
+                }
+              }
+            }}
+          />
+          {sessionSearchQuery.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setSessionSearchQuery('')}
+              className="absolute right-1 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-interactive-hover/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              aria-label={t('sessions.sidebar.header.search.clear')}
+            >
+              <Icon name="close" className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
Closes #3501

## Intent

VS Code users have no way to search sessions. The sidebar list is the only entry point and it hides the search input entirely: VSCodeLayout mounts `SessionSidebar` with `hideDirectoryControls`, and `SidebarHeader` returns `null` in that mode, taking the search field down with the directory controls. With many sessions in a workspace, finding one is scrolling.

This PR renders a compact, always-visible search input at the top of the sessions list when `hideDirectoryControls` is set. It reuses the state and filtering already wired for every runtime (`sessionSearchQuery`, debounced normalized query, match count, `filterSessionNodesForSearch`), so title/path fuzzy match, `ses_` id search, Escape handling, and clear button work exactly as in web/desktop. VS Code is always a single workspace, so this is per-project session search.

## Non-goals

- No changes to the full web/desktop header; its toggle-open search stays as is.
- No new filtering logic, no store changes, no new deps.
- No message-content search; same title+path matching as the existing search.

## Affected surfaces

- `packages/ui`: `SidebarHeader` gains one rendering branch for `hideDirectoryControls` (used only by VSCodeLayout today), plus tests.
- VS Code webview (expanded sidebar and compact sessions list): new search input row.
- Web, desktop, mobile: unchanged code paths. Mobile sessions sheets have their own search and don't use `SidebarHeader`.
- No persisted or external contracts touched.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `theme-system` skill | Adds a visible input with styling | Reuses existing tokens/classes from the web search input (`border-border`, `typography-ui-label`, `primary/50` focus ring); no new colors |
| `locale-ui-patterns` skill | New user-visible affordance | Reuses existing `sessions.sidebar.header.search.*` keys; no new strings |
| `packages/ui/src/components/session/sidebar/DOCUMENTATION.md` (Search section) | Touches sidebar search behavior | Filter semantics untouched; the search still only matches list membership, no fetching |
| `openchamber-change-discipline` skill | Source change scope | Minimal diff in the owning component; entrypoints untouched; no exports added |

## Validation

| Check | Result |
|---|---|
| `node scripts/run-isolated-tests.mjs packages/ui/src/components/session/sidebar/shell` | pass, 2/2 files (includes new tests: compact search renders with `hideDirectoryControls`, clear button works, directory controls stay absent) |
| `bunx oxlint <changed files>` | pass, 0 findings |
| `bun run --cwd packages/ui type-check` | pass, 0 errors |
| Full VS Code webview runtime screenshots | not attached; change is gated to the `hideDirectoryControls` branch, DOM presence/absence asserted in tests. Happy to attach captures from a packaged VSIX if the reviewer wants them |
| Web/desktop visual diff | not verified by screenshot; the new code branch is unreachable when `hideDirectoryControls` is false |

## Visual evidence

VS Code variant: a single search row with leading magnifier, placeholder, and trailing clear button appears above the sessions list in both VS Code mounts. Web/desktop rendering cannot change: the added branch is only taken when `hideDirectoryControls` is true, which only VSCodeLayout passes, and the existing branch path is byte-identical.

## Risks and failure behavior

Low blast radius. If the input fails to render, the previous behavior was "no header at all" in VS Code, so the failure mode is the old state. No filtering logic changed, so wrong-query behavior is identical to existing sidebar search. Rollback is reverting one commit. No persisted state, no security surface, no startup or render hot path added (input is controlled, debouncing lives in `SessionSidebar` and already ran regardless of visibility).
