### PR TITLE
fix(chat): hide compaction summaries from live activity

### DIFF
--- a/packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx
+++ b/packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx
@@ -164,6 +164,19 @@ describe('live Activity with the real message body', () => {
         expect(header?.getAttribute('aria-expanded')).toBe('true');
     });
 
+    test('does not replay compaction summaries as live assistant output', async () => {
+        const progress = assistant('progress', [text('progress-text', 'Prior visible step')], 'tool-calls');
+        const compaction = assistant('compaction', [text('compaction-text', 'PRIVATE COMPACTION SUMMARY')], 'stop');
+        Object.assign(compaction.info, { summary: true });
+        const active = assistant('active', [text('active-text', 'Current live output')]);
+
+        await act(async () => root.render(<Harness record={turn([progress, compaction, active])} />));
+
+        expect(container.textContent).toContain('Prior visible step');
+        expect(container.textContent).toContain('Current live output');
+        expect(container.textContent).not.toContain('PRIVATE COMPACTION SUMMARY');
+    });
+
     test('keeps thinking in the final message inside Activity, not outside with the answer', async () => {
         const thinking: Part = { type: 'reasoning', id: 'thinking', messageID: 'final', sessionID: 'session', text: 'Private reasoning content', time: { start: 1, end: 2 } };
         const final = assistant('final', [thinking, text('final-text', 'Public answer')], 'stop');

--- a/packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx
+++ b/packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx
@@ -16,6 +16,7 @@ import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { projectTurnRecords } from '../lib/turns/projectTurnRecords';
 import type { ChatMessageEntry, TurnChangedFile, TurnRecord } from '../lib/turns/types';
 import { LiveTurnActivity } from './LiveTurnActivity';
+import TurnAssistantBlock from './TurnAssistantBlock';
 
 plugin({
     name: 'live-activity-worker-url',
@@ -175,6 +176,22 @@ describe('live Activity with the real message body', () => {
         expect(container.textContent).toContain('Prior visible step');
         expect(container.textContent).toContain('Current live output');
         expect(container.textContent).not.toContain('PRIVATE COMPACTION SUMMARY');
+    });
+
+    test('does not render compaction summaries in the fallback assistant block', async () => {
+        const compaction = assistant('compaction', [text('compaction-text', 'PRIVATE COMPACTION SUMMARY')], 'stop');
+        Object.assign(compaction.info, { summary: true });
+        const answer = assistant('answer', [text('answer-text', 'Visible answer')], 'stop');
+
+        await act(async () => root.render(
+            <TurnAssistantBlock
+                assistantMessages={[compaction, answer]}
+                renderMessage={(message) => <span key={message.info.id} data-message-id={message.info.id}>{message.info.id}</span>}
+            />,
+        ));
+
+        expect(container.textContent).toBe('answer');
+        expect(container.querySelector('[data-message-id="compaction"]')).toBeNull();
     });
 
     test('keeps thinking in the final message inside Activity, not outside with the answer', async () => {

--- a/packages/ui/src/components/chat/components/LiveTurnActivity.tsx
+++ b/packages/ui/src/components/chat/components/LiveTurnActivity.tsx
@@ -16,11 +16,22 @@ interface LiveTurnActivityProps {
     renderMessage: (message: ChatMessageEntry) => React.ReactNode;
 }
 
+const isCompactionSummaryMessage = (message: ChatMessageEntry): boolean => {
+    return message.info.summary === true;
+};
+
 export function LiveTurnActivity({ turn, hasLaterAssistant, expanded, onToggle, renderMessage }: LiveTurnActivityProps) {
     const { t } = useI18n();
     const contentId = React.useId();
     const finalContentId = React.useId();
-    const finalMessage = getLiveFinalMessage(turn.assistantMessages);
+    // Compaction summaries are internal context snapshots. OMP stores them as
+    // completed assistant messages in the same parent turn, but they are not
+    // model output to replay in the live activity timeline.
+    const liveAssistantMessages = React.useMemo(
+        () => turn.assistantMessages.filter((message) => !isCompactionSummaryMessage(message)),
+        [turn.assistantMessages],
+    );
+    const finalMessage = getLiveFinalMessage(liveAssistantMessages);
     const settled = Boolean(finalMessage) || hasLaterAssistant;
     const isExpanded = !settled || expanded;
     const previouslySettled = React.useRef(settled);
@@ -31,8 +42,8 @@ export function LiveTurnActivity({ turn, hasLaterAssistant, expanded, onToggle, 
     } : null, [finalMessage, isExpanded, finalContentId, animateFinalCollapse]);
     // No diff parsing at token frequency. The report is only shown once the
     // turn settles; later authoritative tool metadata can refine it.
-    const summary = React.useMemo(() => settled ? summarizeLiveActivity(turn.assistantMessages) : null,
-        [settled, turn.assistantMessages]);
+    const summary = React.useMemo(() => settled ? summarizeLiveActivity(liveAssistantMessages) : null,
+        [settled, liveAssistantMessages]);
     const fileLabel = summary && summary.files > 0
         ? t(summary.files === 1 ? 'chat.liveActivity.changedFile' : 'chat.liveActivity.changedFiles', { count: summary.files })
         : null;
@@ -76,7 +87,7 @@ export function LiveTurnActivity({ turn, hasLaterAssistant, expanded, onToggle, 
                 </div>
             ) : null}
             <LiveActivityCollapse expanded={isExpanded} id={contentId}>
-                {turn.assistantMessages.map((message) => message === finalMessage ? null : renderMessage(message))}
+                {liveAssistantMessages.map((message) => message === finalMessage ? null : renderMessage(message))}
             </LiveActivityCollapse>
             <LiveFinalActivityContext.Provider value={finalContext}>
                 {finalMessage ? renderMessage(finalMessage) : null}

--- a/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
+++ b/packages/ui/src/components/chat/components/TurnAssistantBlock.tsx
@@ -8,9 +8,11 @@ interface TurnAssistantBlockProps {
 }
 
 const TurnAssistantBlock: React.FC<TurnAssistantBlockProps> = ({ assistantMessages, renderMessage }) => {
+    const visibleAssistantMessages = assistantMessages.filter((message) => message.info.summary !== true);
+
     return (
         <div className="relative z-0">
-            {assistantMessages.map((message) => renderMessage(message))}
+            {visibleAssistantMessages.map((message) => renderMessage(message))}
         </div>
     );
 };

--- a/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/message/parts/DOCUMENTATION.md
@@ -64,7 +64,7 @@ Use this doc when you ask an agent to change tool/header/description behavior.
 
 Activity Default is shared by the settings UI in both render modes. In live
 mode, Expanded preserves the original timeline without a turn disclosure.
-Collapsed adds one Activity header after completion or interruption while preserving the original live rows,
+Collapsed adds one Activity header after completion or interruption while preserving the visible live rows,
 their order, and their individual controls. It adds no tool subgroups, side
 line, height cap, or inner scroller. Sorted rendering keeps its existing path
 and its own per-turn expansion state.
@@ -72,7 +72,11 @@ and its own per-turn expansion state.
 The active turn stays open without an Activity header. A final assistant message with `finish: stop`
 collapses the earlier messages and the final message's non-text parts, keeping
 the answer and its existing footer outside. Intermediate-text summary fallback
-and compaction summaries never become final answers. An older turn without a
+and compaction summaries never become final answers. Messages with
+`info.summary === true` are internal context snapshots: live Activity excludes
+them from its disclosure rows and header summary, while the ordinary assistant
+block omits them in sorted mode and in live turns without an Activity disclosure.
+An older turn without a
 final answer collapses once a later visible turn has an assistant response;
 a queued user message alone is not enough. Hidden user continuations retain
 the visible-turn mapping established by `projectTurnRecords`.


### PR DESCRIPTION
## Intent

OMP records context compactions as assistant messages with `info.summary === true` in the same parent turn as normal assistant activity. The live Activity renderer and the ordinary assistant block treated those records as live model output, so internal Goal and Constraints snapshots could appear in chat.

This filters compaction summaries before selecting the live final message, calculating the live activity summary, rendering live Activity rows, and rendering the ordinary assistant block used by sorted mode and live turns without Activity. Normal progress and final output remain visible.

## Non-goals

- No changes to the OMP sidecar or its session records.
- No changes to persisted data, transport behavior, or activity classification rules.

## Affected surfaces

- `packages/ui` shared chat rendering used by the web, desktop, VS Code, and mobile surfaces.
- Live Activity no longer replays internal compaction text in its rows or header summary.
- Sorted mode and live fallback rendering no longer show compaction snapshots as full assistant messages.
- No API, persistence, runtime bridge, or cross-process contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | This is a shared UI source and owning-documentation change. | The diff stays in the chat renderers, their regression test, and the owning rendering documentation. Unrelated worktree changes remain outside the branch. |
| `openchamber-change-discipline` | The fix changes local rendering behavior and its documented invariant. | It uses the existing `summary` flag, adds no dependency or speculative abstraction, and validates the owning UI package. |
| `performance-engineering` | The affected renderers run during chat updates. | The live filtered list remains memoized against the projected assistant-message array. The fallback path performs one bounded filter before its existing map and adds no global state or cache. |
| `writing-for-agents` | The owning `DOCUMENTATION.md` is reached through the repository's documentation-discovery pointer. | The documentation records the new visibility rule in the existing live disclosure section without duplicating unrelated guidance. |
| `communication-style` | This pull request is a human-facing review artifact. | The description uses concrete behavior and reports only verified checks. |
| `CONTRIBUTING.md` and `packages/ui/package.json` | They define the pull request contract and package validation commands. | The required intent, non-goals, affected surfaces, validation, evidence, and risk sections are included. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx packages/ui/src/components/chat/lib/turns/liveActivity.test.ts packages/ui/src/components/chat/lib/turns/projectTurnRecords.test.ts` | Pass: 43 tests, 0 failures, 143 assertions. |
| `bun run type-check:ui` | Pass. |
| `bun run lint:ui` | Pass. |
| `bunx oxlint packages/ui/src/components/chat/components/LiveTurnActivity.tsx packages/ui/src/components/chat/components/LiveTurnActivity.test.tsx packages/ui/src/components/chat/components/TurnAssistantBlock.tsx` | Pass. |
| `bun run docs:validate` | Pass: 517 pages, 47 sidebar links. |
| Reported OpenChamber + OMP session reproduction | The supplied reproduction was rechecked locally after applying the filter. The compaction body no longer appeared in the live timeline. |

## Visual evidence

The before state is the supplied screenshot from the reported private sidecar session. The after state is covered by the rendered DOM regression tests at this PR head and the local session recheck. No private session screenshot is attached to avoid publishing its contents.

## Risks and failure behavior

Filtering is scoped to the two assistant-message render paths and uses only the explicit `summary` flag. The sidecar data and projected activity metadata remain untouched. If a message does not carry the flag, existing behavior is unchanged. Reverting the follow-up commit restores the previous fallback rendering while leaving the original live filter commit independently revertible.
