### PR TITLE
fix(work-status): correct turn stats across compactions

### DIFF
--- a/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
@@ -128,6 +128,9 @@ rate; unavailable response timing never falls back to whole-turn speed.
 
 Whole-turn speed uses output plus reasoning tokens from every step, divided by
 elapsed assistant time minus the union of completed and failed tool intervals.
+Compaction summaries are checkpoints, not assistant steps. Providers that
+collate several model requests into one assistant record can supply aggregate
+usage and timing in their namespaced message metadata.
 Waiting for each model response remains included. Invalid or missing inputs
 omit the dependent metric rather than becoming zero; reported zeros remain
 valid. TTFT averages the earliest text/reasoning start delay from every step,

--- a/packages/ui/src/components/chat/work-status/telemetry.test.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.test.ts
@@ -10,6 +10,21 @@ const assistant = (overrides: Partial<AssistantMessage> = {}): AssistantMessage 
   tokens: { input: 100, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
   ...overrides,
 });
+const withOmpTurnUsage = (info: AssistantMessage, turnUsage: NonNullable<AssistantMessage['tokens']>): AssistantMessage => {
+  // SAFETY: The sidecar's runtime message metadata carries this namespaced telemetry extension.
+  (info as AssistantMessage & { metadata?: { omp?: { turnUsage?: NonNullable<AssistantMessage['tokens']> } } }).metadata = {
+    omp: { turnUsage },
+  };
+  return info;
+};
+const withOmpTiming = (
+  info: AssistantMessage,
+  telemetry: { modelDurationMs: number; ttftMs: number; ttftSamples: number },
+): AssistantMessage => {
+  // SAFETY: The sidecar's runtime message metadata carries this namespaced telemetry extension.
+  (info as AssistantMessage & { metadata?: { omp?: typeof telemetry } }).metadata = { omp: telemetry };
+  return info;
+};
 const tool = (start: number, end: number): Part => ({
   id: `tool-${start}`, sessionID: user.sessionID, messageID: 'a1', type: 'tool', tool: 'bash', callID: 'call',
   state: { status: 'completed', input: {}, output: '', title: 'test', metadata: {}, time: { start, end } },
@@ -48,6 +63,88 @@ describe('turn telemetry', () => {
     expect(stats).toEqual({ stepsCount: 2, lastAssistantMessageId: 'a2', totalToolDurationMs: 3000,
       totalLlmDurationMs: 10000, outputTokens: 300, reasoningTokens: 300, totalGeneratedTokens: 600,
       inputTokens: 2500, cost: 0.015, tokensPerSecond: 60, responseTokensPerSecond: null, avgTtftMs: 1000, cacheHitPercent: 44 });
+  });
+
+  test('excludes compaction summaries from turn stats without ending the turn', () => {
+    const records = turn(assistant({ id: 'first', time: { created: 1000, completed: 5000 } }));
+    records.push({
+      info: assistant({
+        id: 'compaction',
+        summary: true,
+        time: { created: 6000, completed: 6000 },
+        tokens: { input: 60_000, output: 25_000, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+      parts: [text(6000)],
+    });
+    records.push({
+      info: assistant({ id: 'final', time: { created: 7000, completed: 9000 }, tokens: { input: 200, output: 50, reasoning: 10, cache: { read: 100, write: 0 } } }),
+      parts: [text(7500)],
+    });
+
+    const stats = getLatestCompletedTurnStats(records);
+    expect(stats?.lastAssistantMessageId).toBe('final');
+    expect(stats?.stepsCount).toBe(2);
+    expect(stats?.totalLlmDurationMs).toBe(6000);
+    expect(stats?.inputTokens).toBe(300);
+    expect(stats?.outputTokens).toBe(150);
+    expect(stats?.reasoningTokens).toBe(10);
+    expect(stats?.totalGeneratedTokens).toBe(160);
+
+    const trailingCompaction = [...records, {
+      info: assistant({ id: 'trailing-compaction', summary: true, time: { created: 10_000, completed: 10_000 } }),
+      parts: [text(10_000)],
+    }];
+    expect(getLatestCompletedTurnStats(trailingCompaction)).toBeNull();
+  });
+
+  test('uses sidecar turn usage totals while keeping final context tokens separate', () => {
+    const first = withOmpTurnUsage(assistant({ id: 'first' }), {
+      input: 1000,
+      output: 200,
+      reasoning: 300,
+      cache: { read: 2000, write: 0 },
+    });
+    const final = withOmpTurnUsage(assistant({ id: 'final', time: { created: 6000, completed: 8000 } }), {
+      input: 1500,
+      output: 100,
+      reasoning: 50,
+      cache: { read: 1000, write: 0 },
+    });
+
+    const stats = getLatestCompletedTurnStats([
+      { info: user, parts: [] },
+      { info: first, parts: [] },
+      { info: final, parts: [] },
+    ]);
+
+    expect(stats?.inputTokens).toBe(2500);
+    expect(stats?.outputTokens).toBe(300);
+    expect(stats?.reasoningTokens).toBe(350);
+    expect(stats?.totalGeneratedTokens).toBe(650);
+    expect(stats?.tokensPerSecond).toBe(650 / 6);
+    expect(stats?.cacheHitPercent).toBe(55);
+  });
+
+  test('uses sidecar model durations and TTFT samples for collated messages', () => {
+    const first = withOmpTiming(assistant({ id: 'first' }), {
+      modelDurationMs: 2500,
+      ttftMs: 1000,
+      ttftSamples: 2,
+    });
+    const final = withOmpTiming(assistant({ id: 'final', time: { created: 6000, completed: 8000 } }), {
+      modelDurationMs: 1500,
+      ttftMs: 500,
+      ttftSamples: 1,
+    });
+
+    const stats = getLatestCompletedTurnStats([
+      { info: user, parts: [] },
+      { info: first, parts: [] },
+      { info: final, parts: [] },
+    ]);
+
+    expect(stats?.totalLlmDurationMs).toBe(4000);
+    expect(stats?.avgTtftMs).toBe(500);
   });
 
   test('uses only the latest user-bounded turn', () => {

--- a/packages/ui/src/components/chat/work-status/telemetry.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.ts
@@ -10,12 +10,25 @@ type CompletedStepStats = {
   toolDurationMs: number | null;
   adjustedLlmDurationMs: number | null;
   ttftMs: number | null;
+  ttftSampleCount: number;
   inputTokens: number | null;
   outputTokens: number | null;
   reasoningTokens: number | null;
   cacheReadTokens: number | null;
   cacheWriteTokens: number | null;
   cost: number | null;
+};
+
+type AssistantInfo = Extract<Message, { role: 'assistant' }>;
+type TelemetryTokens = NonNullable<AssistantInfo['tokens']>;
+type OmpTurnTelemetry = {
+  turnUsage?: TelemetryTokens;
+  modelDurationMs?: number;
+  ttftMs?: number;
+  ttftSamples?: number;
+};
+type OmpTelemetryMetadata = {
+  omp?: OmpTurnTelemetry;
 };
 
 export type CompletedTurnStats = {
@@ -109,6 +122,16 @@ const nonnegative = (value: number | undefined): number | null =>
 const add = (left: number | null, right: number | null): number | null =>
   left === null || right === null ? null : nonnegative(left + right);
 
+const getOmpTurnTelemetry = (info: AssistantInfo): OmpTurnTelemetry | undefined => {
+  // SAFETY: The sidecar namespaces its optional aggregate usage under `info.metadata.omp`.
+  const metadata = (info as AssistantInfo & { metadata?: OmpTelemetryMetadata }).metadata;
+  return metadata?.omp;
+};
+
+const getTelemetryTokens = (info: AssistantInfo): TelemetryTokens | undefined => {
+  return getOmpTurnTelemetry(info)?.turnUsage ?? info.tokens;
+};
+
 /** Text delivery rate for the final reply, not throughput of the agent loop. */
 function calculateResponseTokenRate(record: SessionMessageRecord): number | null {
   const { info, parts } = record;
@@ -138,7 +161,8 @@ function calculateResponseTokenRate(record: SessionMessageRecord): number | null
  */
 function calculateCompletedStepStats(record: SessionMessageRecord): CompletedStepStats | null {
   const { info, parts } = record;
-  if (info.role !== 'assistant') return null;
+  if (info.role !== 'assistant' || info.summary === true) return null;
+  const ompTurnTelemetry = getOmpTurnTelemetry(info);
 
   const { created } = info.time;
   const completed = info.time.completed;
@@ -167,9 +191,11 @@ function calculateCompletedStepStats(record: SessionMessageRecord): CompletedSte
   }
 
   const toolDurationMs = validTools ? nonnegative(sumIntervalsDuration(mergeTimeIntervals(rawToolIntervals))) : null;
-  const adjustedLlmDurationMs = totalDurationMs !== null && toolDurationMs !== null
+  const calculatedLlmDurationMs = totalDurationMs !== null && toolDurationMs !== null
     ? nonnegative(totalDurationMs - toolDurationMs)
     : null;
+  const reportedModelDurationMs = nonnegative(ompTurnTelemetry?.modelDurationMs);
+  const adjustedLlmDurationMs = reportedModelDurationMs ?? calculatedLlmDurationMs;
 
   // Measure TTFT from first text or reasoning part start timestamp
   let ttftMs: number | null = null;
@@ -183,17 +209,29 @@ function calculateCompletedStepStats(record: SessionMessageRecord): CompletedSte
     }
   }
 
-  const inputTokens = nonnegative(info.tokens?.input);
-  const outputTokens = nonnegative(info.tokens?.output);
-  const reasoningTokens = nonnegative(info.tokens?.reasoning);
-  const cacheReadTokens = nonnegative(info.tokens?.cache?.read);
-  const cacheWriteTokens = nonnegative(info.tokens?.cache?.write);
+  const reportedTtftMs = nonnegative(ompTurnTelemetry?.ttftMs);
+  const reportedTtftSamples = nonnegative(ompTurnTelemetry?.ttftSamples);
+  const hasReportedTtft = reportedTtftMs !== null && reportedTtftSamples !== null && reportedTtftSamples > 0;
+  if (hasReportedTtft) {
+    ttftMs = reportedTtftMs;
+  }
+  const ttftSampleCount = hasReportedTtft
+    ? reportedTtftSamples
+    : (ttftMs === null ? 0 : 1);
+
+  const tokens = getTelemetryTokens(info);
+  const inputTokens = nonnegative(tokens?.input);
+  const outputTokens = nonnegative(tokens?.output);
+  const reasoningTokens = nonnegative(tokens?.reasoning);
+  const cacheReadTokens = nonnegative(tokens?.cache?.read);
+  const cacheWriteTokens = nonnegative(tokens?.cache?.write);
   const cost = nonnegative(info.cost);
 
   return {
     toolDurationMs,
     adjustedLlmDurationMs,
     ttftMs,
+    ttftSampleCount,
     inputTokens,
     outputTokens,
     reasoningTokens,
@@ -215,7 +253,7 @@ export function getLatestCompletedTurnStats(
   // Only the newest user-bounded turn qualifies. A partial newer turn must not
   // be published as complete or silently replaced with an older turn's stats.
   const lastCompletedAssistantIdx = records.length - 1;
-  if (records[lastCompletedAssistantIdx].info.role !== 'assistant') return null;
+  if (records[lastCompletedAssistantIdx].info.role !== 'assistant' || records[lastCompletedAssistantIdx].info.summary === true) return null;
   let turnStartIdx = -1;
   for (let i = records.length - 1; i >= 0; i -= 1) {
     const record = records[i];
@@ -230,7 +268,7 @@ export function getLatestCompletedTurnStats(
   const stepStatsList: CompletedStepStats[] = [];
   for (let i = turnStartIdx; i <= lastCompletedAssistantIdx; i += 1) {
     const record = records[i];
-    if (record.info.role === 'assistant') {
+    if (record.info.role === 'assistant' && record.info.summary !== true) {
       const stepStats = calculateCompletedStepStats(record);
       if (!stepStats) return null;
       stepStatsList.push(stepStats);
@@ -248,6 +286,7 @@ export function getLatestCompletedTurnStats(
   let totalCacheWriteTokens: number | null = 0;
   let totalCost: number | null = 0;
   let totalTtft: number | null = 0;
+  let totalTtftSamples = 0;
 
   for (const step of stepStatsList) {
     totalLlmDurationMs = add(totalLlmDurationMs, step.adjustedLlmDurationMs);
@@ -258,10 +297,15 @@ export function getLatestCompletedTurnStats(
     totalCacheReadTokens = add(totalCacheReadTokens, step.cacheReadTokens);
     totalCacheWriteTokens = add(totalCacheWriteTokens, step.cacheWriteTokens);
     totalCost = add(totalCost, step.cost);
-    totalTtft = add(totalTtft, step.ttftMs);
+    if (step.ttftMs === null) {
+      totalTtft = null;
+    } else {
+      totalTtft = add(totalTtft, step.ttftMs);
+      totalTtftSamples += step.ttftSampleCount;
+    }
   }
 
-  const avgTtftMs = totalTtft === null ? null : totalTtft / stepStatsList.length;
+  const avgTtftMs = totalTtft === null || totalTtftSamples === 0 ? null : totalTtft / totalTtftSamples;
 
   const totalGeneratedTokens = add(totalOutputTokens, totalReasoningTokens);
   const tokensPerSecond = totalGeneratedTokens !== null && totalLlmDurationMs !== null && totalLlmDurationMs > 0


### PR DESCRIPTION
## Intent

Correct the work-status turn statistics for OMP sessions that cross automatic compaction. Compaction summaries are checkpoints, not model steps, and a sidecar assistant record can represent several raw model requests. This change makes OpenChamber consume the sidecar's optional aggregate usage and timing metadata while preserving the final assistant token snapshot for context-window display.

The companion sidecar implementation is committed separately as `78264de` in `omp-openchamber-server`.

## Non-goals

- No change to compaction behavior, retry behavior, or model execution.
- No change to the separate final-response delivery-rate metric.
- No layout, label, theme, responsive, or interaction redesign.

## Affected surfaces

- `packages/ui/src/components/chat/work-status/telemetry.ts`: excludes compaction summaries, consumes optional OMP aggregate telemetry, and averages TTFT over provider-request samples.
- `packages/ui/src/components/chat/work-status/telemetry.test.ts`: covers compaction boundaries, sidecar aggregate usage, and sidecar timing.
- `packages/ui/src/components/chat/work-status/DOCUMENTATION.md`: documents compaction and provider metadata semantics.
- Optional persisted/live message metadata contract: reads `info.metadata.omp` when supplied by the companion sidecar and falls back to existing message fields for older sessions and other backends.

Only shared UI telemetry calculation changed. No Electron, mobile, web runtime, or native integration files were changed because those surfaces consume this calculation and do not own the provider message mapping.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` | Repository and package boundaries govern this UI-only change. | Kept the diff focused, added no dependencies, and did not touch `../opencode` or unrelated packages. |
| `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` | Required PR structure and validation reporting. | This description fills every template section and records exact commands and results. |
| `openchamber-change-discipline` skill | Turn-stat fixes must preserve the semantic model instead of hiding incomplete data. | Compaction summaries are filtered explicitly; a trailing summary leaves the newest turn incomplete rather than falling back to an older turn. |
| `ui-api-decoupling` and `sync-state-invariants` skills | The UI consumes server records and must remain stable across live/history synchronization. | Optional metadata is namespaced and backward-compatible; existing fallback calculations remain in place. |
| `packages/ui/src/components/chat/work-status/DOCUMENTATION.md` | Nearest component-specific guidance defines whole-turn speed and TTFT semantics. | Aggregate output plus reasoning tokens, provider model time, tool intervals, and TTFT sample counts follow the documented rules. |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.test.tsx packages/ui/src/components/chat/work-status/telemetry.test.ts packages/ui/src/components/chat/work-status/contextUsage.test.ts` | 42 passed, 0 failed. |
| `bun run type-check:ui` | Passed. |
| `bun run lint:ui` | Passed. |
| `bunx oxlint packages/ui/src/components/chat/work-status/telemetry.ts packages/ui/src/components/chat/work-status/telemetry.test.ts` | Passed. |
| `bun run docs:validate` | Passed: 517 pages, 47 sidebar links. |
| Companion sidecar replay and tests (`78264de`) | 412 sidecar tests passed, 5 live tests skipped; typecheck passed. The target replay now yields 631.0K input tokens, 161.9K generated tokens, 1,845.8s model time, 10.1s average TTFT, 81% cache hit, and about 88 tok/s. |
| Full OpenChamber monorepo test/build and live browser screenshot replay | Not run; the focused UI tests and static checks cover the changed calculation, while no rendered layout changed. |

## Visual evidence

No screenshot is attached for this PR. The patch changes only the values calculated in existing turn-stat rows; it does not add or alter rendered layout, responsive behavior, theme behavior, or interaction states. The supplied session screenshot was used as the symptom reference, and the corrected values are covered by deterministic telemetry tests and the companion session replay.

## Risks and failure behavior

- The exact OMP aggregate values require the companion sidecar metadata. Without it, older sessions and other backends continue using the existing per-record fallback calculations.
- Malformed or incomplete optional metadata is ignored through the existing nonnegative/nullable validation path; it does not become zero or silently substitute an older turn.
- A newest trailing compaction summary is treated as an incomplete turn, so the UI shows no stale completed-turn stats until the continuation arrives.
- The metadata is optional and namespaced, so existing persisted records remain readable and no data migration or destructive cleanup is required.
- The calculation adds negligible work over the existing record scan and does not change provider requests, permissions, or network behavior.
