### PR TITLE
fix(ui): keep alt+arrow inside diff review at file boundaries

### DIFF
--- a/packages/ui/src/components/views/DiffView.tsx
+++ b/packages/ui/src/components/views/DiffView.tsx
@@ -1768,6 +1768,7 @@ export const DiffView: React.FC<DiffViewProps> = ({
             )) {
                 return;
             }
+            event.preventDefault();
             if (changedFiles.length === 0) return;
             const delta = event.key === 'ArrowDown' ? 1 : -1;
             const index = displayFile ? changedFiles.findIndex((file) => file.path === displayFile) : -1;
@@ -1776,7 +1777,6 @@ export const DiffView: React.FC<DiffViewProps> = ({
                 : index + delta;
             const next = changedFiles[nextIndex];
             if (!next) return;
-            event.preventDefault();
             handleSelectFileAndScroll(next.path);
         };
         window.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
Diff review returned before preventDefault when there was no adjacent file, so Alt+Up/Down fell through to the window menu's Previous/Next Session accelerators on Windows/Linux.

## Intent
In a visible diff review, Alt+Up/Down leaked to the window menu's Previous/Next Session accelerators when there was no adjacent file (first/last file, or none), switching sessions unexpectedly. Consume the chord as soon as the diff owns it.

## Non-goals
Go menu accelerators (Alt+Up/Down for sessions, Ctrl+Alt+Up/Down for projects) are unchanged; outside a visible diff they still act.

## Affected surfaces
packages/ui DiffView only, all runtimes. User-visible: Alt+Up/Down in a visible diff is always consumed now.

## Repository guidance
| Guidance | Why | How |
|---|---|---|
| openchamber-change-discipline | source change | one relocated line, no new abstraction |
| shortcuts/DOCUMENTATION.md (local keys) | diff stepping is a local interaction | kept as the existing local listener |

## Validation
| Check | Result |
|---|---|
| `bun run --cwd packages/ui type-check` | pass |
| `bunx eslint src/components/views/DiffView.tsx --config ../../eslint.config.js` | pass |
| `bun test packages/ui/src/components/views/DiffView.test.ts` | 3 pass / 0 fail |
| Manual: Windows desktop, first/last file, Alt+Up/Down | no session switch (recording below) |

## Visual evidence

Before (leak): stepping to the first/last file switches the session.
https://github.com/user-attachments/assets/5b2e13ca-ea96-4bd6-b224-719bcded0fd1

After (fixed): the same presses stay in the diff and the session does not change.
https://github.com/user-attachments/assets/04e6dfb7-3f76-4ed1-89d7-2dc7d7d830ed

## Risks and failure behavior
Scoped to the diff surface: while visible, Alt+Up/Down is consumed even with no adjacent file, so it no longer reaches the Go menu. Rollback = revert the one line.
