### PR TITLE
fix(electron): unassign Ctrl+Alt+Up/Down project navigation on Windows/Linux

### DIFF
--- a/packages/electron/main.mjs
+++ b/packages/electron/main.mjs
@@ -4982,8 +4982,12 @@ const buildAutoHiddenMenu = () => {
         { label: 'Previous Session', accelerator: 'Alt+Up', click: () => dispatchAction('previous-session') },
         { label: 'Next Session', accelerator: 'Alt+Down', click: () => dispatchAction('next-session') },
         { type: 'separator' },
-        { label: 'Previous Project', accelerator: 'Ctrl+Alt+Up', click: () => dispatchAction('previous-project') },
-        { label: 'Next Project', accelerator: 'Ctrl+Alt+Down', click: () => dispatchAction('next-project') },
+        // No accelerator: Ctrl+Alt+Up/Down must stay unassigned. Registering
+        // them here hijacks the keys globally and cycles the active project
+        // (sidebar jumps in project order without changing the session),
+        // which reads as random session jumping.
+        { label: 'Previous Project', click: () => dispatchAction('previous-project') },
+        { label: 'Next Project', click: () => dispatchAction('next-project') },
       ],
     },
     {


### PR DESCRIPTION
## Intent
On Desktop Windows/Linux, pressing Ctrl+Alt+Up/Down cycles the active project even though the keys look unassigned (nothing in Settings > Shortcuts mentions them). The sidebar jumps between projects in order via \setActiveProject\ without changing the session, which reads as random session jumping — sometimes the selection appears to move, sometimes not.

Root cause: \uildAutoHiddenMenu\ in \packages/electron/main.mjs\ registers \Ctrl+Alt+Up\ / \Ctrl+Alt+Down\ accelerators for Previous/Next Project. These fire globally through \dispatchAction('previous-project'/'next-project')\ -> \
avigateProject\ in \packages/ui/src/hooks/useMenuActions.ts\, which wraps around the project list. The macOS menu never had these entries.

Fix: drop the two accelerators, keep the Go-menu items clickable. Verified no other binding claims these keys: \packages/ui/src/lib/shortcuts/config.ts\ has no \ctrl+alt+arrowup/down\, and \DiffView\ Alt+Up/Down / \ChatContainer\ turn navigation both guard modifiers exactly.

## Non-goals
- Alt+Up/Down Previous/Next Session untouched.
- Web/PWA and VS Code extension untouched (no such binding there).
- No change to \
avigateProject\ logic itself.

## Affected surfaces
- \packages/electron\ Windows/Linux auto-hidden (and Alt-key) menu only.
- User-visible: Ctrl+Alt+Up/Down no longer switches projects; Previous/Next Project still available from Go menu by click.

## Validation
- \
ode --check packages/electron/main.mjs\ — pass.
- \un test packages/electron/startup-url-selection.test.mjs\ — 5 pass, 0 fail.
- \g -i Ctrl\+Alt\+(Up|Down)\ across \packages/electron/main.mjs\ + \packages/ui/src\ — only remaining hit is the new code comment.
- Full \un run type-check/lint/test/build\ and on-device Desktop repro recording not performed (no packaged build in this environment); please flag if the automated reviewer needs them.

## Risk and failure behavior
- Low risk: strictly removes two global accelerators. Users who relied on Ctrl+Alt+Up/Down for project switching lose that shortcut (menu click still works); rollback is restoring the two \ccelerator\ fields.