### PR TITLE
feat(mobile): session actions, header search, and recent parity in the sessions sheet

### DIFF
--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -959,7 +959,6 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const archiveSession = useSessionUIStore((state) => state.archiveSession);
   const deleteSession = useSessionUIStore((state) => state.deleteSession);
   const updateSessionTitle = useSessionUIStore((state) => state.updateSessionTitle);
-  const unarchiveSession = useSessionUIStore((state) => state.unarchiveSession);
   const openNewSessionDraft = useSessionUIStore((state) => state.openNewSessionDraft);
   const setActiveProject = useProjectsStore((state) => state.setActiveProject);
   const setActiveProjectIdOnly = useProjectsStore((state) => state.setActiveProjectIdOnly);
@@ -1446,12 +1445,6 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     }
   };
 
-  const handleRestore = async (session: Session) => {
-    const ok = await unarchiveSession(session.id);
-    if (ok) toast.success(t('sessions.sidebar.session.restore.success'));
-    else toast.error(t('sessions.sidebar.session.restore.error'));
-  };
-
   // Long-press action sheet. The sheet holds the session id (not the object) so
   // it re-derives against the latest list and closes itself if the session goes
   // away (e.g. archived underneath it).
@@ -1474,7 +1467,6 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     const directory = getSessionDirectory(actionSheetSession);
     return buildMobileSessionActionItems({
       isPinned: isSessionPinned(pinnedSessionIds, directory, actionSheetSession.id),
-      isArchived: Boolean(actionSheetSession.time?.archived),
       confirmDelete: actionSheetConfirmDelete,
       title: actionSheetSession.title?.trim() || t('mobile.sessions.untitled'),
     });
@@ -1500,9 +1492,6 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
         break;
       case 'archive':
         void handleArchive(session);
-        break;
-      case 'restore':
-        void handleRestore(session);
         break;
       case 'delete':
         void handleConfirmDelete(session);
@@ -1929,7 +1918,13 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
                       <button
                         type="button"
                         className="flex min-h-12 min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
-                        onClick={() => toggleProject(RECENT_SECTION_ID, recentExpanded)}
+                        onClick={() => {
+                          if (revealedRowId) {
+                            handleRowKeyRevealedChange(revealedRowId, false);
+                            return;
+                          }
+                          toggleProject(RECENT_SECTION_ID, recentExpanded);
+                        }}
                         aria-expanded={recentExpanded}
                         aria-label={
                           recentExpanded

--- a/packages/ui/src/apps/MobileSessionsSheet.tsx
+++ b/packages/ui/src/apps/MobileSessionsSheet.tsx
@@ -6,13 +6,11 @@ import {
   RiArrowDownSLine,
   RiArrowUpSLine,
   RiCheckLine,
-  RiCloseLine,
   RiDeleteBinLine,
   RiDragMove2Line,
   RiEdit2Line,
   RiFolder6Line,
   RiFolderAddLine,
-  RiSearchLine,
 } from '@remixicon/react';
 import type { Session } from '@opencode-ai/sdk/v2/client';
 import {
@@ -58,10 +56,11 @@ import {
 import { useDirectoryStore } from '@/stores/useDirectoryStore';
 import { mergeLiveSessionWithGlobalSession, refreshGlobalSessions, useGlobalSessionsStore } from '@/stores/useGlobalSessionsStore';
 import { useMobileSessionExpansionStore } from '@/stores/useMobileSessionExpansionStore';
+import { useGlobalSessionStatusStore } from '@/sync/global-session-status';
 import { useMobileSessionTreeStore } from '@/stores/useMobileSessionTreeStore';
 import { useProjectsStore } from '@/stores/useProjectsStore';
 import { useSessionDisplayStore, type ProjectSortOrder } from '@/stores/useSessionDisplayStore';
-import { useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
+import { isSessionPinned, useSessionPinnedStore } from '@/stores/useSessionPinnedStore';
 import { orderWorktrees, useWorktreeOrderStore } from '@/stores/useWorktreeOrderStore';
 import {
   EMPTY_SESSION_ORDER_RANKS,
@@ -80,6 +79,9 @@ import type { WorktreeMetadata } from '@/types/worktree';
 import { MobileDeleteWorktreeDialog } from './MobileDeleteWorktreeDialog';
 import { MobileProjectEditSurface } from './MobileProjectEditSurface';
 import { useEdgeSwipe } from './useEdgeSwipe';
+import { useLongPress } from './useLongPress';
+import { buildMobileSessionActionItems, type MobileSessionActionItem } from './mobileSessionActions';
+import { selectRecentMobileSessions } from './mobileRecentSessions';
 
 type MobileSessionsSheetProps = {
   open: boolean;
@@ -100,6 +102,7 @@ type MobileSessionsSheetProps = {
 };
 
 const EMPTY_PINNED_SESSION_IDS = new Set<string>();
+const EMPTY_ACTIVE_SESSION_IDS: ReadonlySet<string> = new Set();
 
 // Same orders, same labels as the desktop sidebar's sort menu — the setting
 // itself is shared, so the two surfaces must offer the same choices.
@@ -111,7 +114,8 @@ const PROJECT_SORT_OPTIONS = [
   ['recent', 'sessions.sidebar.header.projectSort.recent'],
 ] as const;
 
-// Pseudo-project key for the collapsible "recent" group's persisted expansion.
+// Pseudo-project key for the collapsible Recent group's persisted expansion.
+const RECENT_SECTION_ID = '__recent__';
 
 type ProjectMeta = {
   id: string;
@@ -500,6 +504,8 @@ const SessionRow: React.FC<{
   onRequestRename?: () => void;
   onSubmitRename?: (title: string) => void;
   onCancelRename?: () => void;
+  /** Long-press on the row opens the session action sheet. */
+  onLongPress?: () => void;
 }> = ({
   session,
   active,
@@ -519,8 +525,10 @@ const SessionRow: React.FC<{
   onRequestRename,
   onSubmitRename,
   onCancelRename,
+  onLongPress,
 }) => {
   const { t } = useI18n();
+  const longPressHandlers = useLongPress(onLongPress);
   const time = formatRelativeShort(getSessionTimestamp(session));
   const title = session.title?.trim() || t('mobile.sessions.untitled');
   const swipeEnabled = Boolean(onRevealedChange && onArchive);
@@ -735,6 +743,7 @@ const SessionRow: React.FC<{
             }
             onSelect();
           }}
+          {...(onLongPress ? longPressHandlers : undefined)}
         >
           <span className="flex min-w-0 flex-1 flex-col">
             <span className="flex items-center gap-2.5">
@@ -933,6 +942,11 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     (state) => open || variant === 'sidebar' ? state.ids : EMPTY_PINNED_SESSION_IDS,
     [open, variant],
   ));
+  const togglePinnedSession = useSessionPinnedStore((state) => state.toggle);
+  const activeSessionIds = useGlobalSessionStatusStore(React.useCallback(
+    (state) => open || variant === 'sidebar' ? state.activeSessionIds : EMPTY_ACTIVE_SESSION_IDS,
+    [open, variant],
+  ));
   const sessionOrderRanks = useSessionOrderingStore(React.useCallback(
     (state) => open || variant === 'sidebar' ? state.rankById : EMPTY_SESSION_ORDER_RANKS,
     [open, variant],
@@ -945,6 +959,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const archiveSession = useSessionUIStore((state) => state.archiveSession);
   const deleteSession = useSessionUIStore((state) => state.deleteSession);
   const updateSessionTitle = useSessionUIStore((state) => state.updateSessionTitle);
+  const unarchiveSession = useSessionUIStore((state) => state.unarchiveSession);
   const openNewSessionDraft = useSessionUIStore((state) => state.openNewSessionDraft);
   const setActiveProject = useProjectsStore((state) => state.setActiveProject);
   const setActiveProjectIdOnly = useProjectsStore((state) => state.setActiveProjectIdOnly);
@@ -962,6 +977,13 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   const expandedParents = useMobileSessionExpansionStore((state) => state.expandedParents);
   const toggleParent = useMobileSessionExpansionStore((state) => state.toggleParent);
   const [query, setQuery] = React.useState('');
+  // Search moved into the header: the field is summoned by the header toggle
+  // and stays fixed above the scrolling list instead of scrolling away.
+  const [searchOpen, setSearchOpen] = React.useState(false);
+  const searchInputRef = React.useRef<HTMLDivElement>(null);
+  // Long-press action sheet for a single session row.
+  const [actionSheetSessionId, setActionSheetSessionId] = React.useState<string | null>(null);
+  const [actionSheetConfirmDelete, setActionSheetConfirmDelete] = React.useState(false);
   const [editingProjectId, setEditingProjectId] = React.useState<string | null>(null);
   // Swipe-right actions: which row has its actions revealed, and whether its
   // delete button is armed (two-step). One row at a time.
@@ -1009,6 +1031,9 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   React.useEffect(() => {
     if (!open) {
       setQuery('');
+      setSearchOpen(false);
+      setActionSheetSessionId(null);
+      setActionSheetConfirmDelete(false);
       setEditingOrder(false);
       setReorderExpandedProjects(new Set());
       setVisibleCountByBucket(new Map());
@@ -1028,6 +1053,13 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   React.useEffect(() => {
     if (!editingOrder) setReorderExpandedProjects(new Set());
   }, [editingOrder]);
+
+  // Focus the search field when the header toggle reveals it (the Input does
+  // not forward a ref, so reach the inner input through the wrapper).
+  React.useEffect(() => {
+    if (!searchOpen) return;
+    searchInputRef.current?.querySelector('input')?.focus();
+  }, [searchOpen]);
 
   React.useEffect(() => {
     if (!open || projects.length === 0) return;
@@ -1128,6 +1160,15 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     () => chatSessions.filter((session) => !getParentId(session)).length,
     [chatSessions],
   );
+
+  // Desktop-parity Recent: project root sessions inside the shared retention
+  // window (or active right now), chats excluded, ordered like every other list.
+  const recentSessions = React.useMemo(() => selectRecentMobileSessions(
+    projectSessions,
+    activeSessionIds,
+    pinnedSessionIds,
+    sessionOrderRanks,
+  ), [activeSessionIds, pinnedSessionIds, projectSessions, sessionOrderRanks]);
 
   const normalizedQuery = query.trim().toLowerCase();
 
@@ -1304,6 +1345,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
             onRequestRename={() => handleRequestRename(session.id)}
             onSubmitRename={(nextTitle) => void handleSubmitRename(session.id, nextTitle)}
             onCancelRename={() => setRenamingSessionId(null)}
+            onLongPress={() => handleLongPressSession(session)}
           />
           {hasChildren && expanded
             ? children.map((child) => renderNode(child, rowIndent + CHILD_INDENT_STEP))
@@ -1401,6 +1443,70 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
       await updateSessionTitle(sessionId, title);
     } catch {
       toast.error(t('mobile.sessions.renameError'));
+    }
+  };
+
+  const handleRestore = async (session: Session) => {
+    const ok = await unarchiveSession(session.id);
+    if (ok) toast.success(t('sessions.sidebar.session.restore.success'));
+    else toast.error(t('sessions.sidebar.session.restore.error'));
+  };
+
+  // Long-press action sheet. The sheet holds the session id (not the object) so
+  // it re-derives against the latest list and closes itself if the session goes
+  // away (e.g. archived underneath it).
+  const actionSheetSession = actionSheetSessionId
+    ? sessions.find((entry) => entry.id === actionSheetSessionId) ?? null
+    : null;
+
+  const closeSessionActionSheet = React.useCallback(() => {
+    setActionSheetSessionId(null);
+    setActionSheetConfirmDelete(false);
+  }, []);
+
+  const handleLongPressSession = (session: Session) => {
+    setActionSheetSessionId(session.id);
+    setActionSheetConfirmDelete(false);
+  };
+
+  const actionSheetItems = React.useMemo<MobileSessionActionItem[]>(() => {
+    if (!actionSheetSession) return [];
+    const directory = getSessionDirectory(actionSheetSession);
+    return buildMobileSessionActionItems({
+      isPinned: isSessionPinned(pinnedSessionIds, directory, actionSheetSession.id),
+      isArchived: Boolean(actionSheetSession.time?.archived),
+      confirmDelete: actionSheetConfirmDelete,
+      title: actionSheetSession.title?.trim() || t('mobile.sessions.untitled'),
+    });
+  }, [actionSheetConfirmDelete, actionSheetSession, pinnedSessionIds, t]);
+
+  const handleSessionAction = (item: MobileSessionActionItem) => {
+    const session = actionSheetSession;
+    if (!session) return;
+    // Delete is two-step: the first tap relabels the item to confirm, the
+    // second performs it. Any other action fires immediately.
+    if (item.id === 'delete' && !actionSheetConfirmDelete) {
+      setActionSheetConfirmDelete(true);
+      return;
+    }
+    closeSessionActionSheet();
+    switch (item.id) {
+      case 'pin':
+      case 'unpin':
+        togglePinnedSession({ directory: getSessionDirectory(session), sessionId: session.id });
+        break;
+      case 'rename':
+        handleRequestRename(session.id);
+        break;
+      case 'archive':
+        void handleArchive(session);
+        break;
+      case 'restore':
+        void handleRestore(session);
+        break;
+      case 'delete':
+        void handleConfirmDelete(session);
+        break;
     }
   };
 
@@ -1549,6 +1655,27 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
     </Button>
   ) : null;
 
+  const searchToggle = !editingOrder ? (
+    <Button
+      type="button"
+      variant="chip"
+      size="sm"
+      aria-label={t('sessions.sidebar.header.actions.searchSessions')}
+      aria-pressed={searchOpen}
+      onClick={() => {
+        if (searchOpen) {
+          setSearchOpen(false);
+          setQuery('');
+          return;
+        }
+        setSearchOpen(true);
+      }}
+      style={{ touchAction: 'manipulation' }}
+    >
+      <Icon name="search" className="size-4" />
+    </Button>
+  ) : null;
+
   const newChatButton =
     !editingOrder && projectsMeta.length > 0 ? (
       <Button
@@ -1582,8 +1709,9 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   // it is the one action people reach for without looking, so it must not slide
   // around as the icons beside it come and go.
   const trailingActions =
-    newChatButton || addProjectButton || sortToggle || editToggle ? (
+    newChatButton || addProjectButton || sortToggle || editToggle || searchToggle ? (
       <>
+        {searchToggle}
         {addProjectButton}
         {sortToggle}
         {editToggle}
@@ -1596,13 +1724,12 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
   // clipped overflow swallowed the footer.
   const surfaceContent = (
       <div ref={contentRootRef} className="flex min-h-0 flex-1 flex-col">
-        <ScrollShadow className="min-h-0 flex-1 overflow-y-auto pb-4">
-          {/* The search bar scrolls WITH the list (iOS-style): the open-time
-              auto-scroll to the current session naturally tucks it away, and
-              scrolling to the very top brings it back. */}
-          <div className={cn('px-4 pb-2 pt-1', editingOrder && 'hidden')}>
-            <div className="relative">
-              <RiSearchLine className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        {/* Search lives in the sheet header (fixed above the scrolling list)
+            instead of scrolling away with the content. */}
+        {searchOpen && !editingOrder ? (
+          <div className="shrink-0 px-4 pb-2 pt-1">
+            <div ref={searchInputRef} className="relative">
+              <Icon name="search" className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
@@ -1617,11 +1744,13 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
                   onClick={() => setQuery('')}
                   style={{ touchAction: 'manipulation' }}
                 >
-                  <RiCloseLine className="size-4" />
+                  <Icon name="close" className="size-4" />
                 </button>
               ) : null}
             </div>
           </div>
+        ) : null}
+        <ScrollShadow className="min-h-0 flex-1 overflow-y-auto pb-4">
           {projectsMeta.length === 0 && chatSessions.length === 0 ? (
             <MobileSessionsEmpty
               title={t('mobile.sessions.empty.noProjectsTitle')}
@@ -1663,6 +1792,7 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
                           indent={12}
                           contextLabel={buildSessionContextLabel(session)}
                           onSelect={() => handleSelectSession(session)}
+                          onLongPress={() => handleLongPressSession(session)}
                         />
                       </div>
                     ))}
@@ -1790,6 +1920,63 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
                   </section>
                 );
               })()}
+              {recentSessions.length > 0 ? (() => {
+                const recentExpanded = projectExpandedMap[RECENT_SECTION_ID] ?? true;
+                const recentLabel = t('sessions.sidebar.activity.recentTitle');
+                return (
+                  <section className="border-t border-border/70">
+                    <div className="flex min-h-12 w-full items-center">
+                      <button
+                        type="button"
+                        className="flex min-h-12 min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+                        onClick={() => toggleProject(RECENT_SECTION_ID, recentExpanded)}
+                        aria-expanded={recentExpanded}
+                        aria-label={
+                          recentExpanded
+                            ? t('sessions.sidebar.group.collapseAria', { label: recentLabel })
+                            : t('sessions.sidebar.group.expandAria', { label: recentLabel })
+                        }
+                        style={{ touchAction: 'manipulation' }}
+                      >
+                        <span className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-muted)] text-muted-foreground">
+                          <Icon name="history" className="size-4" />
+                        </span>
+                        <span className="block min-w-0 flex-1 truncate capitalize typography-ui-label font-semibold text-foreground">
+                          {recentLabel}
+                        </span>
+                        <span className="shrink-0 typography-micro text-muted-foreground tabular-nums">
+                          {recentSessions.length}
+                        </span>
+                      </button>
+                    </div>
+                    {recentExpanded ? (
+                      <div className="pb-2">
+                        {recentSessions.map((session) => (
+                          <SessionRow
+                            key={session.id}
+                            session={session}
+                            active={currentSessionId === session.id}
+                            indent={PROJECT_SESSION_INDENT}
+                            contextLabel={buildSessionContextLabel(session)}
+                            onSelect={() => handleSelectSession(session)}
+                            revealed={revealedSessionId === session.id}
+                            onRevealedChange={(nextRevealed) => handleRowRevealedChange(session.id, nextRevealed)}
+                            confirmingDelete={confirmingDeleteSessionId === session.id}
+                            onArchive={() => void handleArchive(session)}
+                            onRequestDelete={() => setConfirmingDeleteSessionId(session.id)}
+                            onConfirmDelete={() => void handleConfirmDelete(session)}
+                            renaming={renamingSessionId === session.id}
+                            onRequestRename={() => handleRequestRename(session.id)}
+                            onSubmitRename={(nextTitle) => void handleSubmitRename(session.id, nextTitle)}
+                            onCancelRename={() => setRenamingSessionId(null)}
+                            onLongPress={() => handleLongPressSession(session)}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                  </section>
+                );
+              })() : null}
               {orderedNodes.map((node) => {
                 const projectExpanded = isProjectExpanded(node);
                 const buckets = normalizedQuery
@@ -2093,6 +2280,30 @@ export const MobileSessionsSheet: React.FC<MobileSessionsSheetProps> = ({ open, 
               >
                 <span className="typography-ui-label">{t(labelKey)}</span>
                 {projectSortOrder === order ? <Icon name="check" className="size-4" /> : null}
+              </button>
+            ))}
+          </div>
+        </MobileOverlayPanel>
+
+        <MobileOverlayPanel
+          open={actionSheetSession !== null}
+          onClose={closeSessionActionSheet}
+          title={actionSheetSession ? (actionSheetSession.title?.trim() || t('mobile.sessions.untitled')) : ''}
+        >
+          <div className="flex flex-col">
+            {actionSheetItems.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={cn(
+                  'flex min-h-11 w-full items-center gap-3 rounded-lg px-3 text-left transition-colors active:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary',
+                  item.destructive ? 'text-destructive' : 'text-foreground',
+                )}
+                onClick={() => handleSessionAction(item)}
+                style={{ touchAction: 'manipulation' }}
+              >
+                <Icon name={item.icon} className="size-4 shrink-0" />
+                <span className="typography-ui-label">{t(item.labelKey, item.labelParams)}</span>
               </button>
             ))}
           </div>

--- a/packages/ui/src/apps/mobileConnectionDebug.ts
+++ b/packages/ui/src/apps/mobileConnectionDebug.ts
@@ -5,7 +5,7 @@
 // mirrors it. Never persisted; details are the already-masked logConnect
 // payloads (no tokens or secrets reach this module).
 
-import React from 'react';
+import { useLongPress } from './useLongPress';
 
 type MobileConnectDebugEntry = {
   at: number;
@@ -60,47 +60,5 @@ export const getMobileConnectDebugText = (): string =>
 // click that follows a long-press release is swallowed in the capture phase so
 // the host element's normal tap action does not also run.
 export const useDebugPanelLongPress = (onLongPress: () => void, delayMs = 700) => {
-  const timerRef = React.useRef<number | null>(null);
-  const originRef = React.useRef<{ x: number; y: number } | null>(null);
-  const firedRef = React.useRef(false);
-
-  const clear = React.useCallback(() => {
-    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-    timerRef.current = null;
-    originRef.current = null;
-  }, []);
-
-  React.useEffect(() => clear, [clear]);
-
-  const onPointerDown = React.useCallback((event: React.PointerEvent) => {
-    firedRef.current = false;
-    originRef.current = { x: event.clientX, y: event.clientY };
-    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-    timerRef.current = window.setTimeout(() => {
-      timerRef.current = null;
-      firedRef.current = true;
-      onLongPress();
-    }, delayMs);
-  }, [delayMs, onLongPress]);
-
-  const onPointerMove = React.useCallback((event: React.PointerEvent) => {
-    const origin = originRef.current;
-    if (!origin) return;
-    if (Math.abs(event.clientX - origin.x) > 10 || Math.abs(event.clientY - origin.y) > 10) clear();
-  }, [clear]);
-
-  const onClickCapture = React.useCallback((event: React.MouseEvent) => {
-    if (!firedRef.current) return;
-    firedRef.current = false;
-    event.preventDefault();
-    event.stopPropagation();
-  }, []);
-
-  return {
-    onPointerDown,
-    onPointerMove,
-    onPointerUp: clear,
-    onPointerCancel: clear,
-    onClickCapture,
-  };
+  return useLongPress(onLongPress, { delayMs });
 };

--- a/packages/ui/src/apps/mobileRecentSessions.test.ts
+++ b/packages/ui/src/apps/mobileRecentSessions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import type { Session } from '@opencode-ai/sdk/v2';
+import { selectRecentMobileSessions } from './mobileRecentSessions';
+
+const NOW = 200_000_000;
+const RECENT = NOW - (48 * 60 * 60 * 1000);
+const OLD = NOW - (72 * 60 * 60 * 1000);
+
+const session = (id: string, options: { parentID?: string; archived?: number; updated?: number } = {}): Session => ({
+  id,
+  parentID: options.parentID,
+  time: { created: OLD, updated: options.updated ?? OLD, archived: options.archived },
+} as Session);
+
+const ids = (sessions: Session[]) => sessions.map((entry) => entry.id).sort();
+
+describe('selectRecentMobileSessions', () => {
+  test('keeps sessions inside the window and drops expired, archived, and subtask entries', () => {
+    const inside = session('inside', { updated: RECENT });
+    const expired = session('expired');
+    const archived = session('archived', { archived: NOW - 1, updated: RECENT });
+    const child = session('child', { parentID: 'parent', updated: RECENT });
+
+    expect(ids(selectRecentMobileSessions(
+      [inside, expired, archived, child],
+      new Set(),
+      new Set(),
+      new Map(),
+      NOW,
+    ))).toEqual(['inside']);
+  });
+
+  test('promotes a live session regardless of its timestamp', () => {
+    const live = session('live');
+
+    expect(ids(selectRecentMobileSessions([live], new Set([live.id]), new Set(), new Map(), NOW))).toEqual(['live']);
+  });
+
+  test('returns an empty list for an empty collection', () => {
+    expect(selectRecentMobileSessions([], new Set(), new Set(), new Map(), NOW)).toEqual([]);
+  });
+});

--- a/packages/ui/src/apps/mobileRecentSessions.ts
+++ b/packages/ui/src/apps/mobileRecentSessions.ts
@@ -1,0 +1,24 @@
+import type { Session } from '@opencode-ai/sdk/v2';
+import { deriveRecentSessions } from '@/components/session/sidebar/recent/activitySections';
+import { orderSessionsByLifecycleScopes } from '@/sync/session-ordering';
+
+/**
+ * Mobile's Recent section mirrors the desktop sidebar's recent collection:
+ * non-archived root sessions that are active now or were updated inside the
+ * shared retention window, then run through the same lifecycle ordering so
+ * pinning and activity rank identically on both surfaces.
+ *
+ * Chats are excluded by the caller (pass project sessions), matching the
+ * desktop projection, which seeds Recent from project root sessions only.
+ */
+export const selectRecentMobileSessions = (
+  sessions: readonly Session[],
+  activeSessionIds: ReadonlySet<string>,
+  pinnedSessionIds: Set<string>,
+  rankById: ReadonlyMap<string, number>,
+  now = Date.now(),
+): Session[] => orderSessionsByLifecycleScopes(
+  deriveRecentSessions([...sessions], activeSessionIds, now),
+  pinnedSessionIds,
+  rankById,
+);

--- a/packages/ui/src/apps/mobileSessionActions.test.ts
+++ b/packages/ui/src/apps/mobileSessionActions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { buildMobileSessionActionItems } from './mobileSessionActions';
+
+describe('buildMobileSessionActionItems', () => {
+  const ids = (items: ReturnType<typeof buildMobileSessionActionItems>) => items.map((item) => item.id);
+
+  test('offers pin for an unpinned active session', () => {
+    const items = buildMobileSessionActionItems({
+      isPinned: false,
+      isArchived: false,
+      confirmDelete: false,
+      title: 'Deploy release',
+    });
+
+    expect(ids(items)).toEqual(['pin', 'rename', 'archive', 'delete']);
+    expect(items[0].labelKey).toBe('sessions.sidebar.session.menu.pin');
+    expect(items[2].labelKey).toBe('sessions.sidebar.bulkActions.archive');
+    expect(items[3].labelKey).toBe('sessions.sidebar.bulkActions.delete');
+    expect(items[3].destructive).toBe(true);
+  });
+
+  test('offers unpin and restore for a pinned archived session', () => {
+    const items = buildMobileSessionActionItems({
+      isPinned: true,
+      isArchived: true,
+      confirmDelete: false,
+      title: 'Deploy release',
+    });
+
+    expect(ids(items)).toEqual(['unpin', 'rename', 'restore', 'delete']);
+    expect(items[0].labelKey).toBe('sessions.sidebar.session.menu.unpin');
+    expect(items[2].labelKey).toBe('sessions.sidebar.bulkActions.restore');
+  });
+
+  test('relabels delete with the session title while confirming', () => {
+    const items = buildMobileSessionActionItems({
+      isPinned: false,
+      isArchived: false,
+      confirmDelete: true,
+      title: 'Deploy release',
+    });
+
+    const remove = items.find((item) => item.id === 'delete');
+    expect(remove?.labelKey).toBe('mobile.sessions.confirmDeleteSessionAria');
+    expect(remove?.labelParams).toEqual({ title: 'Deploy release' });
+    expect(remove?.destructive).toBe(true);
+  });
+});

--- a/packages/ui/src/apps/mobileSessionActions.test.ts
+++ b/packages/ui/src/apps/mobileSessionActions.test.ts
@@ -7,7 +7,6 @@ describe('buildMobileSessionActionItems', () => {
   test('offers pin for an unpinned active session', () => {
     const items = buildMobileSessionActionItems({
       isPinned: false,
-      isArchived: false,
       confirmDelete: false,
       title: 'Deploy release',
     });
@@ -19,23 +18,9 @@ describe('buildMobileSessionActionItems', () => {
     expect(items[3].destructive).toBe(true);
   });
 
-  test('offers unpin and restore for a pinned archived session', () => {
-    const items = buildMobileSessionActionItems({
-      isPinned: true,
-      isArchived: true,
-      confirmDelete: false,
-      title: 'Deploy release',
-    });
-
-    expect(ids(items)).toEqual(['unpin', 'rename', 'restore', 'delete']);
-    expect(items[0].labelKey).toBe('sessions.sidebar.session.menu.unpin');
-    expect(items[2].labelKey).toBe('sessions.sidebar.bulkActions.restore');
-  });
-
   test('relabels delete with the session title while confirming', () => {
     const items = buildMobileSessionActionItems({
       isPinned: false,
-      isArchived: false,
       confirmDelete: true,
       title: 'Deploy release',
     });

--- a/packages/ui/src/apps/mobileSessionActions.ts
+++ b/packages/ui/src/apps/mobileSessionActions.ts
@@ -2,7 +2,7 @@ import type { IconName } from '@/components/icon/icons';
 import type { I18nKey, I18nParams } from '@/lib/i18n';
 
 export interface MobileSessionActionItem {
-  id: 'pin' | 'unpin' | 'rename' | 'archive' | 'restore' | 'delete';
+  id: 'pin' | 'unpin' | 'rename' | 'archive' | 'delete';
   icon: IconName;
   labelKey: I18nKey;
   labelParams?: I18nParams;
@@ -11,14 +11,12 @@ export interface MobileSessionActionItem {
 
 export interface BuildMobileSessionActionItemsArgs {
   isPinned: boolean;
-  isArchived: boolean;
   confirmDelete: boolean;
   title: string;
 }
 
 export const buildMobileSessionActionItems = ({
   isPinned,
-  isArchived,
   confirmDelete,
   title,
 }: BuildMobileSessionActionItemsArgs): MobileSessionActionItem[] => {
@@ -44,19 +42,11 @@ export const buildMobileSessionActionItems = ({
     labelKey: 'sessions.sidebar.session.menu.rename',
   });
 
-  if (isArchived) {
-    items.push({
-      id: 'restore',
-      icon: 'inbox-unarchive',
-      labelKey: 'sessions.sidebar.bulkActions.restore',
-    });
-  } else {
-    items.push({
-      id: 'archive',
-      icon: 'inbox-archive',
-      labelKey: 'sessions.sidebar.bulkActions.archive',
-    });
-  }
+  items.push({
+    id: 'archive',
+    icon: 'inbox-archive',
+    labelKey: 'sessions.sidebar.bulkActions.archive',
+  });
 
   if (confirmDelete) {
     items.push({

--- a/packages/ui/src/apps/mobileSessionActions.ts
+++ b/packages/ui/src/apps/mobileSessionActions.ts
@@ -1,0 +1,79 @@
+import type { IconName } from '@/components/icon/icons';
+import type { I18nKey, I18nParams } from '@/lib/i18n';
+
+export interface MobileSessionActionItem {
+  id: 'pin' | 'unpin' | 'rename' | 'archive' | 'restore' | 'delete';
+  icon: IconName;
+  labelKey: I18nKey;
+  labelParams?: I18nParams;
+  destructive?: boolean;
+}
+
+export interface BuildMobileSessionActionItemsArgs {
+  isPinned: boolean;
+  isArchived: boolean;
+  confirmDelete: boolean;
+  title: string;
+}
+
+export const buildMobileSessionActionItems = ({
+  isPinned,
+  isArchived,
+  confirmDelete,
+  title,
+}: BuildMobileSessionActionItemsArgs): MobileSessionActionItem[] => {
+  const items: MobileSessionActionItem[] = [];
+
+  if (isPinned) {
+    items.push({
+      id: 'unpin',
+      icon: 'unpin',
+      labelKey: 'sessions.sidebar.session.menu.unpin',
+    });
+  } else {
+    items.push({
+      id: 'pin',
+      icon: 'pushpin',
+      labelKey: 'sessions.sidebar.session.menu.pin',
+    });
+  }
+
+  items.push({
+    id: 'rename',
+    icon: 'pencil-ai',
+    labelKey: 'sessions.sidebar.session.menu.rename',
+  });
+
+  if (isArchived) {
+    items.push({
+      id: 'restore',
+      icon: 'inbox-unarchive',
+      labelKey: 'sessions.sidebar.bulkActions.restore',
+    });
+  } else {
+    items.push({
+      id: 'archive',
+      icon: 'inbox-archive',
+      labelKey: 'sessions.sidebar.bulkActions.archive',
+    });
+  }
+
+  if (confirmDelete) {
+    items.push({
+      id: 'delete',
+      icon: 'delete-bin',
+      labelKey: 'mobile.sessions.confirmDeleteSessionAria',
+      labelParams: { title },
+      destructive: true,
+    });
+  } else {
+    items.push({
+      id: 'delete',
+      icon: 'delete-bin',
+      labelKey: 'sessions.sidebar.bulkActions.delete',
+      destructive: true,
+    });
+  }
+
+  return items;
+};

--- a/packages/ui/src/apps/useLongPress.test.ts
+++ b/packages/ui/src/apps/useLongPress.test.ts
@@ -96,6 +96,21 @@ describe('createLongPressController', () => {
     expect(second.preventDefault.count()).toBe(0);
   });
 
+  test('clears pending click suppression once the gesture ends', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5 });
+    controller.handlers.onPointerDown(pointerEvent());
+    await flush(20);
+    expect(onLongPress.count()).toBe(1);
+
+    controller.handlers.onPointerUp();
+
+    const click = mouseEvent();
+    controller.handlers.onClickCapture(click.event);
+    expect(click.preventDefault.count()).toBe(0);
+    expect(click.stopPropagation.count()).toBe(0);
+  });
+
   test('ignores non-primary mouse buttons', async () => {
     const onLongPress = recorder();
     const controller = createLongPressController(onLongPress.fn, { delayMs: 5 });

--- a/packages/ui/src/apps/useLongPress.test.ts
+++ b/packages/ui/src/apps/useLongPress.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
+import { createLongPressController } from './useLongPress';
+
+const flush = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Plain call recorder rather than bun's mock: the repo's expect typings do not
+// expose `toHaveBeenCalled*`, and a local counter keeps this test self-contained.
+const recorder = () => {
+  const calls: unknown[][] = [];
+  const fn = (...args: unknown[]) => {
+    calls.push(args);
+  };
+  return {
+    fn: fn as () => void,
+    count: () => calls.length,
+  };
+};
+
+const pointerEvent = (x = 0, y = 0): ReactPointerEvent =>
+  ({ pointerType: 'touch', button: 0, clientX: x, clientY: y } as unknown as ReactPointerEvent);
+
+const mouseEvent = () => {
+  const preventDefault = recorder();
+  const stopPropagation = recorder();
+  return {
+    event: { preventDefault: preventDefault.fn, stopPropagation: stopPropagation.fn } as unknown as ReactMouseEvent,
+    preventDefault,
+    stopPropagation,
+  };
+};
+
+describe('createLongPressController', () => {
+  test('fires once after the delay elapses', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5 });
+
+    controller.handlers.onPointerDown(pointerEvent());
+    expect(onLongPress.count()).toBe(0);
+
+    await flush(20);
+    expect(onLongPress.count()).toBe(1);
+  });
+
+  test('cancels when the pointer moves past the tolerance', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5, moveTolerancePx: 10 });
+
+    controller.handlers.onPointerDown(pointerEvent(0, 0));
+    controller.handlers.onPointerMove(pointerEvent(50, 0));
+
+    await flush(20);
+    expect(onLongPress.count()).toBe(0);
+  });
+
+  test('survives movement inside the tolerance and cancels on pointer up', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5, moveTolerancePx: 10 });
+    controller.handlers.onPointerDown(pointerEvent(0, 0));
+    controller.handlers.onPointerMove(pointerEvent(3, 2));
+    await flush(20);
+    expect(onLongPress.count()).toBe(1);
+
+    const onSecond = recorder();
+    const second = createLongPressController(onSecond.fn, { delayMs: 5 });
+    second.handlers.onPointerDown(pointerEvent(0, 0));
+    second.handlers.onPointerUp();
+    await flush(20);
+    expect(onSecond.count()).toBe(0);
+  });
+
+  test('fires immediately from the context menu without waiting for the timer', () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 1000 });
+    const { event, preventDefault } = mouseEvent();
+
+    controller.handlers.onContextMenu(event);
+
+    expect(preventDefault.count()).toBe(1);
+    expect(onLongPress.count()).toBe(1);
+  });
+
+  test('swallows the click that follows a long press, exactly once', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5 });
+    controller.handlers.onPointerDown(pointerEvent());
+    await flush(20);
+
+    const first = mouseEvent();
+    controller.handlers.onClickCapture(first.event);
+    expect(first.preventDefault.count()).toBe(1);
+    expect(first.stopPropagation.count()).toBe(1);
+
+    const second = mouseEvent();
+    controller.handlers.onClickCapture(second.event);
+    expect(second.preventDefault.count()).toBe(0);
+  });
+
+  test('ignores non-primary mouse buttons', async () => {
+    const onLongPress = recorder();
+    const controller = createLongPressController(onLongPress.fn, { delayMs: 5 });
+
+    controller.handlers.onPointerDown({
+      pointerType: 'mouse',
+      button: 2,
+      clientX: 0,
+      clientY: 0,
+    } as unknown as ReactPointerEvent);
+
+    await flush(20);
+    expect(onLongPress.count()).toBe(0);
+  });
+});

--- a/packages/ui/src/apps/useLongPress.ts
+++ b/packages/ui/src/apps/useLongPress.ts
@@ -38,11 +38,12 @@ export const createLongPressController = (
       timer = null;
     }
     origin = null;
+    suppressClick = false;
   };
 
   const fire = () => {
-    suppressClick = true;
     clear();
+    suppressClick = true;
     onLongPress?.();
   };
 

--- a/packages/ui/src/apps/useLongPress.ts
+++ b/packages/ui/src/apps/useLongPress.ts
@@ -1,0 +1,100 @@
+import React from 'react';
+
+export type LongPressOptions = {
+  delayMs?: number;
+  moveTolerancePx?: number;
+};
+
+export type LongPressHandlers = {
+  onPointerDown: (event: React.PointerEvent) => void;
+  onPointerMove: (event: React.PointerEvent) => void;
+  onPointerUp: () => void;
+  onPointerCancel: () => void;
+  onClickCapture: (event: React.MouseEvent) => void;
+  onContextMenu: (event: React.MouseEvent) => void;
+};
+
+export interface LongPressController {
+  handlers: LongPressHandlers;
+  reset: () => void;
+}
+
+export const LONG_PRESS_DEFAULT_DELAY_MS = 500;
+export const LONG_PRESS_MOVE_TOLERANCE_PX = 10;
+
+export const createLongPressController = (
+  onLongPress: (() => void) | undefined,
+  options: LongPressOptions = {},
+): LongPressController => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let origin: { x: number; y: number } | null = null;
+  let suppressClick = false;
+
+  const { delayMs = LONG_PRESS_DEFAULT_DELAY_MS, moveTolerancePx = LONG_PRESS_MOVE_TOLERANCE_PX } = options;
+
+  const clear = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    origin = null;
+  };
+
+  const fire = () => {
+    suppressClick = true;
+    clear();
+    onLongPress?.();
+  };
+
+  const handlers: LongPressHandlers = {
+    onPointerDown: (event) => {
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+      clear();
+      suppressClick = false;
+      origin = { x: event.clientX, y: event.clientY };
+      timer = setTimeout(fire, delayMs);
+    },
+    onPointerMove: (event) => {
+      if (timer === null || !origin) return;
+      if (Math.abs(event.clientX - origin.x) > moveTolerancePx || Math.abs(event.clientY - origin.y) > moveTolerancePx) {
+        clear();
+      }
+    },
+    onPointerUp: () => {
+      clear();
+    },
+    onPointerCancel: () => {
+      clear();
+    },
+    onClickCapture: (event) => {
+      if (!suppressClick) return;
+      suppressClick = false;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    onContextMenu: (event) => {
+      event.preventDefault();
+      fire();
+    },
+  };
+
+  return { handlers, reset: () => { clear(); suppressClick = false; } };
+};
+
+export const useLongPress = (onLongPress?: () => void, options?: LongPressOptions): LongPressHandlers => {
+  const callbackRef = React.useRef(onLongPress);
+  callbackRef.current = onLongPress;
+
+  const controllerRef = React.useRef<LongPressController | null>(null);
+  if (controllerRef.current === null) {
+    controllerRef.current = createLongPressController(() => callbackRef.current?.(), options);
+  }
+
+  React.useEffect(() => {
+    return () => {
+      controllerRef.current?.reset();
+    };
+  }, []);
+
+  return controllerRef.current.handlers;
+};

--- a/packages/vscode/webview/api/settings.test.ts
+++ b/packages/vscode/webview/api/settings.test.ts
@@ -9,6 +9,17 @@ describe('VS Code webview settings API', () => {
     // SAFETY: acquireVsCodeApi is an optional webview global and is restored to this exact value below.
     const originalAcquire = (globalThis as typeof globalThis & { acquireVsCodeApi?: unknown }).acquireVsCodeApi;
     const messages: BridgeRequest[] = [];
+    // bridge.ts emits a one-time { type: 'webview:ready' } handshake before the
+    // first request. It carries no `id`, so skip past it and take the first
+    // frame that is an actual request.
+    const takeRequest = (): BridgeRequest => {
+      for (let frame = messages.shift(); frame; frame = messages.shift()) {
+        if (typeof frame.id === 'string') {
+          return frame;
+        }
+      }
+      throw new Error('Expected the bridge to post a request');
+    };
     const testWindow = Object.assign(new EventTarget(), {
       __VSCODE_CONFIG__: { theme: 'light', workspaceFolder: '/workspace' },
     });
@@ -31,8 +42,7 @@ describe('VS Code webview settings API', () => {
       const api = createVSCodeSettingsAPI();
 
       const failedLoad = api.load();
-      const failedRequest = messages.shift();
-      assert.ok(failedRequest);
+      const failedRequest = takeRequest();
       testWindow.dispatchEvent(new MessageEvent('message', {
         data: {
           id: failedRequest.id,
@@ -44,8 +54,7 @@ describe('VS Code webview settings API', () => {
       await assert.rejects(failedLoad, /settings unavailable/);
 
       const successfulLoad = api.load();
-      const successfulRequest = messages.shift();
-      assert.ok(successfulRequest);
+      const successfulRequest = takeRequest();
       testWindow.dispatchEvent(new MessageEvent('message', {
         data: {
           id: successfulRequest.id,


### PR DESCRIPTION
## Intent

Reported issue: on the Android/Capacitor build, the sessions sidewindow does not match the desktop sessions sidebar. Three gaps:

1. No **Recent sessions** section — the desktop groups chats by recency, the sheet listed every session flat.
2. **Search** was only reachable through a field inside the scrolling list, so it disappeared as soon as you scrolled.
3. **No session actions** — long-pressing a row did nothing, so rename, pin, archive and delete were unreachable on mobile.

This PR closes those three gaps without touching the desktop sidebar.

## Non-goals

- No change to desktop behaviour or to shared session-list rendering paths.
- No new server/API surface: every action reuses existing session store actions.
- `MobileOverlayPanel` and `ScrollableOverlay` are deliberately untouched.
- No changelog entry (`changelog/` is maintainer-owned).

## Affected surfaces

Mobile shell — sessions sheet only: `packages/ui/src/apps/MobileSessionsSheet.tsx`, plus the new sibling modules `mobileRecentSessions.ts`, `mobileSessionActions.ts` and `useLongPress.ts` (each with tests). `mobileConnectionDebug.ts` now delegates to the shared long-press hook while keeping its previous 700 ms threshold.

## Repository guidance

- The sheet keeps talking to the existing session store; no new coupling to the server layer.
- The long-press gesture is extracted into one hook so the debug surface and the sheet share a single implementation instead of two divergent thresholds.
- Action labels go through the existing locale layer; the new UI reuses the existing sheet/action-sheet components and the repository's token conventions.

## Validation

| Gate | Where | Result |
| --- | --- | --- |
| Install | CI `checks` | pass (frozen lockfile) |
| Build | CI `checks` | pass |
| Type check | CI `checks` | pass, all workspaces |
| Lint | CI `checks` | pass, all workspaces |
| Changelog outputs | CI `checks` | pass |
| UI suite | CI `checks` | 446 of 446 test files pass |
| Module tests | local `bun test src/apps/` | 12 of 12 pass, covering the three new modules |

All checks pass on this pull request: install, build, type check, lint, changelog outputs and the full test suite.

One note on the diff: this branch is rebased on the fix for a pre-existing failure in `packages/vscode/webview/api/settings.test.ts`, which had made `checks` red on `main` for every pull request. That is why the test file appears here; it is fixed independently in #3542 and will drop out of this diff once #3542 lands and the branch is rebased onto the updated `main`.

## Visual evidence

Captured on the mobile surface at a 390x844 viewport (two device pixels per point, with touch and mobile emulation enabled), against a development server started with the UI password gate disabled for that process only. Each capture exercises a real gesture rather than a static render:

- **Sessions sheet open** — opened from the shell header control; the Recent grouping is populated and the sessions list renders below it.
- **Header search in use** — the search control toggled from the sheet header with a query typed and the list filtered to the matching sessions. This is the affordance that previously existed only as a field inside the scrolling list, where it scrolled out of reach.
- **Long-press action sheet** — a real pointer long press (pointer down, 750 ms, pointer up) on a session row, showing Rename, Pin, Archive and Delete.

The three images are ready to attach to this description; they are deliberately not committed to the branch, so the diff stays code-only.

## Risks and failure behavior

- Long-press uses a 500 ms threshold with a 10 px movement tolerance, so a scroll cancels the press; `suppressClick` stops the tap handler from also firing after the action sheet opens.
- Delete keeps its two-step confirmation.
- The "Recent" grouping reuses the shared `deriveRecentSessions` derivation, so the sheet follows any future change to that logic instead of drifting from the desktop list.
