### PR TITLE
test(vscode): stop indexing the webview message queue by position

### DIFF
--- a/packages/vscode/webview/api/settings.test.ts
+++ b/packages/vscode/webview/api/settings.test.ts
@@ -9,6 +9,17 @@ describe('VS Code webview settings API', () => {
     // SAFETY: acquireVsCodeApi is an optional webview global and is restored to this exact value below.
     const originalAcquire = (globalThis as typeof globalThis & { acquireVsCodeApi?: unknown }).acquireVsCodeApi;
     const messages: BridgeRequest[] = [];
+    // bridge.ts emits a one-time { type: 'webview:ready' } handshake before the
+    // first request. It carries no `id`, so skip past it and take the first
+    // frame that is an actual request.
+    const takeRequest = (): BridgeRequest => {
+      for (let frame = messages.shift(); frame; frame = messages.shift()) {
+        if (typeof frame.id === 'string') {
+          return frame;
+        }
+      }
+      throw new Error('Expected the bridge to post a request');
+    };
     const testWindow = Object.assign(new EventTarget(), {
       __VSCODE_CONFIG__: { theme: 'light', workspaceFolder: '/workspace' },
     });
@@ -31,8 +42,7 @@ describe('VS Code webview settings API', () => {
       const api = createVSCodeSettingsAPI();
 
       const failedLoad = api.load();
-      const failedRequest = messages.shift();
-      assert.ok(failedRequest);
+      const failedRequest = takeRequest();
       testWindow.dispatchEvent(new MessageEvent('message', {
         data: {
           id: failedRequest.id,
@@ -44,8 +54,7 @@ describe('VS Code webview settings API', () => {
       await assert.rejects(failedLoad, /settings unavailable/);
 
       const successfulLoad = api.load();
-      const successfulRequest = messages.shift();
-      assert.ok(successfulRequest);
+      const successfulRequest = takeRequest();
       testWindow.dispatchEvent(new MessageEvent('message', {
         data: {
           id: successfulRequest.id,


### PR DESCRIPTION
## Intent

`checks` is currently red on `main` because of a single test, which means no pull request can get a green workflow.

`packages/vscode/webview/api/settings.test.ts` fails deterministically: `propagates a failed bridge read and retries successfully` times out after 5000 ms before its done callback is called. Everything else in the workflow passes — install, build, type-check, lint, changelog outputs, the `scripts` suite (4 of 4 files), the `ui` suite (446 of 446 files) and the `vscode` `src` suite. The `vscode` `webview` sub-suite reports 40 of 41 files passing, and this is the one failure.

Cause: `getVSCodeAPI()` in `bridge.ts` emits a one-time `{ type: 'webview:ready' }` handshake before the first request (added in `e5e835a87`, about half an hour before this test was written in `6cf247894`). The test took the outbound frame with `messages.shift()`, assuming it was the request. It received the handshake, whose `id` is `undefined`; the bridge listener deliberately ignores frames whose `id` is not a string, so the promise returned by `api.load()` was never settled and the watchdog fired. The outbound queue is, in order: the `webview:ready` handshake, then `{ id: 'req_1_…', type: 'api:config/settings:get' }`.

Reproduced on untouched `main` as well as on a feature branch — four runs, 5002 ms to 5017 ms, exit 1 every time — so this is a deterministic hang, not a load-sensitive timeout, and it is not caused by any pending pull request.

## Non-goals

- `bridge.ts` is not modified: the handshake is intentional, it retires orphaned event streams on webview reload.
- No assertion is weakened, no timeout raised, no test skipped.
- No other test file or package is touched.

## Affected surfaces

`packages/vscode/webview/api/settings.test.ts` only — a small helper plus its two call sites.

## Validation

| Gate | Command | Result |
| --- | --- | --- |
| Webview suite | `cd packages/vscode && node ../../scripts/run-isolated-tests.mjs webview` | 6 of 6 files pass, green on two consecutive runs (was 5 of 6, exit 1) |
| Package suite | `bun run --cwd packages/vscode test` | 41 of 41 files pass |
| Type check | `bun run --cwd packages/vscode type-check` | exit 0 |
| Lint | `bun run --cwd packages/vscode lint` | exit 0 |

## Visual evidence

Not a visual change.

## Risks and failure behavior

The helper now consumes the first queued frame that carries a string `id` and fails loudly if no such frame is posted, so a bridge that stopped posting requests would break the test by name instead of stalling it until the watchdog fires. Any future frame added ahead of the request is tolerated; a real request frame is still required, exactly as before.

This also unblocks `checks` for the two open pull requests that surfaced it (#3538, #3539).
