### PR TITLE
fix(quota): resolve {file:...} apiKey references for provider requests

### DIFF
--- a/packages/web/server/lib/quota/DOCUMENTATION.md
+++ b/packages/web/server/lib/quota/DOCUMENTATION.md
@@ -38,7 +38,7 @@ These provider IDs are currently dispatchable via `fetchQuotaForProvider(provide
 | `nano-gpt` | NanoGPT | `providers/nanogpt.js` | `nano-gpt`, `nanogpt`, `nano_gpt` |
 | `openrouter` | OpenRouter | `providers/openrouter.js` | `openrouter` |
 | `zai-coding-plan` | z.ai | `providers/zai.js` | `zai-coding-plan`, `zai`, `z.ai` |
-| `zhipuai-coding-plan` | Zhipu AI Coding Plan | `providers/zhipuai-coding-plan.js` | `zhipuai-coding-plan`, `zhipuai`, `zhipu` |
+| `zhipuai-coding-plan` | Zhipu AI Coding Plan | `providers/zhipuai-coding-plan.js` | `zhipuai-coding-plan`, `zhipuai`, `zhipu`; reads the key from OpenCode `auth.json`, falls back to provider config options and resolves `{file:...}` apiKey references there (`utils/auth.js`) |
 | `minimax-coding-plan` | MiniMax Coding Plan (minimax.io) | `providers/minimax-coding-plan.js` / `providers/minimax-shared.js` | `minimax-coding-plan` |
 | `minimax-cn-coding-plan` | MiniMax Coding Plan (minimaxi.com) | `providers/minimax-cn-coding-plan.js` / `providers/minimax-shared.js` | `minimax-cn-coding-plan` |
 | `ollama-cloud` | Ollama Cloud | `providers/ollama-cloud.js` | Manual cookie pasted into Settings (`aid=...; __Secure-session=...` from `ollama.com`), stored under `~/.config/openchamber/quota/` |

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.js
@@ -30,6 +30,7 @@ import { readConfigLayers } from '../../opencode/shared.js';
 import {
   getAuthEntry,
   normalizeAuthEntry,
+  resolveApiKeyFileReference,
   buildResult,
   toUsageWindow,
   resolveWindowSeconds,
@@ -46,7 +47,7 @@ function getApiKey() {
   const apiKeyFromAuth = entry?.key ?? entry?.token;
 
   if (apiKeyFromAuth) {
-    return apiKeyFromAuth;
+    return resolveApiKeyFileReference(apiKeyFromAuth);
   }
 
   try {
@@ -55,7 +56,7 @@ function getApiKey() {
     for (const alias of aliases) {
       const providerConfig = mergedConfig?.provider?.[alias];
       if (providerConfig?.options?.apiKey) {
-        return providerConfig.options.apiKey;
+        return resolveApiKeyFileReference(providerConfig.options.apiKey);
       }
     }
   } catch {

--- a/packages/web/server/lib/quota/providers/zhipuai-coding-plan.test.js
+++ b/packages/web/server/lib/quota/providers/zhipuai-coding-plan.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const keyFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'openchamber-quota-')), 'api-key');
+fs.writeFileSync(keyFile, 'file-reference-token\n');
+
+vi.mock('../../opencode/auth.js', () => ({
+  readAuthFile: () => ({}),
+}));
+
+vi.mock('../../opencode/shared.js', () => ({
+  OPENCODE_CONFIG_DIR: '/tmp/opencode-test-config',
+  readConfigLayers: vi.fn(() => ({
+    mergedConfig: {
+      provider: {
+        'zhipuai-coding-plan': { options: { apiKey: `{file:${keyFile}}` } },
+      },
+    },
+  })),
+}));
+
+import { fetchQuota } from './zhipuai-coding-plan.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const mockResponse = (body) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+describe('Zhipu AI Coding Plan quota provider', () => {
+  it('resolves {file:...} apiKey references from provider config', async () => {
+    let authHeader = null;
+    vi.stubGlobal('fetch', vi.fn(async (url, init) => {
+      authHeader = init.headers.Authorization;
+      return mockResponse({
+        data: {
+          limits: [
+            { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 36 },
+          ],
+        },
+      });
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(authHeader).toBe('Bearer file-reference-token');
+    expect(result.usage.windows['Tokens']).toMatchObject({ usedPercent: 36 });
+  });
+
+  it('keeps the raw value when the referenced file is unreadable', async () => {
+    let authHeader = null;
+    vi.stubGlobal('fetch', vi.fn(async (url, init) => {
+      authHeader = init.headers.Authorization;
+      return mockResponse({
+        data: {
+          limits: [
+            { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 36 },
+          ],
+        },
+      });
+    }));
+
+    const { readConfigLayers } = await import('../../opencode/shared.js');
+    const brokenKeyFile = `{file:${path.join(os.tmpdir(), 'openchamber-quota', 'missing-key')}}`;
+    vi.mocked(readConfigLayers).mockImplementationOnce(() => ({
+      mergedConfig: {
+        provider: {
+          'zhipuai-coding-plan': { options: { apiKey: `${brokenKeyFile}` } },
+        },
+      },
+    }));
+
+    const result = await fetchQuota();
+
+    expect(result.ok).toBe(true);
+    expect(authHeader).toBe(`Bearer ${brokenKeyFile}`);
+  });
+});

--- a/packages/web/server/lib/quota/utils/auth.js
+++ b/packages/web/server/lib/quota/utils/auth.js
@@ -34,6 +34,20 @@ export const getAuthEntry = (auth, aliases) => {
   return null;
 };
 
+// OpenCode config accepts `{file:/path}` apiKey references and resolves them for
+// chat traffic; raw references reaching a quota provider mean the key never loads.
+export const resolveApiKeyFileReference = (value) => {
+  if (typeof value !== 'string') return value;
+  const match = value.trim().match(/^\{file:(.+)\}$/);
+  if (!match) return value;
+  try {
+    const resolved = fs.readFileSync(match[1].trim(), 'utf8').trim();
+    return resolved || value;
+  } catch {
+    return value;
+  }
+};
+
 export const normalizeAuthEntry = (entry) => {
   if (!entry) return null;
   if (typeof entry === 'string') {


### PR DESCRIPTION
Title: fix(quota): resolve {file:...} apiKey references in Zhipu provider config

## Intent

OpenCode config accepts `{file:/path}` apiKey references and resolves them when it launches chat traffic. The Zhipu quota provider reads provider options through `readConfigLayers` and passed the value through raw, so a `{file:...}` reference traveled to the monitor endpoint as the literal bearer string and every request failed authentication.

I hit this in real use. My key lives in a file reference, opencode itself talks to Zhipu fine, and the quota panel showed the provider with no data and no reason. Two failures stack here: the raw reference in the header, and the response handling that turns the resulting error into empty success. The second one is #3509. This one fixes the first.

`utils/auth.js` gains `resolveApiKeyFileReference`, and `getApiKey` in `zhipuai-coding-plan.js` applies it at both key sources, the auth.json fallback and the provider config entry. When the referenced file is missing or unreadable, the raw value is kept, so the request fails auth upstream instead of silently changing shape.

## Non-goals

Central resolution inside `readConfigLayers` itself. It would cover every consumer at once and may be the better home for this, but that touches shared config plumbing used far beyond quota, so it is noted here rather than changed. No support for other reference forms. No VS Code change: the extension reads auth.json directly, where file references do not appear.

## Affected surfaces

`packages/web` server quota only. `utils/auth.js` gains the helper, `zhipuai-coding-plan.js` wires it into `getApiKey`, `DOCUMENTATION.md` provider row updated, one new test file. No UI, persisted, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `openchamber-change-discipline` skill | Source change with a new export | Package vitest slice run, oxlint on authored files, dead-code inspected for the new export |
| `packages/web/server/lib/quota/DOCUMENTATION.md` | Owning module doc, provider table | The zhipuai row now states both key sources and the file-reference resolution |
| Existing provider test precedent | Nine provider tests mock config and auth modules with `vi.mock` | The new test file follows the same pattern |

## Validation

| Check | Result |
|---|---|
| `bun run --cwd packages/web vitest run server/lib/quota` | 189 tests passed, 2 new: one covering reference resolution through the real helper, one covering the unreadable-file fallback keeping the raw value |
| `bunx oxlint` on changed files | `auth.js` clean. `zhipuai-coding-plan.js` reports two typeof findings in the limit transforms at lines 117 and 131, pre-existing and untouched by this diff. The test file's module-mocking finding matches the existing suite pattern |
| `bun run dead-code` | `resolveApiKeyFileReference` is imported by the provider, not flagged |
| `bun run type-check`, `bun run lint`, `bun run build` at the repo root | Green. Five packages exit 0 for type-check and lint, build finishes in 42.2s |
| `bun run test` at the repo root | Every suite green except `scripts/legend-list-padding.test.mjs`, which fails 4 pass 12 fail on upstream/main as well, a pre-existing baseline failure |
| Live manual check on a real instance, English UI | Provider configured with a `{file:...}` reference pointing at the key file. On main the monitor request fails authentication and the panel shows empty windows with no error. On this branch the reference resolves and the monitor call succeeds; rendering the windows additionally needs the `CREDIT_LIMIT` parsing from #3352, so the after screenshot below is captured with that PR stacked on top. Without it, both states look identical in the panel |

Not verified: the mobile suite, which the root test run does not include and which does not exercise these server modules.

## Visual evidence

Usage settings panel, Zhipu provider, key configured as a `{file:...}` reference, UI language forced to English, same window size, dialog-level capture. On main the detail reads "No quota windows reported" with no error anywhere. The second shot is captured with #3352 stacked on top of this branch and shows both windows rendering, because main's parser cannot read the `CREDIT_LIMIT` entries the live monitor API now returns; without #3352 the panel shows empty windows whether the reference resolves or not. Screenshots below.

![Before: upstream main with a file-reference key shows an empty panel](https://raw.githubusercontent.com/ouyangjian28/openchamber/pr-assets-20260911/shots/shot-main-b.png)

![After: this branch with #3352 applied renders both quota windows](https://raw.githubusercontent.com/ouyangjian28/openchamber/pr-assets-20260911/shots/shot-b3-b.png)

## Risks and failure behavior

- A missing or unreadable referenced file keeps the raw value, the request fails auth upstream, and that failure surfaces as an error message once #3509 lands. On main it stays silent, same as today.
- The file read happens at quota fetch cadence, a small synchronous read of a key file. Not a hot path.
- Security: the resolved content is used only in the Authorization header, same as a literal key would be.
- Rollback is reverting one commit. No data or contract migration involved.
- Stacking: #3352 is open and touches limit parsing in the same provider file. This diff touches only `getApiKey` and the import block, no overlap. The #3509 business-error PR adds a new `zhipuai-coding-plan.test.js`, and this PR adds one too, so an add/add conflict is expected there and resolves by keeping both describe blocks.
