### PR TITLE
feat(ui): show elapsed time in turn stats

### DIFF
--- a/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/work-status/DOCUMENTATION.md
@@ -133,6 +133,10 @@ omit the dependent metric rather than becoming zero; reported zeros remain
 valid. TTFT averages the earliest text/reasoning start delay from every step,
 only when all steps have a valid sample.
 
+Elapsed time is wall-clock time from the first user message in the turn through
+the final assistant completion. It includes model waits, tool execution,
+compaction, and other gaps; it is not used as a throughput denominator.
+
 Metric labels stay short. Every row is a single hover and keyboard-focus target
 for a shared tooltip, with a 750ms hover delay and a portal outside the panel's
 scroller. Tooltips explain the measurement in every locale. The token row uses

--- a/packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.test.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.test.tsx
@@ -89,6 +89,7 @@ describe('mounted turn telemetry with live sync stores', () => {
     expect(dom.container.textContent).not.toContain('Whole turn');
     await act(async () => store().setState({ sessionStatusReady: true }));
     expect(dom.container.textContent).toContain('~6 tok/s');
+    expect(dom.container.textContent).toContain('Elapsed6.0s');
     expect(dom.container.textContent).toContain('100 ↑ · 30 ↓');
     const heading = dom.container.querySelector('button');
     if (!heading) throw new Error('Expected section heading');
@@ -203,7 +204,7 @@ describe('mounted turn telemetry with live sync stores', () => {
       },
     }));
     const triggers = dom.container.querySelectorAll<HTMLElement>('[data-slot="tooltip-trigger"]');
-    expect(triggers.length).toBe(9);
+    expect(triggers.length).toBe(10);
     for (const trigger of triggers) expect(trigger.tabIndex).toBe(0);
     expect(dom.container.querySelectorAll('[title]').length).toBe(0);
     const response = triggers[0];

--- a/packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.tsx
+++ b/packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.tsx
@@ -107,6 +107,13 @@ export const WorkStatusTelemetrySection: React.FC<Props> = ({ sessionId, directo
               value={<WorkStatusValue>{formatThroughputRate(stats.tokensPerSecond)}</WorkStatusValue>}
             />
           ) : null}
+          {stats.elapsedDurationMs !== null ? (
+            <TelemetryRow
+              label={t('chat.workStatus.telemetry.elapsed')}
+              description={t('chat.workStatus.telemetry.elapsedDescription')}
+              value={<WorkStatusValue>{formatTelemetryDuration(stats.elapsedDurationMs)}</WorkStatusValue>}
+            />
+          ) : null}
 
           {stats.totalLlmDurationMs !== null ? (
             <TelemetryRow

--- a/packages/ui/src/components/chat/work-status/telemetry.test.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.test.ts
@@ -28,7 +28,9 @@ describe('turn telemetry', () => {
   test('formats durations, counts and approximate throughput', () => {
     expect(formatTelemetryDuration(0)).toBe('0.0s');
     expect(formatTelemetryDuration(1234)).toBe('1.2s');
-    expect(formatTelemetryDuration(84000)).toBe('1m24s');
+    expect(formatTelemetryDuration(84000)).toBe('1m 24s');
+    expect(formatTelemetryDuration(2796044)).toBe('46m 36s');
+    expect(formatTelemetryDuration(84600)).toBe('1m 25s');
     expect(formatTelemetryTokens(0)).toBe('0');
     expect(formatTelemetryTokens(500)).toBe('500');
     expect(formatTelemetryTokens(1234)).toBe('1.2K');

--- a/packages/ui/src/components/chat/work-status/telemetry.test.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.test.ts
@@ -45,9 +45,23 @@ describe('turn telemetry', () => {
       tokens: { input: 1500, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
     }), parts: [text(21500)] });
     const stats = getLatestCompletedTurnStats(records);
-    expect(stats).toEqual({ stepsCount: 2, lastAssistantMessageId: 'a2', totalToolDurationMs: 3000,
+    expect(stats).toEqual({ stepsCount: 2, lastAssistantMessageId: 'a2', elapsedDurationMs: 24000, totalToolDurationMs: 3000,
       totalLlmDurationMs: 10000, outputTokens: 300, reasoningTokens: 300, totalGeneratedTokens: 600,
       inputTokens: 2500, cost: 0.015, tokensPerSecond: 60, responseTokensPerSecond: null, avgTtftMs: 1000, cacheHitPercent: 44 });
+  });
+
+  test('omits elapsed time when turn boundary timestamps are invalid', () => {
+    const invalidStartStats = getLatestCompletedTurnStats([
+      { info: { ...user, time: { created: Number.NaN } }, parts: [] },
+      { info: assistant(), parts: [] },
+    ]);
+    const invalidEndStats = getLatestCompletedTurnStats([
+      { info: { ...user, time: { created: 6000 } }, parts: [] },
+      { info: assistant(), parts: [] },
+    ]);
+
+    expect(invalidStartStats?.elapsedDurationMs).toBeNull();
+    expect(invalidEndStats?.elapsedDurationMs).toBeNull();
   });
 
   test('uses only the latest user-bounded turn', () => {

--- a/packages/ui/src/components/chat/work-status/telemetry.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.ts
@@ -21,6 +21,7 @@ type CompletedStepStats = {
 export type CompletedTurnStats = {
   lastAssistantMessageId: string;
   stepsCount: number;
+  elapsedDurationMs: number | null;
   totalLlmDurationMs: number | null;
   totalToolDurationMs: number | null;
   avgTtftMs: number | null;
@@ -227,6 +228,13 @@ export function getLatestCompletedTurnStats(
 
   if (turnStartIdx === -1) return null;
 
+  const turnStartMs = nonnegative(records[turnStartIdx - 1].info.time.created);
+  const turnEndMs = nonnegative(records[lastCompletedAssistantIdx].info.time.completed);
+  const elapsedDurationMs =
+    turnStartMs !== null && turnEndMs !== null && turnEndMs >= turnStartMs
+      ? turnEndMs - turnStartMs
+      : null;
+
   const stepStatsList: CompletedStepStats[] = [];
   for (let i = turnStartIdx; i <= lastCompletedAssistantIdx; i += 1) {
     const record = records[i];
@@ -276,6 +284,7 @@ export function getLatestCompletedTurnStats(
   return {
     lastAssistantMessageId: records[lastCompletedAssistantIdx].info.id,
     stepsCount: stepStatsList.length,
+    elapsedDurationMs,
     totalLlmDurationMs,
     totalToolDurationMs,
     avgTtftMs,

--- a/packages/ui/src/components/chat/work-status/telemetry.ts
+++ b/packages/ui/src/components/chat/work-status/telemetry.ts
@@ -83,8 +83,8 @@ export const formatTelemetryDuration = (ms: number): string => {
     return `${(ms / 1000).toFixed(1)}s`;
   }
   const minutes = Math.floor(ms / 60_000);
-  const seconds = Math.floor((ms % 60_000) / 1000);
-  return `${minutes}m${seconds}s`;
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
 };
 
 export const formatTelemetryTokens = (tokens: number): string => {

--- a/packages/ui/src/lib/i18n/messages/de.ts
+++ b/packages/ui/src/lib/i18n/messages/de.ts
@@ -3298,6 +3298,8 @@ export const dict = {
   'chat.workStatus.telemetry.responseSpeed': 'Antwort',
   'chat.workStatus.telemetry.responseSpeedDescription': 'Wie schnell der abschließende Text ankam. Ohne anfängliche Wartezeit, Denken und frühere Werkzeugaufrufe. Eine Schätzung aus Textzeitstempeln, keine Geschwindigkeitsmessung des Anbieters.',
   'chat.workStatus.telemetry.speed': 'Anfrage',
+  'chat.workStatus.telemetry.elapsed': 'Verstrichene Zeit',
+  'chat.workStatus.telemetry.elapsedDescription': 'Zeit von der ersten Benutzernachricht bis zur letzten Antwort des Assistenten. Enthält das Warten auf das Modell, Werkzeugausführung, Kompaktierung und andere Lücken.',
   'chat.workStatus.telemetry.llmDuration': 'Modellzeit',
   'chat.workStatus.telemetry.llmDurationDescription': 'Zeit aller Modellschritte einschließlich Warten auf Antworten. Die Werkzeuglaufzeit ist abgezogen. Das ist nicht nur die Zeit zur Texterzeugung.',
   'chat.workStatus.telemetry.toolDuration': 'Werkzeugzeit',

--- a/packages/ui/src/lib/i18n/messages/en.ts
+++ b/packages/ui/src/lib/i18n/messages/en.ts
@@ -3301,6 +3301,8 @@ export const dict = {
   'chat.workStatus.telemetry.responseSpeedDescription': 'How fast the final text arrived. Excludes the initial wait, reasoning, and earlier tool calls. An estimate from text timestamps, not a provider speed measurement.',
   'chat.workStatus.telemetry.speed': 'Whole turn',
   'chat.workStatus.telemetry.speedDescription': 'Tokens generated across all steps, including reasoning, divided by time with tool execution removed. Waiting for the model still counts, so many short tool calls can lower this number.',
+  'chat.workStatus.telemetry.elapsed': 'Elapsed',
+  'chat.workStatus.telemetry.elapsedDescription': 'Wall-clock time from the first user message to the final assistant response. Includes model waiting, tool execution, compaction, and other gaps.',
   'chat.workStatus.telemetry.llmDuration': 'Model time',
   'chat.workStatus.telemetry.llmDurationDescription': 'Time spent on all model steps, including waiting for responses. Tool execution time is removed. This is not just time spent generating text.',
   'chat.workStatus.telemetry.toolDuration': 'Tool time',

--- a/packages/ui/src/lib/i18n/messages/es.ts
+++ b/packages/ui/src/lib/i18n/messages/es.ts
@@ -3301,6 +3301,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': 'Respuesta',
   'chat.workStatus.telemetry.responseSpeedDescription': 'La velocidad a la que llegó el texto final. Excluye la espera inicial, el razonamiento y las llamadas anteriores a herramientas. Es una estimación basada en las marcas de tiempo del texto, no una medición del proveedor.',
   'chat.workStatus.telemetry.speed': 'Solicitud',
+  'chat.workStatus.telemetry.elapsed': 'Tiempo transcurrido',
+  'chat.workStatus.telemetry.elapsedDescription': 'Tiempo de reloj desde el primer mensaje del usuario hasta la respuesta final del asistente. Incluye la espera del modelo, la ejecución de herramientas, la compactación y otros intervalos.',
   'chat.workStatus.telemetry.llmDuration': 'Modelo',
   'chat.workStatus.telemetry.llmDurationDescription': 'Tiempo de todos los pasos del modelo, incluida la espera de respuestas. Se resta la ejecución de herramientas. No es solo el tiempo de generación de texto.',
   'chat.workStatus.telemetry.toolDuration': 'Herramientas',

--- a/packages/ui/src/lib/i18n/messages/fr.ts
+++ b/packages/ui/src/lib/i18n/messages/fr.ts
@@ -3298,6 +3298,8 @@ export const dict = {
   'chat.workStatus.telemetry.responseSpeed': 'Réponse',
   'chat.workStatus.telemetry.responseSpeedDescription': 'La vitesse à laquelle le texte final est arrivé. Sans attente initiale, raisonnement ni appels précédents aux outils. Une estimation basée sur les horodatages du texte, pas une mesure du fournisseur.',
   'chat.workStatus.telemetry.speed': 'Requête',
+  'chat.workStatus.telemetry.elapsed': 'Temps écoulé',
+  'chat.workStatus.telemetry.elapsedDescription': 'Temps réel entre le premier message de l’utilisateur et la réponse finale de l’assistant. Inclut l’attente du modèle, l’exécution des outils, la compaction et les autres intervalles.',
   'chat.workStatus.telemetry.llmDuration': 'Modèle',
   'chat.workStatus.telemetry.llmDurationDescription': 'Durée de toutes les étapes du modèle, attente des réponses comprise. Le temps des outils est soustrait. Ce ne sont pas uniquement les secondes de génération du texte.',
   'chat.workStatus.telemetry.toolDuration': 'Outils',

--- a/packages/ui/src/lib/i18n/messages/ja.ts
+++ b/packages/ui/src/lib/i18n/messages/ja.ts
@@ -3300,6 +3300,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': '回答',
   'chat.workStatus.telemetry.responseSpeedDescription': '最終テキストが届いた速さです。開始前の待ち時間、推論、先行するツール呼び出しは含みません。テキストの時刻から求めた推定値で、プロバイダー側の速度測定ではありません。',
   'chat.workStatus.telemetry.speed': 'リクエスト全体',
+  'chat.workStatus.telemetry.elapsed': '経過時間',
+  'chat.workStatus.telemetry.elapsedDescription': '最初のユーザーメッセージから最終アシスタント応答までの実時間です。モデルの待ち時間、ツール実行、コンパクション、その他の間隔を含みます。',
   'chat.workStatus.telemetry.llmDuration': 'モデル時間',
   'chat.workStatus.telemetry.llmDurationDescription': '応答待ちを含む全モデルステップの時間です。ツール実行時間は差し引いています。テキスト生成だけの時間ではありません。',
   'chat.workStatus.telemetry.toolDuration': 'ツール時間',

--- a/packages/ui/src/lib/i18n/messages/ko.ts
+++ b/packages/ui/src/lib/i18n/messages/ko.ts
@@ -3300,6 +3300,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': '응답',
   'chat.workStatus.telemetry.responseSpeedDescription': '최종 텍스트가 도착한 속도입니다. 시작 전 대기, 추론, 이전 도구 호출은 제외합니다. 텍스트 시간 기록으로 계산한 추정치이며 제공자 측 속도 측정값은 아닙니다.',
   'chat.workStatus.telemetry.speed': '전체 요청',
+  'chat.workStatus.telemetry.elapsed': '경과 시간',
+  'chat.workStatus.telemetry.elapsedDescription': '첫 사용자 메시지부터 최종 어시스턴트 응답까지의 실제 경과 시간입니다. 모델 대기, 도구 실행, 압축 및 기타 공백을 포함합니다.',
   'chat.workStatus.telemetry.llmDuration': '모델 시간',
   'chat.workStatus.telemetry.llmDurationDescription': '응답 대기를 포함한 모든 모델 단계의 시간입니다. 도구 실행 시간은 뺍니다. 텍스트 생성 시간만을 뜻하지는 않습니다.',
   'chat.workStatus.telemetry.toolDuration': '도구 시간',

--- a/packages/ui/src/lib/i18n/messages/pl.ts
+++ b/packages/ui/src/lib/i18n/messages/pl.ts
@@ -3317,6 +3317,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': 'Odpowiedź',
   'chat.workStatus.telemetry.responseSpeedDescription': 'Jak szybko docierał końcowy tekst. Bez początkowego oczekiwania, rozumowania i wcześniejszych wywołań narzędzi. To szacunek z czasów tekstu, a nie pomiar po stronie dostawcy.',
   'chat.workStatus.telemetry.speed': 'Całe żądanie',
+  'chat.workStatus.telemetry.elapsed': 'Czas rzeczywisty',
+  'chat.workStatus.telemetry.elapsedDescription': 'Czas od pierwszej wiadomości użytkownika do końcowej odpowiedzi asystenta. Obejmuje oczekiwanie na model, wykonywanie narzędzi, kompakcję i inne przerwy.',
   'chat.workStatus.telemetry.llmDuration': 'Czas modelu',
   'chat.workStatus.telemetry.llmDurationDescription': 'Czas wszystkich kroków modelu wraz z oczekiwaniem na odpowiedzi. Czas narzędzi jest odjęty. To nie tylko czas generowania tekstu.',
   'chat.workStatus.telemetry.toolDuration': 'Narzędzia',

--- a/packages/ui/src/lib/i18n/messages/pt-BR.ts
+++ b/packages/ui/src/lib/i18n/messages/pt-BR.ts
@@ -3301,6 +3301,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': 'Resposta',
   'chat.workStatus.telemetry.responseSpeedDescription': 'A velocidade com que o texto final chegou. Exclui a espera inicial, o raciocínio e as chamadas anteriores de ferramentas. É uma estimativa pelos horários do texto, não uma medição do provedor.',
   'chat.workStatus.telemetry.speed': 'Solicitação',
+  'chat.workStatus.telemetry.elapsed': 'Tempo decorrido',
+  'chat.workStatus.telemetry.elapsedDescription': 'Tempo de relógio entre a primeira mensagem do usuário e a resposta final do assistente. Inclui espera pelo modelo, execução de ferramentas, compactação e outros intervalos.',
   'chat.workStatus.telemetry.llmDuration': 'Modelo',
   'chat.workStatus.telemetry.llmDurationDescription': 'Tempo de todas as etapas do modelo, incluindo a espera pelas respostas. O tempo das ferramentas é descontado. Não é apenas o tempo de geração do texto.',
   'chat.workStatus.telemetry.toolDuration': 'Ferramentas',

--- a/packages/ui/src/lib/i18n/messages/tr.ts
+++ b/packages/ui/src/lib/i18n/messages/tr.ts
@@ -3211,6 +3211,8 @@ export const dict = {
   'chat.workStatus.telemetry.responseSpeed': 'Yanıt',
   'chat.workStatus.telemetry.responseSpeedDescription': 'Son metnin ne hızla geldiği. İlk bekleme, akıl yürütme ve önceki araç çağrıları dahil değildir. Metin zamanlarından hesaplanan bir tahmindir, sağlayıcı tarafındaki hız ölçümü değildir.',
   'chat.workStatus.telemetry.speed': 'Tüm istek',
+  'chat.workStatus.telemetry.elapsed': 'Geçen süre',
+  'chat.workStatus.telemetry.elapsedDescription': 'İlk kullanıcı mesajından son asistan yanıtına kadar geçen gerçek süredir. Model bekleme, araç çalıştırma, sıkıştırma ve diğer aralıkları içerir.',
   'chat.workStatus.telemetry.llmDuration': 'Model süresi',
   'chat.workStatus.telemetry.llmDurationDescription': 'Yanıt bekleme dahil tüm model adımlarının süresi. Araç çalışma süresi çıkarılır. Yalnızca metin üretme süresi değildir.',
   'chat.workStatus.telemetry.toolDuration': 'Araç süresi',

--- a/packages/ui/src/lib/i18n/messages/uk.ts
+++ b/packages/ui/src/lib/i18n/messages/uk.ts
@@ -3301,6 +3301,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': 'Відповідь',
   'chat.workStatus.telemetry.responseSpeedDescription': 'Як швидко надходив фінальний текст. Без очікування на початок, міркувань і попередніх викликів інструментів. Це оцінка за часовими мітками тексту, а не вимір швидкості на сервері провайдера.',
   'chat.workStatus.telemetry.speed': 'Увесь запит',
+  'chat.workStatus.telemetry.elapsed': 'Час, що минув',
+  'chat.workStatus.telemetry.elapsedDescription': 'Фактичний час від першого повідомлення користувача до фінальної відповіді асистента. Включає очікування моделі, виконання інструментів, компакцію та інші проміжки.',
   'chat.workStatus.telemetry.llmDuration': 'Час моделі',
   'chat.workStatus.telemetry.llmDurationDescription': 'Час усіх кроків моделі, включно з очікуванням відповідей. Час виконання інструментів віднято. Це не лише час генерації тексту.',
   'chat.workStatus.telemetry.toolDuration': 'Час інструментів',

--- a/packages/ui/src/lib/i18n/messages/zh-CN.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-CN.ts
@@ -3301,6 +3301,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': '回答速度',
   'chat.workStatus.telemetry.responseSpeedDescription': '最终文本到达的速度。不含开始前的等待、推理和之前的工具调用。这是根据文本时间戳估算的速度，不是提供商测得的生成速度。',
   'chat.workStatus.telemetry.speed': '整个请求',
+  'chat.workStatus.telemetry.elapsed': '已用时间',
+  'chat.workStatus.telemetry.elapsedDescription': '从第一条用户消息到助手最终回复的实际耗时。包括等待模型、工具执行、压缩和其他间隔。',
   'chat.workStatus.telemetry.llmDuration': '模型耗时',
   'chat.workStatus.telemetry.llmDurationDescription': '所有模型步骤的耗时，包括等待回答的时间。已扣除工具执行时间，并不只是生成文本的时间。',
   'chat.workStatus.telemetry.toolDuration': '工具耗时',

--- a/packages/ui/src/lib/i18n/messages/zh-TW.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-TW.ts
@@ -3300,6 +3300,8 @@ export const dict: Record<I18nKey, string> = {
   'chat.workStatus.telemetry.responseSpeed': '回答速度',
   'chat.workStatus.telemetry.responseSpeedDescription': '最終文字到達的速度。不含開始前的等待、推理和先前的工具呼叫。這是根據文字時間戳記估算的速度，不是供應商測得的生成速度。',
   'chat.workStatus.telemetry.speed': '整個請求',
+  'chat.workStatus.telemetry.elapsed': '經過時間',
+  'chat.workStatus.telemetry.elapsedDescription': '從第一則使用者訊息到助理最終回覆的實際耗時。包含等待模型、工具執行、壓縮與其他間隔。',
   'chat.workStatus.telemetry.llmDuration': '模型耗時',
   'chat.workStatus.telemetry.llmDurationDescription': '所有模型步驟的耗時，包括等待回答的時間。已扣除工具執行時間，並不只是生成文字的時間。',
   'chat.workStatus.telemetry.toolDuration': '工具耗時',


### PR DESCRIPTION
## Intent

Add an Elapsed row to Turn stats showing wall-clock time from the first user message through the final assistant completion. This exposes the total time that can include model waits, tool execution, compaction, and other gaps without changing throughput denominators. Positive duration formatting now matches the chat footer's rounding and spacing convention.

## Non-goals

- Do not change model time, tool time, TTFT, throughput, token, cache, or cost calculations.
- Do not change compaction or session-turn selection; that remains scoped to #3517.
- Do not touch the sidecar or amend #3517.

## Affected surfaces

- Shared UI telemetry calculation and Turn stats panel.
- All supported locale dictionaries for the new label and tooltip.
- Owning work-status documentation and focused unit/mounted UI tests.
- No persisted schema, API, sidecar, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| AGENTS.md | Repository and package workflow rules | Kept the branch based on upstream/main, limited the diff, and used focused validation. |
| openchamber-change-discipline | Small UI behavior change with an exported telemetry type | Kept the contract explicit, validated invalid timestamps, and updated owning docs. |
| ui-api-decoupling | UI consumes a shared telemetry calculation | Kept elapsed-time computation in telemetry.ts and made the component render-only. |
| theme-system and locale-ui-patterns | Visible shared UI row | Reused existing primitives and added translated label/tooltip keys in every locale. |
| work-status DOCUMENTATION.md, CONTRIBUTING.md, PR template | Owning behavior and PR contract | Documented wall-clock semantics, validation, risks, and scope. |

## Validation

| Check | Result |
|---|---|
| bun test packages/ui/src/components/chat/work-status/telemetry.test.ts packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.test.tsx | 31 passed, 0 failed |
| bun run type-check:ui | Passed |
| bun run lint:ui | Passed |
| bunx oxlint packages/ui/src/components/chat/work-status/telemetry.ts packages/ui/src/components/chat/work-status/telemetry.test.ts packages/ui/src/components/chat/work-status/WorkStatusTelemetrySection.tsx | Passed |
| bun run docs:validate | Passed: 517 pages, 47 sidebar links |
| git diff --check | Passed |

## Visual evidence

<img width="309" height="689" alt="Screenshot 2026-09-13 at 10 49 23 am" src="https://github.com/user-attachments/assets/c0386c08-4793-4459-95c0-37b70381ba55" />

## Risks and failure behavior

Elapsed is shown only when both boundary timestamps are finite and non-reversed. Invalid boundaries produce no elapsed row and do not invalidate the other metrics. The value is informational only and is not used for throughput or persisted anywhere.

Related: #3517