### PR TITLE
fix(ui): keep failed-dictation salvage controls on screen

### DIFF
--- a/packages/ui/src/components/chat/ChatInput.tsx
+++ b/packages/ui/src/components/chat/ChatInput.tsx
@@ -121,6 +121,7 @@ import {
     type ComposerChange,
     type ComposerEditorHandle,
 } from './composer/editor/ComposerEditor';
+import { useComposerHeightLimit } from './composer/editor/useComposerHeightLimit';
 import { createComposerEditorViewStore } from './composer/editor/viewStore';
 import { composerAutoCorrect } from './composer/editor/autocorrect';
 import {
@@ -2197,14 +2198,23 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
         }
     }, [agents, currentAgentName, currentSessionId, setAgent, saveSessionAgentSelection]);
 
-    // Height the dictation transcript needs (null when idle). Its overlay sits
+    // Height the failed-dictation salvage text needs. Its overlay sits
     // absolutely over the composer, so the composer must be able to grow for
-    // it. The editor sizes itself to its own content; this is the one external
-    // constraint, applied as a floor on the editor's container.
+    // it. Apply the editor's line and screen bounds before using that height as
+    // a floor, otherwise long salvage text can push the action row off-screen.
+    const dictationHeightHostRef = React.useRef<HTMLDivElement | null>(null);
     const [dictationContentHeight, setDictationContentHeight] = React.useState<number | null>(null);
     const handleDictationContentHeightChange = React.useCallback((height: number | null) => {
         setDictationContentHeight((prev) => (prev === height ? prev : height));
     }, []);
+    const dictationHeightLimit = useComposerHeightLimit({
+        active: dictationContentHeight !== null,
+        disabled: isComposerExpanded,
+        hostRef: dictationHeightHostRef,
+        maxLines: isMobile ? MAX_MOBILE_COMPOSER_LINES : MAX_VISIBLE_COMPOSER_LINES,
+        boundSelector: isMobile ? '[data-composer-bound]' : undefined,
+        boundGapPx: isMobile ? MOBILE_COMPOSER_BOUND_GAP_PX : 0,
+    });
 
     const updateAutocompleteState = React.useCallback((
         value: string,
@@ -3500,14 +3510,20 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                             {!isBtwActive ? <ActiveEditorFileSuggestion /> : null}
                         </div>
                         <div
+                            ref={dictationHeightHostRef}
                             className={cn("relative overflow-hidden", isComposerExpanded && 'flex flex-1 min-h-0 flex-col')}
                             onDragEnter={handleDragEnter}
                             onDragOver={handleDragOver}
                             onDropCapture={handleDropCapture}
                             onDrop={handleDrop}
                             onDragEnd={handleDragEnd}
-                            style={dictationContentHeight !== null
-                                ? { minHeight: `${dictationContentHeight}px` }
+                            style={dictationContentHeight !== null && !isComposerExpanded
+                                ? {
+                                    minHeight: `${Math.min(
+                                        dictationContentHeight,
+                                        dictationHeightLimit ?? dictationContentHeight,
+                                    )}px`,
+                                }
                                 : undefined}
                         >
                             <ComposerEditor

--- a/packages/ui/src/components/chat/composer/DOCUMENTATION.md
+++ b/packages/ui/src/components/chat/composer/DOCUMENTATION.md
@@ -319,6 +319,12 @@ refusing programmatic focus outside a gesture, WebKit leaving the layout
 viewport panned after the keyboard hides, overlay chains handing off through a
 frame where nothing is open.
 
+Typed text and salvage text shown after a failed dictation use the same measured
+line and screen-height limits. Once the viewport reports usable space, content
+scrolls inside the composer so the failed-dictation action row stays inside the
+chat screen. A transient non-positive viewport measurement keeps the existing
+line cap until the next resize instead of collapsing the editor to zero height.
+
 **Every timeout and `flushSync` in them has a reason recorded next to it, and
 none of them is verifiable outside a real device.** Change them only against
 hardware.

--- a/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
+++ b/packages/ui/src/components/chat/composer/editor/ComposerEditor.tsx
@@ -41,6 +41,7 @@ import type { ComposerEditorViewStore } from './viewStore';
 import { composerEditorTheme, composerSelectionExtension } from './theme';
 import { handleComposerHostMouseDown } from './hostMouseDown';
 import { restoreDeferredEnterModifiers } from '../keyboardPolicy';
+import { getComposerHeightLimit } from './heightLimit';
 
 export interface ComposerSelection {
     start: number;
@@ -435,12 +436,14 @@ export const ComposerEditor = React.forwardRef<ComposerEditorHandle, ComposerEdi
                     getComputedStyle(view.contentDOM).lineHeight || '',
                 );
                 if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-                let cap = lineHeight * maxLines;
-                if (boundEl && branch) {
-                    const chrome = branch.offsetHeight - view.scrollDOM.offsetHeight;
-                    const available = boundEl.clientHeight - chrome - boundGapPx;
-                    if (available > 0) cap = Math.min(cap, available);
-                }
+                const cap = getComposerHeightLimit({
+                    maxLinesHeight: lineHeight * maxLines,
+                    boundHeight: boundEl?.clientHeight,
+                    surroundingHeight: branch
+                        ? branch.offsetHeight - view.scrollDOM.offsetHeight
+                        : undefined,
+                    boundGapPx,
+                });
                 const next = `${cap}px`;
                 // The scroller growing re-fires the observer with an unchanged
                 // result; writing only on change keeps that loop silent.

--- a/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
+++ b/packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getComposerHeightLimit, getComposerHostHeightLimit } from '../heightLimit';
+
+describe('getComposerHeightLimit', () => {
+    test('keeps short composer content below both limits', () => {
+        const contentHeight = 120;
+        const limit = getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 640,
+            surroundingHeight: 180,
+            boundGapPx: 4,
+        });
+
+        expect(Math.min(contentHeight, limit)).toBe(contentHeight);
+    });
+
+    test('[issue-2533] keeps long failed-dictation salvage text and its controls inside the mobile bound', () => {
+        const salvageTextHeight = 1800;
+        const boundHeight = 640;
+        const surroundingHeight = 316;
+        const boundGapPx = 4;
+        const limit = getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight,
+            surroundingHeight,
+            boundGapPx,
+        });
+        const appliedHeight = Math.min(salvageTextHeight, limit);
+
+        expect(appliedHeight).toBe(320);
+        expect(appliedHeight + surroundingHeight + boundGapPx).toBeLessThanOrEqual(boundHeight);
+    });
+
+    test('[issue-2533] keeps failed-dictation salvage text bounded after a short viewport reflow', () => {
+        expect(getComposerHostHeightLimit({
+            maxLinesHeight: 360,
+            editorHeight: 52,
+            renderedScrollHeight: 15,
+            boundHeight: 361,
+            branchHeight: 357,
+            hostHeight: 52,
+            boundGapPx: 4,
+        })).toBe(52);
+    });
+
+    test('[issue-2533] does not feed the applied salvage height back into its limit', () => {
+        const dimensions = {
+            maxLinesHeight: 360,
+            editorHeight: 52,
+            renderedScrollHeight: 52,
+            boundHeight: 640,
+            boundGapPx: 4,
+        };
+
+        const initial = getComposerHostHeightLimit({
+            ...dimensions,
+            branchHeight: 316,
+            hostHeight: 52,
+        });
+        const afterGrowth = getComposerHostHeightLimit({
+            ...dimensions,
+            branchHeight: 624,
+            hostHeight: 360,
+        });
+
+        expect(initial).toBe(360);
+        expect(afterGrowth).toBe(initial);
+    });
+
+    test('uses the line cap when a tablet has more vertical room', () => {
+        expect(getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 1200,
+            surroundingHeight: 220,
+            boundGapPx: 4,
+        })).toBe(360);
+    });
+
+    test('keeps the line cap when no positive screen budget can be measured', () => {
+        expect(getComposerHeightLimit({
+            maxLinesHeight: 360,
+            boundHeight: 320,
+            surroundingHeight: 340,
+            boundGapPx: 4,
+        })).toBe(360);
+    });
+
+    test('falls back to the line cap when no screen bound is available', () => {
+        expect(getComposerHeightLimit({ maxLinesHeight: 180 })).toBe(180);
+    });
+});

--- a/packages/ui/src/components/chat/composer/editor/heightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/heightLimit.ts
@@ -1,0 +1,53 @@
+export interface ComposerHeightLimitOptions {
+    maxLinesHeight: number;
+    boundHeight?: number;
+    surroundingHeight?: number;
+    boundGapPx?: number;
+}
+
+export function getComposerHeightLimit(options: ComposerHeightLimitOptions): number {
+    const {
+        maxLinesHeight,
+        boundHeight,
+        surroundingHeight,
+        boundGapPx = 0,
+    } = options;
+    let limit = maxLinesHeight;
+    if (boundHeight !== undefined && surroundingHeight !== undefined) {
+        const available = boundHeight - surroundingHeight - boundGapPx;
+        if (available > 0) limit = Math.min(limit, available);
+    }
+    return limit;
+}
+
+export interface ComposerHostHeightLimitOptions {
+    maxLinesHeight: number;
+    editorHeight: number;
+    renderedScrollHeight: number;
+    boundHeight?: number;
+    branchHeight?: number;
+    hostHeight?: number;
+    boundGapPx?: number;
+}
+
+export function getComposerHostHeightLimit(options: ComposerHostHeightLimitOptions): number {
+    const {
+        maxLinesHeight,
+        editorHeight,
+        renderedScrollHeight,
+        boundHeight,
+        branchHeight,
+        hostHeight,
+        boundGapPx,
+    } = options;
+    const editorChrome = Math.max(0, editorHeight - renderedScrollHeight);
+    const surroundingHeight = branchHeight !== undefined && hostHeight !== undefined
+        ? Math.max(0, branchHeight - hostHeight)
+        : undefined;
+    return getComposerHeightLimit({
+        maxLinesHeight: maxLinesHeight + editorChrome,
+        boundHeight,
+        surroundingHeight,
+        boundGapPx,
+    });
+}

--- a/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
+++ b/packages/ui/src/components/chat/composer/editor/useComposerHeightLimit.ts
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { getComposerHostHeightLimit } from './heightLimit';
+
+interface UseComposerHeightLimitOptions {
+    active: boolean;
+    disabled?: boolean;
+    hostRef: React.RefObject<HTMLElement | null>;
+    maxLines: number;
+    boundSelector?: string;
+    boundGapPx?: number;
+}
+
+export function useComposerHeightLimit(options: UseComposerHeightLimitOptions): number | null {
+    const {
+        active,
+        disabled = false,
+        hostRef,
+        maxLines,
+        boundSelector,
+        boundGapPx = 0,
+    } = options;
+    const [heightLimit, setHeightLimit] = React.useState<number | null>(null);
+
+    React.useLayoutEffect(() => {
+        if (!active || disabled) {
+            setHeightLimit(null);
+            return;
+        }
+
+        const host = hostRef.current;
+        const content = host?.querySelector<HTMLElement>('.cm-content');
+        const editor = host?.querySelector<HTMLElement>('[data-chat-input="true"]');
+        const scroller = editor?.querySelector<HTMLElement>('.cm-scroller');
+        if (!host || !content || !editor || !scroller) return;
+
+        const bound = boundSelector ? host.closest<HTMLElement>(boundSelector) : null;
+        let branch: HTMLElement | null = null;
+        if (bound) {
+            branch = host;
+            while (branch.parentElement && branch.parentElement !== bound) {
+                branch = branch.parentElement;
+            }
+        }
+
+        const applyLimit = () => {
+            const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight || '');
+            if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
+            const next = getComposerHostHeightLimit({
+                maxLinesHeight: lineHeight * maxLines,
+                editorHeight: editor.offsetHeight,
+                renderedScrollHeight: scroller.offsetHeight,
+                boundHeight: bound?.clientHeight,
+                // Excluding the host keeps this budget stable when its
+                // failed-dictation min-height changes.
+                branchHeight: bound && branch ? branch.offsetHeight : undefined,
+                hostHeight: bound && branch ? host.offsetHeight : undefined,
+                boundGapPx,
+            });
+            setHeightLimit((previous) => (previous === next ? previous : next));
+        };
+
+        applyLimit();
+        if (!window.ResizeObserver) return;
+        const observer = new window.ResizeObserver(applyLimit);
+        observer.observe(content);
+        observer.observe(editor);
+        observer.observe(scroller);
+        if (branch) observer.observe(branch);
+        if (bound) observer.observe(bound);
+        return () => observer.disconnect();
+    }, [active, boundGapPx, boundSelector, disabled, hostRef, maxLines]);
+
+    return heightLimit;
+}

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -38,8 +38,8 @@ interface ComposerDictationProps {
     onInsertAndSend: (text: string) => void;
     /** Reports whether dictation is active (recording/transcribing/failed overlay shown). */
     onActiveChange?: (active: boolean) => void;
-    /** Reports the height (px) the transcript needs, so the host can grow the
-        composer like typed text would; null when dictation is idle. */
+    /** Reports the height (px) failed-dictation salvage text needs, so the host
+        can grow the composer like typed text would; null when none is shown. */
     onContentHeightChange?: (height: number | null) => void;
     /** Render the mic trigger button (default). Pass false when the host renders
         its own trigger and only needs the overlay + recording engine. */
@@ -227,23 +227,23 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
     const transcriptContentRef = React.useRef<HTMLDivElement | null>(null);
     const [footerHeight, setFooterHeight] = React.useState<number | null>(null);
     const isActiveStatus = status !== 'idle';
+    const hasSalvageText = status === 'failed' && Boolean(partialTranscript.trim());
 
-    // Grow the composer with the transcript, the way typing grows the
-    // textarea. The overlay is absolutely positioned over the composer, so it
-    // can't push the composer's height itself — measure how much room the
-    // transcript wants (scrollHeight ignores the clamped box) and report it to
-    // the host, which feeds it into the textarea autosize (same line cap, then
-    // the transcript area scrolls).
+    // Grow the composer with failed-dictation salvage text, the way typing grows
+    // the textarea. The overlay is absolutely positioned over the composer, so
+    // it can't push the composer's height itself. Measure how much room the text
+    // wants and report it to the host, which applies the editor's line and
+    // viewport caps before the salvage area scrolls.
     const onContentHeightChangeRef = React.useRef(onContentHeightChange);
     React.useEffect(() => {
         onContentHeightChangeRef.current = onContentHeightChange;
     }, [onContentHeightChange]);
     // Two instances can coexist (mobile footer + wrapper engine); only the one
-    // that actually reported a height may clear it, or an idle sibling
-    // mounting mid-recording would zero the active transcript's height.
+    // that reported salvage height may clear it, or an idle sibling mounting
+    // beside a failed dictation would zero the active overlay's height.
     const hasReportedHeightRef = React.useRef(false);
     React.useLayoutEffect(() => {
-        if (!isActiveStatus) {
+        if (!hasSalvageText) {
             if (hasReportedHeightRef.current) {
                 hasReportedHeightRef.current = false;
                 onContentHeightChangeRef.current?.(null);
@@ -253,18 +253,26 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
         const area = transcriptAreaRef.current;
         const content = transcriptContentRef.current;
         if (!area || !content) return;
-        // Measure the text block, not the container: the container is flex-1
+        // Measure the salvage text block, not the container: the container is flex-1
         // inside the overlay, so its scrollHeight tracks the composer's own
         // height — feeding that back would creep a few px on every transcript
         // update instead of stepping per wrapped line.
-        const style = window.getComputedStyle(area);
-        const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
-        hasReportedHeightRef.current = true;
-        onContentHeightChangeRef.current?.(content.offsetHeight + padding);
-        // Once the composer hits its line cap the transcript area starts
-        // scrolling — follow the newest words like a textarea caret would.
-        area.scrollTop = area.scrollHeight;
-    }, [isActiveStatus, partialTranscript, status, error]);
+        const reportHeight = () => {
+            const style = window.getComputedStyle(area);
+            const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+            hasReportedHeightRef.current = true;
+            onContentHeightChangeRef.current?.(content.offsetHeight + padding);
+            // Once the composer hits its line cap the salvage area starts
+            // scrolling — follow the newest words like a textarea caret would.
+            area.scrollTop = area.scrollHeight;
+        };
+        reportHeight();
+        if (!window.ResizeObserver) return;
+        const observer = new window.ResizeObserver(reportHeight);
+        // Re-report after rotation or any other width change rewraps the text.
+        observer.observe(content);
+        return () => observer.disconnect();
+    }, [hasSalvageText, partialTranscript]);
     React.useEffect(() => () => {
         if (hasReportedHeightRef.current) {
             hasReportedHeightRef.current = false;

--- a/packages/ui/src/components/dictation/ComposerDictation.tsx
+++ b/packages/ui/src/components/dictation/ComposerDictation.tsx
@@ -260,11 +260,19 @@ export const ComposerDictation: React.FC<ComposerDictationProps> = ({
         const reportHeight = () => {
             const style = window.getComputedStyle(area);
             const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+            const firstReport = !hasReportedHeightRef.current;
+            // Follow the newest words only while the reader is already at the
+            // end. A re-report (rotation, rewrap) must not yank a user who
+            // scrolled up back down — reading and copying earlier salvage text
+            // is the recovery path this overlay exists for.
+            const atEnd = area.scrollHeight - area.scrollTop - area.clientHeight <= 24;
             hasReportedHeightRef.current = true;
             onContentHeightChangeRef.current?.(content.offsetHeight + padding);
             // Once the composer hits its line cap the salvage area starts
             // scrolling — follow the newest words like a textarea caret would.
-            area.scrollTop = area.scrollHeight;
+            if (firstReport || atEnd) {
+                area.scrollTop = area.scrollHeight;
+            }
         };
         reportHeight();
         if (!window.ResizeObserver) return;


### PR DESCRIPTION
## Intent

Fixes #2533. Refs #3532.

A long dictation that fails partway (e.g. the server answers `Dictation stream not started` after several minutes) renders the partial transcript as **salvage text** in the composer overlay. The host grew the composer to the full transcript height through an uncapped `minHeight`, so on mobile the overlay outgrew the viewport:

- the transcript tail could not be scrolled to,
- the caret could not be placed (read-only text; iOS offers only **Copy**, never **Select All**), and
- the `retry` / `discard` / `insert` row was pushed off-screen.

Minutes of dictation were trapped with no recovery path; force-quitting discards them. This is the failure the reporter hit on a physical iPhone (iOS/Capacitor).

This change applies the editor's measured **line and screen-height caps** to the salvage height before using it as a floor, so the composer stops at the viewport and the salvage area scrolls internally. The limit math moves into `heightLimit.ts` (shared with the editor) and is measured through `useComposerHeightLimit`; a height is reported only while salvage text is shown, and re-reported after rotation or any width change that rewraps the text.

**This is a rebase of #3026 (by @karimodm) onto current `main`** — that branch is `mergeable: false / dirty`. The intent is unchanged; the surrounding composer moved (floating composer, etc.), so the patch was ported and re-verified. Full credit to @karimodm.

## Non-goals

- No change to speech capture, transcription providers, or the dictation WebSocket protocol.
- No live transcript while recording/transcribing (unchanged; only the failed-salvage path grows the composer).
- No change to recovery button behaviour, keyboard handling, or the fullscreen composer.
- No change to desktop or VS Code layouts beyond routing the editor cap through the shared helper.

## Affected surfaces

- `packages/ui`: the shared composer used by web, desktop, hosted mobile and Capacitor mobile.
- The failed-dictation salvage overlay on mobile (the reported iOS path); the editor's own cap is refactored onto the shared helper.
- No persisted data, API, route, setting or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| `AGENTS.md` + change discipline | shared UI and mobile runtime behaviour | diff stays in composer sizing, the shared helper, focused tests, and the owning documentation |
| `theme-system` | affects shared layout | no colours, tokens, controls, icons or animations changed |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | owns composer sizing and mobile behaviour | records the shared typed/salvage limit and the transient non-positive viewport fallback |
| `changelog/` is read-only until the maintainer asks | release notes are release-time work | no changelog entry added |

## Validation

| Check | Result |
|---|---|
| `bun test packages/ui/src/components/chat/composer/editor/__tests__/composerHeightLimit.test.ts` | **7 pass, 0 fail** (9 assertions) |
| `bun test packages/ui/src/components/chat/composer packages/ui/src/components/dictation` | **380 pass, 0 fail** |
| `bun run --cwd packages/ui type-check` | pass |
| `bun run --cwd packages/ui lint` | pass |

**Hardware note:** the report is from a physical iPhone (iOS). The original screenshot and reproduction are in #3532. I could not reproduce on a physical iOS device here, so a device check of the salvage overlay before merge is welcome.

## Visual evidence

This is a user-visible mobile fix, so here is the before state and the reasoning for the after:

- **Before** (reporter's physical iPhone, failed dictation with long salvage text): the transcript fills the viewport, the `retry` / `discard` / `insert` row is below the fold, and the tail cannot be reached — https://files.catbox.moe/qurti7.jpg (also in #3532). The same screenshot on the reporter's macOS app shows the underlying cause the server reports: `Dictation worker request timed out: session.commit`.
- **After:** the composer stops at the measured bound, so the salvage area scrolls internally and the action row stays pinned above the keyboard. I could not capture this on a physical iOS device from here — the height math is pinned by `composerHeightLimit.test.ts` (7 tests) and the composer+dictation suite (380 tests), and a device check is requested below.

## Risks and failure behavior

- **Composer folding to zero on a transient measurement:** `getComposerHeightLimit` keeps the line cap whenever the measured screen budget is non-positive, so a resize race cannot collapse the editor. Pinned by the "no positive screen budget" test.
- **Feedback loop (the limit growing with the host it limits):** the growing host is excluded from its own budget (`getComposerHostHeightLimit` subtracts `hostHeight` from `branchHeight`). Pinned by the "does not feed the applied salvage height back into its limit" test.
- **Scroll position:** the salvage area only auto-follows while the reader is already at the end, so a re-report after rotation no longer yanks someone who scrolled up to copy text (second commit on this branch).
- **Cross-runtime:** desktop inherits the 8-line cap for salvage text; VS Code is unaffected because dictation is disabled there. No persisted data, API, route, or setting changes.
- **Rollback:** revert the two commits; nothing is persisted, so no migration or cleanup is needed.
