### PR TITLE
fix(mobile): correct iOS PWA viewport sizing

### DIFF
--- a/packages/ui/src/styles/mobile.css
+++ b/packages/ui/src/styles/mobile.css
@@ -152,20 +152,18 @@
     min-height: 0;
   }
 
-  /* -webkit-fill-available above is a pre-dvh iOS Safari fix. On Android
-     Chrome it freezes the root at the pre-keyboard height: when
-     interactive-widget=resizes-content shrinks the viewport, the document
-     stays taller than the screen and (with overflow hidden) the composer's
-     bottom is clipped behind the keyboard with no way to scroll to it.
-     Every dvh-capable browser gets the dynamic height instead; the legacy
-     fallback above keeps serving browsers without dvh. */
+  /* -webkit-fill-available above is required by iOS Safari. On Android Chrome
+     it freezes the root at the pre-keyboard height, so dvh-capable non-WebKit
+     browsers take the dynamic height instead. */
   @supports (height: 100dvh) {
-    :root.mobile-pointer:not(.desktop-runtime) {
-      height: 100dvh;
-    }
+    @supports not (-webkit-touch-callout: none) {
+      :root.mobile-pointer:not(.desktop-runtime) {
+        height: 100dvh;
+      }
 
-    :root.mobile-pointer:not(.desktop-runtime) .flex.flex-col.h-screen {
-      height: 100dvh;
+      :root.mobile-pointer:not(.desktop-runtime) .flex.flex-col.h-screen {
+        height: 100dvh;
+      }
     }
   }
 
@@ -241,16 +239,6 @@
     :root.mobile-pointer:not(.desktop-runtime) .flex.flex-col.h-screen {
       min-height: 100vh;
       min-height: -webkit-fill-available;
-    }
-
-    /* Same Android-keyboard clipping fix as above: dvh-capable browsers
-       must not keep a frozen -webkit-fill-available minimum. */
-    @supports (min-height: 100dvh) {
-      :root.device-mobile:not(.desktop-runtime) .flex.flex-col.h-screen,
-      :root.device-tablet:not(.desktop-runtime) .flex.flex-col.h-screen,
-      :root.mobile-pointer:not(.desktop-runtime) .flex.flex-col.h-screen {
-        min-height: 100dvh;
-      }
     }
 
     /* Prevent content overlap in iOS */


### PR DESCRIPTION
## Intent

Fixes #2287.
Fixes #3201.

Remove the dead band at the bottom of the installed iOS PWA so the complete composer remains reachable. This branch also includes the iOS fullscreen composer fix from #3202, authored by @alexandrereyes, so the normal and fullscreen viewport corrections can be reviewed and tested together.

The PWA document shell now gives `<html>` and `<body>` an explicit `100vh` height instead of deriving both through `height: 100%`. Inner application containers keep their existing sizing and keyboard handling.

## Non-goals

- No composer send, focus, keyboard shortcut, or scrolling behavior changes.
- No changes to the Capacitor mobile entry point or Electron mini-chat entry point.
- No changes to Android's existing `100dvh` keyboard behavior.

## Affected surfaces

- `packages/web/index.html`, used by the web app and installed PWA.
- `packages/ui/src/styles/mobile.css`, through the included #3202 commit.
- Installed iOS PWA layout with the composer idle, focused with the keyboard open, and expanded to fullscreen.
- Desktop web uses the same HTML entry point, but `100vh` and the previous full-height chain resolve to the same visible viewport there. VS Code, Electron mini-chat, and Capacitor mobile use different entry points or runtime guards.
- No persisted data, API, authentication, or external contract changes.

## Repository guidance

| Guidance | Why it applies | How the change complies |
|---|---|---|
| Root `AGENTS.md` and `openchamber-change-discipline` | This changes packaged web output and iOS runtime layout. | The implementation changes only the PWA root-height source and the existing iOS viewport rules from #3202. The web build and physical-device flows were tested. |
| `theme-system` | The change affects shared UI layout. | No colors, controls, icons, theme tokens, or animations changed. |
| `packages/ui/src/components/chat/composer/DOCUMENTATION.md` | The affected behavior includes the mobile composer's browser viewport correction. | Existing composer positioning and keyboard choreography remain intact. The verification covers normal and fullscreen composer states on a physical iPhone. |
| `packages/web/README.md` and `CONTRIBUTING.md` | The web package owns the PWA build and its review evidence. | The packaged PWA build passed, and this PR includes before and after screenshots from its current HEAD. |
| `communication-style` | The PR description and evidence labels are maintainer-facing text. | The description states the observed behavior, implementation boundary, checks, and remaining validation gap directly. |

## Validation

| Check | Result |
|---|---|
| `bunx bun@1.3.14 install --frozen-lockfile` | Passed on Windows with Node 24.14.1. |
| `bunx bun@1.3.14 run build:web` | Passed. Vite built the web bundle and PWA service worker. |
| `bunx bun@1.3.14 run type-check:ui` | Passed. |
| `bunx bun@1.3.14 run lint:ui` | Passed. |
| `git diff --check` | Passed. |
| Physical iPhone, installed PWA before the root-height change | Reproduced the bottom dead band clipping the model and mode row. |
| Physical iPhone, installed PWA idle after the change | Passed. The complete composer is visible and the dead band is gone. |
| Physical iPhone, normal composer with software keyboard open | Passed. The complete composer remains above the keyboard. |
| Physical iPhone, fullscreen composer with software keyboard open | Passed. The footer and complete Send button remain visible, confirming the root-height fix coexists with #3202. |
| Android and desktop browser manual checks | Not run. Android's declarations are unchanged, and desktop does not use the affected standalone iOS viewport combination. |

## Visual evidence

Before, the bottom band cuts through the composer's model and mode row:

<img width="920" height="2000" alt="image" src="https://github.com/user-attachments/assets/a99f79e9-48c2-4608-9e4f-a9304868921e" />

After, the complete idle composer is visible:

<img width="920" height="2000" alt="image" src="https://github.com/user-attachments/assets/8b196e7a-b3b9-48b3-b298-0d672500ba58" />

The normal composer remains visible with the software keyboard open:

<img width="920" height="2000" alt="image" src="https://github.com/user-attachments/assets/c2bc5e94-4132-4e87-ba70-f862dd550272" />

The fullscreen composer also keeps its footer and Send button above the keyboard:

<img width="920" height="2000" alt="image" src="https://github.com/user-attachments/assets/272c9008-6189-4321-a3ec-d24341d92096" />

## Risks and failure behavior

The root-height change is limited to the main web/PWA document. The included #3202 change preserves `-webkit-fill-available` for iOS composer viewport handling and keeps Android on its existing `100dvh` path. Physical-device testing covered the interaction between both changes.

The main remaining gap is manual Android and desktop browser testing. Reverting the two commits restores the previous CSS and document sizing without data migration or cleanup.
