### PR TITLE
fix(quota): surface provider business errors in the usage panel (web + vscode)

### DIFF
--- a/packages/vscode/src/quotaProviders.test.ts
+++ b/packages/vscode/src/quotaProviders.test.ts
@@ -20,6 +20,7 @@ const AUTH = JSON.stringify({
   'opencode-go': { key: 'test-token' },
   openrouter: { key: 'test-token' },
   'zai-coding-plan': { key: 'test-token' },
+  'zhipuai-coding-plan': { key: 'test-token' },
   deepseek: { key: 'test-token' },
   hyper: { key: 'test-token' },
   'github-copilot': { access: 'test-token' },
@@ -668,6 +669,38 @@ describe('Z.ai quota provider (VS Code parity)', () => {
     assert.equal(windows.weekly!.windowSeconds, 7 * 24 * 60 * 60);
     assert.equal(windows.weekly!.resetAt, 1787844668997);
     assert.equal(windows.weekly!.valueLabel, '65 / 60k credits');
+  });
+
+  test('surfaces business-layer auth errors returned with HTTP 200', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      code: 401,
+      success: false,
+      msg: 'token expired or incorrect',
+    })));
+
+    const result = await fetchQuotaForProvider('zai-coding-plan');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.error, 'token expired or incorrect');
+    assert.equal(result.usage, null);
+  });
+});
+
+describe('Zhipu AI Coding Plan quota provider (VS Code parity)', () => {
+  test('surfaces business-layer auth errors returned with HTTP 200', async () => {
+    stubFetchReturning(() => Promise.resolve(mockResponse({
+      code: 401,
+      success: false,
+      msg: 'token expired or incorrect',
+    })));
+
+    const result = await fetchQuotaForProvider('zhipuai-coding-plan');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.configured, true);
+    assert.equal(result.error, 'token expired or incorrect');
+    assert.equal(result.usage, null);
   });
 });
 

--- a/packages/vscode/src/quotaProviders.ts
+++ b/packages/vscode/src/quotaProviders.ts
@@ -450,6 +450,17 @@ const buildResult = (data: {
   return result;
 };
 
+// Zhipu/z.ai monitor APIs report credential failures inside an HTTP 200 body
+// ({ code: 401, success: false, msg }); without this check they parse as empty success.
+const resolveBusinessError = (payload: unknown): string | null => {
+  const body = asObject(payload);
+  if (!body) return null;
+  const rejected = body.success === false
+    || (typeof body.code === 'number' && body.code !== 200);
+  if (!rejected) return null;
+  return asNonEmptyString(body.msg) ?? asNonEmptyString(body.message) ?? 'API request rejected';
+};
+
 const resolveXaiAuth = (): XaiAuthEntry | null => {
   const entry = getProviderAuth('xai');
   if (!entry || typeof entry !== 'object' || entry.type !== 'oauth') return null;
@@ -2173,6 +2184,16 @@ const fetchZaiQuota = async (): Promise<ProviderResult> => {
     }
 
     const payload = await response.json() as ZaiPayload;
+    const businessError = resolveBusinessError(payload);
+    if (businessError) {
+      return buildResult({
+        providerId: 'zai-coding-plan',
+        providerName: 'z.ai',
+        ok: false,
+        configured: true,
+        error: businessError,
+      });
+    }
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
     const windows: Record<string, UsageWindow> = {};
     // The API renamed TOKENS_LIMIT to CREDIT_LIMIT; field semantics stayed the same,
@@ -2254,6 +2275,16 @@ const fetchZhipuaiCodingPlanQuota = async (): Promise<ProviderResult> => {
     }
 
     const payload = await response.json() as ZhipuaiPayload;
+    const businessError = resolveBusinessError(payload);
+    if (businessError) {
+      return buildResult({
+        providerId: 'zhipuai-coding-plan',
+        providerName: 'Zhipu AI Coding Plan',
+        ok: false,
+        configured: true,
+        error: businessError,
+      });
+    }
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
     const tokensLimit = limits.find((limit): limit is ZhipuaiTokensLimit => limit?.type === 'TOKENS_LIMIT');

--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -55,6 +55,7 @@ All providers should return results via shared helpers to preserve API shape:
 - Required fields: `providerId`, `providerName`, `ok`, `configured`, `usage`, `fetchedAt`
 - Optional field: `error`
 - Unsupported provider requests should return `ok: false`, `configured: false`, `error: Unsupported provider`
+- Monitor APIs that report failures inside an HTTP 200 body (Zhipu and z.ai answer expired credentials with `{ code: 401, success: false, msg }`) must surface that as `ok: false` with the body's message; `resolveBusinessError` in `utils/transformers.js` performs the check for the web providers and the VS Code copy carries its own.
 
 Provider modules must export `providerId`, `providerName`, `aliases`, `isConfigured(auth?)`, and `fetchQuota()`.
 `fetchQuota()` should return a quota result with `usage.windows` keyed by window name (for example `5h`, `7d`, `daily`) and optional provider-specific `usage.models` data.

--- a/packages/web/server/lib/quota/providers/zai.js
+++ b/packages/web/server/lib/quota/providers/zai.js
@@ -5,6 +5,7 @@ import {
   buildResult,
   toUsageWindow,
   toNumber,
+  resolveBusinessError,
   resolveWindowSeconds,
   resolveWindowLabel,
   normalizeTimestamp
@@ -69,6 +70,16 @@ export const fetchQuota = async () => {
     }
 
     const payload = await response.json();
+    const businessError = resolveBusinessError(payload);
+    if (businessError) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: businessError
+      });
+    }
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
     const windows = {};
     // The API renamed TOKENS_LIMIT to CREDIT_LIMIT; field semantics stayed the same,

--- a/packages/web/server/lib/quota/providers/zai.test.js
+++ b/packages/web/server/lib/quota/providers/zai.test.js
@@ -84,4 +84,19 @@ describe('Z.ai quota provider', () => {
       valueLabel: '65 / 60k credits',
     });
   });
+
+  it('surfaces business-layer auth errors returned with HTTP 200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      code: 401,
+      success: false,
+      msg: 'token expired or incorrect',
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('token expired or incorrect');
+    expect(result.usage).toBeNull();
+  });
 });

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -32,6 +32,7 @@ import {
   normalizeAuthEntry,
   buildResult,
   toUsageWindow,
+  resolveBusinessError,
   resolveWindowSeconds,
   normalizeTimestamp
 } from '../utils/index.js';
@@ -102,6 +103,16 @@ export const fetchQuota = async () => {
     }
 
     const payload = await response.json();
+    const businessError = resolveBusinessError(payload);
+    if (businessError) {
+      return buildResult({
+        providerId,
+        providerName,
+        ok: false,
+        configured: true,
+        error: businessError
+      });
+    }
     const limits = Array.isArray(payload?.data?.limits) ? payload.data.limits : [];
 
     const tokensLimit = limits.find((limit) => limit?.type === 'TOKENS_LIMIT');

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.test.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.test.js
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({}),
+}));
+
+vi.mock('../../opencode/shared.js', () => ({
+  OPENCODE_CONFIG_DIR: '/tmp/opencode-test-config',
+  readConfigLayers: () => ({
+    mergedConfig: {
+      provider: {
+        'zhipuai-coding-plan': { options: { apiKey: 'test-token' } },
+      },
+    },
+  }),
+}));
+
+import { fetchQuota } from './zhipuai-coding-plan.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+describe('Zhipu AI Coding Plan quota provider', () => {
+  it('reads the API key from provider config when auth.json has no entry', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      data: {
+        limits: [
+          { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 36 },
+          { type: 'TIME_LIMIT', unit: 5, number: 1, percentage: 0 },
+        ],
+      },
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(result.configured).toBe(true);
+    expect(result.usage.windows['Tokens']).toMatchObject({
+      usedPercent: 36,
+      windowSeconds: 5 * 60 * 60,
+    });
+  });
+
+  it('surfaces business-layer auth errors returned with HTTP 200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({
+      code: 401,
+      success: false,
+      msg: 'token expired or incorrect',
+    })));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(false);
+    expect(result.configured).toBe(true);
+    expect(result.error).toBe('token expired or incorrect');
+    expect(result.usage).toBeNull();
+  });
+});

--- a/packages/web/server/lib/quota/utils/transformers.js
+++ b/packages/web/server/lib/quota/utils/transformers.js
@@ -57,3 +57,13 @@ export const resolveWindowLabel = (windowSeconds) => {
   }
   return `${windowSeconds}s`;
 };
+
+// Zhipu/z.ai monitor APIs report credential failures inside an HTTP 200 body
+// ({ code: 401, success: false, msg }); without this check they parse as empty success.
+export const resolveBusinessError = (payload) => {
+  if (!payload || typeof payload !== 'object') return null;
+  if (payload.success === false || (typeof payload.code === 'number' && payload.code !== 200)) {
+    return payload.msg || payload.message || 'API request rejected';
+  }
+  return null;
+};


### PR DESCRIPTION
Title: fix(quota): surface business-layer auth errors from Zhipu and z.ai monitor APIs

## Intent

The Zhipu and z.ai quota monitor APIs report expired or invalid credentials inside an HTTP 200 body. A capture from today with a bad key:

```
HTTP/1.1 200
{"code":401,"msg":"令牌已过期或验证不正确","success":false}
```

The providers only checked `response.ok`, so a dead key parsed as a success with zero limits. The UI rendered the provider with no windows and no reason, and the logs said nothing either. I hit this in real use: a key that had rotated out looked exactly like an account with no quota data.

This PR adds a `resolveBusinessError` helper, shared in `utils/transformers.js` on web and copied locally in the VS Code `quotaProviders.ts`, and calls it right after `response.json()` in all four fetch paths: web z.ai, web Zhipu, VS Code z.ai, VS Code Zhipu. When the body says `success: false` or carries a numeric code other than 200, the result becomes `ok: false`, `configured: true`, with `error` set to the API's own message. This is the AGENTS.md invariant applied to in-band errors: never let fetch failure masquerade as authoritative empty success.

## Non-goals

The family-wide sweep stays out. On main, 17 other web providers use `response.ok`-only checks, and each one needs knowledge of what that API's in-band errors actually look like before the check can be written honestly. No retry logic. No translation of the message, the API string passes through. No changes to how keys are read.

## Affected surfaces

- `packages/web` server quota: `zai.js`, `zhipuai-coding-plan.js`, shared helper in `utils/transformers.js`, response-contract note in `DOCUMENTATION.md`
- `packages/vscode`: `quotaProviders.ts` local helper copy, same check in `fetchZaiQuota` and `fetchZhipuaiCodingPlanQuota`, tests
- Hosted mobile and desktop render server results, nothing to change there
- No persisted or external contracts change

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md correctness invariant, never let fetch failure masquerade as authoritative empty success | Both monitor APIs do exactly this inside HTTP 200 | The parsed body is checked before limits are read; a business error returns ok:false with the API message |
| `openchamber-change-discipline` skill | Source, a new export, and a two-surface sync changed | Focused tests per surface, oxlint on authored files, dead-code inspected for the new export |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Owning module doc, response contract section | Contract now states that in-band monitor errors must surface as ok:false |
| VS Code parity convention in `quotaProviders.test.ts` | The extension carries its own copy of the fetch logic | Helper duplicated locally using the file's `asObject` and `asNonEmptyString` helpers, tests added on both sides |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web vitest run server/lib/quota` | 190 tests passed, 3 new: one z.ai expired-key case, two in the new `zhipuai-coding-plan.test.js` |
| `node scripts/run-isolated-tests.mjs src` in packages/vscode | 35/35 test files passed, 2 new tests included |
| `bunx oxlint` on changed source files | No findings on authored code. The new test file mocks modules with `vi.mock` the way the nine existing provider tests do, and the module-mocking rule flags those the same way |
| `bun run dead-code` | `resolveBusinessError` is imported by both providers, not flagged |
| `bun run --cwd packages/vscode type-check` | Clean across both tsconfigs |
| `bun run type-check`, `bun run lint`, `bun run build` at the repo root | Green. Five packages exit 0 for type-check and lint, build finishes in 42.6s |
| `bun run test` at the repo root | Every suite green except `scripts/legend-list-padding.test.mjs`, which fails 4 pass 12 fail on upstream/main as well, a pre-existing baseline failure |
| Live manual check on a real instance, English UI | Expired Zhipu key: main renders the provider with empty windows, this branch shows the API message. Screenshots below |

Not verified: the mobile suite, which the root test run does not include and which does not exercise these server modules.

## Visual evidence

Usage settings panel, Zhipu provider, key set to an expired-format value, UI language forced to English, same window size, dialog-level capture. On main the detail reads "No quota windows reported" with no error anywhere. On this branch it reads "Failed to refresh usage data" with the API's own message below it. Screenshots below.

![Before: upstream main with an expired key shows an empty panel and no error](https://raw.githubusercontent.com/ouyangjian28/openchamber/pr-assets-20260911/shots/shot-main-a.png)

![After: this branch surfaces the refresh failure and the API message](https://raw.githubusercontent.com/ouyangjian28/openchamber/pr-assets-20260911/shots/shot-b2-a.png)

## Risks and failure behavior

- The visible change: states that used to render as empty success now show an error. That is the point. Anyone who relied on silent empties sees the truth instead.
- Providers whose APIs never signal errors in band are untouched. The helper returns null unless `success` is false or the code is a number other than 200.
- Rollback is reverting one commit. No data or contract migration involved.
- Stacking: #3352 is open and touches limit parsing in the same two fetch functions. The insertions here sit between `response.json()` and the parsing block, so the regions adjoin but do not overlap. A companion PR from me resolves `{file:...}` apiKey references in `getApiKey` of `zhipuai-coding-plan.js`; it also adds a new `zhipuai-coding-plan.test.js`, so an add/add conflict is expected there and resolves by keeping both describe blocks.
